### PR TITLE
Verifier<->Executor parity [CCIP-7391]

### DIFF
--- a/executor/cmd/main.go
+++ b/executor/cmd/main.go
@@ -155,7 +155,7 @@ func main() {
 	defer shutdownCancel()
 
 	// Stop execution coordinator
-	if err := coordinator.Stop(); err != nil {
+	if err := coordinator.Close(); err != nil {
 		lggr.Errorw("Execution coordinator stop error", "error", err)
 	}
 

--- a/executor/executor_coordinator.go
+++ b/executor/executor_coordinator.go
@@ -20,7 +20,7 @@ type Coordinator struct {
 	leaderElector       LeaderElector
 	lggr                logger.Logger
 	ccvDataCh           chan MessageWithCCVData
-	executableMessageCh chan MessageWithCCVData //nolint:unused //will be used by executor
+	executableMessageCh chan MessageWithCCVData
 	doneCh              chan struct{}
 	cancel              context.CancelFunc
 	delayedMessageHeap  *messageHeap
@@ -64,18 +64,8 @@ func NewCoordinator(options ...Option) (*Coordinator, error) {
 		opt(ec)
 	}
 
-	var errs []error
-	appendIfNil := func(field any, fieldName string) {
-		if field == nil {
-			errs = append(errs, fmt.Errorf("%s is not set", fieldName))
-		}
-	}
-	appendIfNil(ec.executor, "executor")
-	appendIfNil(ec.leaderElector, "leaderElector")
-	appendIfNil(ec.lggr, "logger")
-	appendIfNil(ec.ccvStreamer, "ccvResultStreamer")
-	if len(errs) > 0 {
-		return nil, errors.Join(errs...)
+	if err := ec.validate(); err != nil {
+		return nil, fmt.Errorf("invalid coordinator configuration: %w", err)
 	}
 
 	return ec, nil
@@ -85,7 +75,7 @@ func (ec *Coordinator) Start(ctx context.Context) error {
 	ec.mu.Lock()
 	defer ec.mu.Unlock()
 	if ec.running {
-		return fmt.Errorf("Coordinator already running")
+		return fmt.Errorf("coordinator already running")
 	}
 
 	ec.running = true
@@ -101,18 +91,29 @@ func (ec *Coordinator) Start(ctx context.Context) error {
 	return nil
 }
 
-func (ec *Coordinator) Stop() error {
+func (ec *Coordinator) Close() error {
 	ec.mu.RLock()
 	if !ec.running {
 		ec.mu.RUnlock()
-		return fmt.Errorf("ExecutorCoordinator not started")
+		return fmt.Errorf("coordinator not running")
 	}
 	ec.mu.RUnlock()
 
 	ec.lggr.Infow("Coordinator stopping")
 	ec.cancel()
 	<-ec.doneCh
-	ec.lggr.Infow("ExecutorCoordinator stopped")
+
+	// Close all channels
+	close(ec.ccvDataCh)
+	if ec.executableMessageCh != nil {
+		close(ec.executableMessageCh)
+	}
+
+	ec.mu.Lock()
+	ec.running = false
+	ec.mu.Unlock()
+
+	ec.lggr.Infow("Coordinator stopped")
 
 	return nil
 }
@@ -188,9 +189,47 @@ func (ec *Coordinator) run(ctx context.Context) {
 	}
 }
 
-// IsRunning returns whether the coordinator is running.
-func (ec *Coordinator) IsRunning() bool {
+// validate checks that all required components are configured.
+func (ec *Coordinator) validate() error {
+	var errs []error
+	appendIfNil := func(field any, fieldName string) {
+		if field == nil {
+			errs = append(errs, fmt.Errorf("%s is not set", fieldName))
+		}
+	}
+
+	appendIfNil(ec.executor, "executor")
+	appendIfNil(ec.leaderElector, "leaderElector")
+	appendIfNil(ec.lggr, "logger")
+	appendIfNil(ec.ccvStreamer, "ccvResultStreamer")
+
+	return errors.Join(errs...)
+}
+
+// Ready returns nil if the coordinator is ready, or an error otherwise.
+func (ec *Coordinator) Ready() error {
 	ec.mu.RLock()
 	defer ec.mu.RUnlock()
-	return ec.running
+
+	if !ec.running {
+		return errors.New("coordinator not running")
+	}
+
+	return nil
+}
+
+// HealthReport returns a full health report of the coordinator and its dependencies.
+func (ec *Coordinator) HealthReport() map[string]error {
+	ec.mu.RLock()
+	defer ec.mu.RUnlock()
+
+	report := make(map[string]error)
+	report[ec.Name()] = ec.Ready()
+
+	return report
+}
+
+// Name returns the fully qualified name of the coordinator.
+func (ec *Coordinator) Name() string {
+	return "executor.Coordinator"
 }

--- a/executor/executor_coordinator_test.go
+++ b/executor/executor_coordinator_test.go
@@ -123,17 +123,17 @@ func TestLifecycle(t *testing.T) {
 		ec := getReader()
 		ctx, cancel := context.WithCancel(t.Context())
 		require.NoError(t, ec.Start(ctx))
-		require.True(t, ec.IsRunning())
+		require.NoError(t, ec.Ready())
 		cancel()
-		require.Eventuallyf(t, func() bool { return ec.IsRunning() == false }, 2*time.Second, 100*time.Millisecond, "executor coordinator did not stop in time")
+		require.Eventuallyf(t, func() bool { return ec.Ready() != nil }, 2*time.Second, 100*time.Millisecond, "executor coordinator did not stop in time")
 	})
 
 	t.Run("stop called", func(t *testing.T) {
 		ec := getReader()
 		require.NoError(t, ec.Start(t.Context()))
-		require.True(t, ec.IsRunning())
-		require.NoError(t, ec.Stop())
-		require.Eventuallyf(t, func() bool { return ec.IsRunning() == false }, 2*time.Second, 100*time.Millisecond, "executor coordinator did not stop in time")
+		require.NoError(t, ec.Ready())
+		require.NoError(t, ec.Close())
+		require.Eventuallyf(t, func() bool { return ec.Ready() != nil }, 2*time.Second, 100*time.Millisecond, "executor coordinator did not stop in time")
 	})
 }
 
@@ -184,5 +184,5 @@ func TestStopNotRunning(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ec)
 
-	require.ErrorContains(t, ec.Stop(), "Coordinator not started")
+	require.ErrorContains(t, ec.Close(), "coordinator not running")
 }

--- a/protocol/interfaces.go
+++ b/protocol/interfaces.go
@@ -37,7 +37,7 @@ type HealthReporter interface {
 // calls in a safe manner.
 type Service interface {
 	// Start the service.
-	//  - Must return promptly if the context is cancelled.
+	//  - Must return promptly if the context is canceled.
 	//  - Must not retain the context after returning (only applies to start-up)
 	//  - Must not depend on external resources (no blocking network calls)
 	Start(context.Context) error

--- a/protocol/interfaces.go
+++ b/protocol/interfaces.go
@@ -13,3 +13,40 @@ type CheckpointManager interface {
 	// ReadCheckpoint reads a checkpoint for a specific chain, returns nil if not found
 	ReadCheckpoint(ctx context.Context, chainSelector ChainSelector) (*big.Int, error)
 }
+
+// HealthReporter should be implemented by any type requiring health checks.
+type HealthReporter interface {
+	// Ready should return nil if ready, or an error message otherwise. From the k8s docs:
+	// > ready means it's initialized and healthy means that it can accept traffic in kubernetes
+	// See: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+	Ready() error
+	// HealthReport returns a full health report of the callee including its dependencies.
+	// Keys are based on Name(), with nil values when healthy or errors otherwise.
+	// Use CopyHealth to collect reports from sub-services.
+	// This should run very fast, so avoid doing computation and instead prefer reporting pre-calculated state.
+	HealthReport() map[string]error
+	// Name returns the fully qualified name of the component. Usually the logger name.
+	Name() string
+}
+
+// Service represents a long-running service inside the Application.
+//
+// The simplest way to implement a Service is via NewService.
+//
+// For other cases, consider embedding a services.StateMachine to implement these
+// calls in a safe manner.
+type Service interface {
+	// Start the service.
+	//  - Must return promptly if the context is cancelled.
+	//  - Must not retain the context after returning (only applies to start-up)
+	//  - Must not depend on external resources (no blocking network calls)
+	Start(context.Context) error
+	// Close stops the Service.
+	// Invariants: Usually after this call the Service cannot be started
+	// again, you need to build a new Service to do so.
+	//
+	// See MultiCloser
+	Close() error
+
+	HealthReporter
+}

--- a/verifier/cmd/main.go
+++ b/verifier/cmd/main.go
@@ -251,7 +251,7 @@ func main() {
 	})
 
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		if err := coordinator.HealthCheck(ctx); err != nil {
+		if err := coordinator.Ready(); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			lggr.Infow("❌ Unhealthy: %s\n", err.Error())
 			return
@@ -293,7 +293,7 @@ func main() {
 	}
 
 	// Stop verification coordinator
-	if err := coordinator.Stop(); err != nil {
+	if err := coordinator.Close(); err != nil {
 		lggr.Errorw("Coordinator stop error", "error", err)
 	}
 

--- a/verifier/pkg/reader/evm_source_reader.go
+++ b/verifier/pkg/reader/evm_source_reader.go
@@ -417,7 +417,7 @@ func (r *EVMSourceReader) eventMonitoringLoop(ctx context.Context) {
 			return
 
 		case <-r.stopCh:
-			r.logger.Infow("🛑 Stop signal received, stopping event monitoring")
+			r.logger.Infow("🛑 Close signal received, stopping event monitoring")
 			return
 
 		case <-ticker.C:

--- a/verifier/verification_coordinator_finality_test.go
+++ b/verifier/verification_coordinator_finality_test.go
@@ -87,7 +87,7 @@ func TestFinality_FinalizedMessage(t *testing.T) {
 
 	err := setup.coordinator.Start(ctx)
 	require.NoError(t, err)
-	defer setup.coordinator.Stop()
+	defer setup.coordinator.Close()
 
 	// Message at block 940 (< finalized 950) should be processed immediately
 	finalizedMessage := createTestMessage(t, 1, 1337, 2337, 0)
@@ -121,7 +121,7 @@ func TestFinality_CustomFinality(t *testing.T) {
 
 	err := setup.coordinator.Start(ctx)
 	require.NoError(t, err)
-	defer setup.coordinator.Stop()
+	defer setup.coordinator.Close()
 
 	customFinality := uint16(15)
 
@@ -155,7 +155,7 @@ func TestFinality_WaitingForFinality(t *testing.T) {
 
 	err := setup.coordinator.Start(ctx)
 	require.NoError(t, err)
-	defer setup.coordinator.Stop()
+	defer setup.coordinator.Close()
 
 	nonFinalizedMessage := createTestMessage(t, 1, 1337, 2337, 0)
 	nonFinalizedBlock := InitialFinalizedBlock + 10


### PR DESCRIPTION
* Added `Service` and `HealthReporter` interfaces under protocol/
* Both verifier and executor coordinators implement the above interfaces
* Use `appendIfNil()` pattern but inside `validate` function
* Close channels in executor in `Close` function
* Use one flag `running` in verifier instead of `start` and `stop` flags
* Prevent starting a started coordinator