### PR TITLE
update executor to avoid skipping messages

### DIFF
--- a/executor/cmd/main.go
+++ b/executor/cmd/main.go
@@ -64,6 +64,8 @@ func main() {
 	// Use SugaredLogger for better API
 	lggr = logger.Sugared(lggr)
 
+	lggr.Infow("Executor configuration", "config", executorConfig)
+
 	// Create context with cancellation
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -108,11 +110,14 @@ func main() {
 	le := leaderelector.RandomDelayLeader{}
 
 	indexerStream := ccvstreamer.NewIndexerStorageStreamer(
-		executorConfig.IndexerAddress,
 		lggr,
-		time.Now().Add(-1*executorConfig.GetLookbackWindow()).Unix(),
-		executorConfig.GetPollingInterval(),
-		executorConfig.GetBackoffDuration())
+		ccvstreamer.IndexerStorageConfig{
+			IndexerURI:      executorConfig.IndexerAddress,
+			LastQueryTime:   time.Now().Add(-1 * executorConfig.GetLookbackWindow()).Unix(),
+			PollingInterval: executorConfig.GetPollingInterval(),
+			Backoff:         executorConfig.GetBackoffDuration(),
+			QueryLimit:      executorConfig.IndexerQueryLimit,
+		})
 
 	// Create executor coordinator
 	coordinator, err := executor.NewCoordinator(

--- a/executor/executor_config.toml
+++ b/executor/executor_config.toml
@@ -3,6 +3,7 @@ private_key="ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 source_polling_interval="5s"
 source_backoff_duration="15s"
 startup_lookback_window="1h"
+indexer_query_limit=20
 pyroscope_url="http://pyroscope:4040"
 [blockchain_infos]
     [blockchain_infos.3379446385462418246]

--- a/executor/pkg/configuration/config.go
+++ b/executor/pkg/configuration/config.go
@@ -8,13 +8,14 @@ import (
 )
 
 type Configuration struct {
-	BlockchainInfos map[string]*types.BlockchainInfo `toml:"blockchain_infos"`
-	IndexerAddress  string                           `toml:"indexer_address"`
-	PrivateKey      string                           `toml:"private_key"`
-	PollingInterval string                           `toml:"source_polling_interval"`
-	BackoffDuration string                           `toml:"source_backoff_duration"`
-	LookbackWindow  string                           `toml:"startup_lookback_window"`
-	PyroscopeURL    string                           `toml:"pyroscope_url"`
+	BlockchainInfos   map[string]*types.BlockchainInfo `toml:"blockchain_infos"`
+	IndexerAddress    string                           `toml:"indexer_address"`
+	PrivateKey        string                           `toml:"private_key"`
+	PollingInterval   string                           `toml:"source_polling_interval"`
+	BackoffDuration   string                           `toml:"source_backoff_duration"`
+	LookbackWindow    string                           `toml:"startup_lookback_window"`
+	IndexerQueryLimit uint64                           `toml:"indexer_query_limit"`
+	PyroscopeURL      string                           `toml:"pyroscope_url"`
 }
 
 func (c *Configuration) Validate() error {

--- a/executor/pkg/contracttransmitter/evm_contract_transmitter.go
+++ b/executor/pkg/contracttransmitter/evm_contract_transmitter.go
@@ -128,7 +128,9 @@ func (ct *EVMContractTransmitter) ConvertAndWriteMessageToChain(ctx context.Cont
 		return err
 	}
 
-	ct.lggr.Infow("submitted tx to chain", "tx hash", tx.Hash().Hex())
+	messageID, _ := report.Message.MessageID()
+
+	ct.lggr.Infow("submitted tx to chain", "tx hash", tx.Hash().Hex(), "msgId", messageID)
 
 	return nil
 }


### PR DESCRIPTION
We were occasionally skipping messages due to a gap in the time window. 

This fixes the issue and also supports using a configurable query limit / offset