### PR TITLE
feat(indexer): message id endpoint

### DIFF
--- a/go.md
+++ b/go.md
@@ -28,6 +28,7 @@ flowchart LR
 	chainlink-ccv/common --> chainlink-evm
 	chainlink-ccv/common --> chainlink-protos/chainlink-ccv/go
 	click chainlink-ccv/common href "https://github.com/smartcontractkit/chainlink-ccv"
+	chainlink-ccv/devenv --> chainlink-ccv/aggregator
 	chainlink-ccv/devenv --> chainlink-ccv/ccv-evm
 	chainlink-ccv/devenv --> chainlink-ccv/indexer
 	chainlink-ccv/devenv --> chainlink-testing-framework/wasp

--- a/indexer/go.mod
+++ b/indexer/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.9.5
 	github.com/stretchr/testify v1.11.1
 	github.com/ulule/limiter/v3 v3.11.2
+	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/metric v1.38.0
 	go.opentelemetry.io/otel/sdk/metric v1.37.0
 	go.uber.org/zap v1.27.0
@@ -60,7 +61,6 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.12.2 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.12.2 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.36.0 // indirect

--- a/indexer/pkg/api/api.go
+++ b/indexer/pkg/api/api.go
@@ -21,12 +21,13 @@ func NewV1API(lggr logger.Logger, storage common.IndexerStorage, monitoring comm
 
 	v1Group := router.Group("/v1")
 
-	v1Group.GET("/ping", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "pong"})
-	})
-
+	// View all known verifications over a time range
 	ccvDataV1Handler := v1.NewCCVDataV1Handler(storage, lggr, monitoring)
 	v1Group.GET("/ccvdata", ccvDataV1Handler.Handle)
+
+	// Get all verifications for a specific messageID
+	messageIDV1Handler := v1.NewMessageIDV1Handler(storage, lggr, monitoring)
+	v1Group.GET("/messageid/:messageID", messageIDV1Handler.Handle)
 
 	return router
 }

--- a/indexer/pkg/api/handlers/v1/ccv_data.go
+++ b/indexer/pkg/api/handlers/v1/ccv_data.go
@@ -38,8 +38,6 @@ func (h *CCVDataV1Handler) Handle(c *gin.Context) {
 		Offset:               0,
 	}
 
-	startDuration := time.Now()
-
 	if err := c.ShouldBindQuery(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -62,9 +60,8 @@ func (h *CCVDataV1Handler) Handle(c *gin.Context) {
 		return
 	}
 
-	h.lggr.Debugw("ccvData ", "ccvData", ccvData)
+	h.lggr.Debugw("/v1/ccvdata", "number of messages returned", len(ccvData))
 	c.JSON(http.StatusOK, gin.H{"success": true, "ccvData": ccvData})
-	h.monitoring.Metrics().RecordVerificationRecordRequestDuration(c.Request.Context(), time.Since(startDuration))
 }
 
 func (h *CCVDataV1Handler) parseSelectorTypes(c *gin.Context, paramName string) ([]protocol.ChainSelector, bool) {

--- a/indexer/pkg/api/handlers/v1/message_id.go
+++ b/indexer/pkg/api/handlers/v1/message_id.go
@@ -1,0 +1,53 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/common"
+	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/storage"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+type MessageIDV1Handler struct {
+	storage    common.IndexerStorage
+	lggr       logger.Logger
+	monitoring common.IndexerMonitoring
+}
+
+func NewMessageIDV1Handler(storage common.IndexerStorage, lggr logger.Logger, monitoring common.IndexerMonitoring) *MessageIDV1Handler {
+	return &MessageIDV1Handler{
+		storage:    storage,
+		lggr:       lggr,
+		monitoring: monitoring,
+	}
+}
+
+func (h *MessageIDV1Handler) Handle(c *gin.Context) {
+	messageID := c.Param("messageID")
+	messageIDBytes32, err := protocol.NewBytes32FromString(messageID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid MessageID"})
+		return
+	}
+
+	// Get all verifications for the messageID
+	verifications, err := h.storage.GetCCVData(c.Request.Context(), messageIDBytes32)
+
+	switch err {
+	case storage.ErrCCVDataNotFound:
+		c.JSON(http.StatusNotFound, gin.H{"error": "MessageID not found"})
+		return
+	case nil:
+		break
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, MessageIDV1Response{
+		MessageID:     messageID,
+		Verifications: verifications,
+	})
+}

--- a/indexer/pkg/api/handlers/v1/message_id.go
+++ b/indexer/pkg/api/handlers/v1/message_id.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/common"
 	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/storage"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
@@ -40,7 +41,6 @@ func (h *MessageIDV1Handler) Handle(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "MessageID not found"})
 		return
 	case nil:
-		break
 	default:
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
 		return

--- a/indexer/pkg/api/handlers/v1/types.go
+++ b/indexer/pkg/api/handlers/v1/types.go
@@ -1,0 +1,8 @@
+package v1
+
+import "github.com/smartcontractkit/chainlink-ccv/protocol"
+
+type MessageIDV1Response struct {
+	MessageID     string             `json:"messageID"`
+	Verifications []protocol.CCVData `json:"verifications"`
+}

--- a/indexer/pkg/common/metrics.go
+++ b/indexer/pkg/common/metrics.go
@@ -21,6 +21,8 @@ type IndexerMetricLabeler interface {
 	IncrementActiveRequestsCounter(ctx context.Context)
 	// DecrementActiveRequestsCounter decrements the active requests counter.
 	DecrementActiveRequestsCounter(ctx context.Context)
+	// RecordHTTPRequestDuration records the HTTP request duration.
+	RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path string, method string, status int)
 	// IncrementUniqueMessagesCounter increments the unique messages counter.
 	IncrementUniqueMessagesCounter(ctx context.Context)
 	// IncrementVerificationRecordsCounter increments the verification records counter.
@@ -31,8 +33,6 @@ type IndexerMetricLabeler interface {
 	RecordStorageWriteDuration(ctx context.Context, duration time.Duration)
 	// RecordStorageInsertErrorsCounter records the storage insert errors counter.
 	RecordStorageInsertErrorsCounter(ctx context.Context)
-	// RecordVerificationRecordRequestDuration records the verification record request duration.
-	RecordVerificationRecordRequestDuration(ctx context.Context, duration time.Duration)
 	// RecordScannerPollingErrorsCounter records the scanner polling errors counter.
 	RecordScannerPollingErrorsCounter(ctx context.Context)
 	// RecordVerificationRecordChannelSizeGauge records the verification record channel size gauge.

--- a/indexer/pkg/common/metrics.go
+++ b/indexer/pkg/common/metrics.go
@@ -22,7 +22,7 @@ type IndexerMetricLabeler interface {
 	// DecrementActiveRequestsCounter decrements the active requests counter.
 	DecrementActiveRequestsCounter(ctx context.Context)
 	// RecordHTTPRequestDuration records the HTTP request duration.
-	RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path string, method string, status int)
+	RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path, method string, status int)
 	// IncrementUniqueMessagesCounter increments the unique messages counter.
 	IncrementUniqueMessagesCounter(ctx context.Context)
 	// IncrementVerificationRecordsCounter increments the verification records counter.

--- a/indexer/pkg/monitoring/metrics.go
+++ b/indexer/pkg/monitoring/metrics.go
@@ -183,7 +183,7 @@ func (c *IndexerMetricLabeler) DecrementActiveRequestsCounter(ctx context.Contex
 	c.im.activeRequestsUpDownCounter.Add(ctx, -1, metric.WithAttributes(otelLabels...))
 }
 
-func (c *IndexerMetricLabeler) RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path string, method string, status int) {
+func (c *IndexerMetricLabeler) RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path, method string, status int) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.im.requestDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes([]attribute.KeyValue{
 		attribute.String("path", path),

--- a/indexer/pkg/monitoring/metrics.go
+++ b/indexer/pkg/monitoring/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/common"
@@ -19,6 +20,7 @@ type IndexerMetrics struct {
 	// HTTP Metrics
 	httpRequestsCounter         metric.Int64Counter
 	activeRequestsUpDownCounter metric.Int64UpDownCounter
+	requestDurationSeconds      metric.Float64Histogram
 
 	// Storage Metrics
 	uniqueMessagesCounter       metric.Int64Counter
@@ -26,9 +28,6 @@ type IndexerMetrics struct {
 	storageQueryDurationSeconds metric.Float64Histogram
 	storageWriteDurationSeconds metric.Float64Histogram
 	storageInsertErrorsCounter  metric.Int64Counter
-
-	// Verification Record Metrics
-	verificationRecordRequestDurationSeconds metric.Float64Histogram
 
 	// Scanner Metrics
 	scannerPollingErrorsCounter        metric.Int64Counter
@@ -53,6 +52,14 @@ func InitMetrics() (im *IndexerMetrics, err error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register active requests up down counter: %w", err)
+	}
+
+	im.requestDurationSeconds, err = beholder.GetMeter().Float64Histogram("indexer_http_request_duration_seconds",
+		metric.WithDescription("Total duration of requesting the HTTP request"),
+		metric.WithUnit("seconds"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register http request duration histogram: %w", err)
 	}
 
 	im.uniqueMessagesCounter, err = beholder.GetMeter().Int64Counter(
@@ -95,14 +102,6 @@ func InitMetrics() (im *IndexerMetrics, err error) {
 		return nil, fmt.Errorf("failed to register storage insert errors counter: %w", err)
 	}
 
-	im.verificationRecordRequestDurationSeconds, err = beholder.GetMeter().Float64Histogram("indexer_verification_record_request_duration_seconds",
-		metric.WithDescription("Total duration of requesting the verification record"),
-		metric.WithUnit("seconds"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to register verification record request duration histogram: %w", err)
-	}
-
 	im.scannerPollingErrorsCounter, err = beholder.GetMeter().Int64Counter("indexer_scanner_polling_errors_total",
 		metric.WithDescription("Total number of errors when polling the scanner"),
 	)
@@ -143,7 +142,7 @@ func MetricViews() []sdkmetric.View {
 			}},
 		),
 		sdkmetric.NewView(
-			sdkmetric.Instrument{Name: "indexer_verification_record_request_duration_seconds"},
+			sdkmetric.Instrument{Name: "indexer_http_request_duration_seconds"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
 				Boundaries: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 			}},
@@ -184,6 +183,15 @@ func (c *IndexerMetricLabeler) DecrementActiveRequestsCounter(ctx context.Contex
 	c.im.activeRequestsUpDownCounter.Add(ctx, -1, metric.WithAttributes(otelLabels...))
 }
 
+func (c *IndexerMetricLabeler) RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path string, method string, status int) {
+	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
+	c.im.requestDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes([]attribute.KeyValue{
+		attribute.String("path", path),
+		attribute.String("method", method),
+		attribute.Int("status", status),
+	}...), metric.WithAttributes(otelLabels...))
+}
+
 func (c *IndexerMetricLabeler) IncrementUniqueMessagesCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.im.uniqueMessagesCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
@@ -207,11 +215,6 @@ func (c *IndexerMetricLabeler) RecordStorageWriteDuration(ctx context.Context, d
 func (c *IndexerMetricLabeler) RecordStorageInsertErrorsCounter(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.im.storageInsertErrorsCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
-}
-
-func (c *IndexerMetricLabeler) RecordVerificationRecordRequestDuration(ctx context.Context, duration time.Duration) {
-	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
-	c.im.verificationRecordRequestDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes(otelLabels...))
 }
 
 func (c *IndexerMetricLabeler) RecordScannerPollingErrorsCounter(ctx context.Context) {

--- a/indexer/pkg/monitoring/noop.go
+++ b/indexer/pkg/monitoring/noop.go
@@ -24,9 +24,11 @@ func (n *NoopIndexerMetricLabeler) With(keyValues ...string) common.IndexerMetri
 }
 
 // All metric recording methods are no-ops.
-func (n *NoopIndexerMetricLabeler) IncrementHTTPRequestCounter(ctx context.Context)         {}
-func (n *NoopIndexerMetricLabeler) IncrementActiveRequestsCounter(ctx context.Context)      {}
-func (n *NoopIndexerMetricLabeler) DecrementActiveRequestsCounter(ctx context.Context)      {}
+func (n *NoopIndexerMetricLabeler) IncrementHTTPRequestCounter(ctx context.Context)    {}
+func (n *NoopIndexerMetricLabeler) IncrementActiveRequestsCounter(ctx context.Context) {}
+func (n *NoopIndexerMetricLabeler) DecrementActiveRequestsCounter(ctx context.Context) {}
+func (n *NoopIndexerMetricLabeler) RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path string, method string, status int) {
+}
 func (n *NoopIndexerMetricLabeler) IncrementUniqueMessagesCounter(ctx context.Context)      {}
 func (n *NoopIndexerMetricLabeler) IncrementVerificationRecordsCounter(ctx context.Context) {}
 func (n *NoopIndexerMetricLabeler) RecordStorageQueryDuration(ctx context.Context, duration time.Duration) {

--- a/indexer/pkg/monitoring/noop.go
+++ b/indexer/pkg/monitoring/noop.go
@@ -27,7 +27,7 @@ func (n *NoopIndexerMetricLabeler) With(keyValues ...string) common.IndexerMetri
 func (n *NoopIndexerMetricLabeler) IncrementHTTPRequestCounter(ctx context.Context)    {}
 func (n *NoopIndexerMetricLabeler) IncrementActiveRequestsCounter(ctx context.Context) {}
 func (n *NoopIndexerMetricLabeler) DecrementActiveRequestsCounter(ctx context.Context) {}
-func (n *NoopIndexerMetricLabeler) RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path string, method string, status int) {
+func (n *NoopIndexerMetricLabeler) RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path, method string, status int) {
 }
 func (n *NoopIndexerMetricLabeler) IncrementUniqueMessagesCounter(ctx context.Context)      {}
 func (n *NoopIndexerMetricLabeler) IncrementVerificationRecordsCounter(ctx context.Context) {}

--- a/indexer/pkg/storage/errors.go
+++ b/indexer/pkg/storage/errors.go
@@ -1,0 +1,8 @@
+package storage
+
+import "fmt"
+
+var (
+	ErrCCVDataNotFound  = fmt.Errorf("CCV data not found")
+	ErrDuplicateCCVData = fmt.Errorf("duplicate CCV data")
+)

--- a/indexer/pkg/storage/in_memory.go
+++ b/indexer/pkg/storage/in_memory.go
@@ -14,11 +14,6 @@ import (
 
 var _ common.IndexerStorage = (*InMemoryStorage)(nil)
 
-var (
-	ErrCCVDataNotFound  = fmt.Errorf("CCV data not found")
-	ErrDuplicateCCVData = fmt.Errorf("duplicate CCV data")
-)
-
 // InMemoryStorage provides efficient in-memory storage optimized for query performance.
 type InMemoryStorage struct {
 	// Primary storage: messageID -> []CCVData (for O(1) lookup by messageID)

--- a/protocol/message_types.go
+++ b/protocol/message_types.go
@@ -21,16 +21,16 @@ const (
 
 // TokenTransfer represents a chain-agnostic token transfer with canonical encoding.
 type TokenTransfer struct {
-	Amount                   *big.Int `json:"amount"`
-	SourceTokenAddress       []byte   `json:"source_token_address"`
-	DestTokenAddress         []byte   `json:"dest_token_address"`
-	TokenReceiver            []byte   `json:"token_receiver"`
-	ExtraData                []byte   `json:"extra_data"`
-	Version                  uint8    `json:"version"`
-	SourceTokenAddressLength uint8    `json:"source_token_address_length"`
-	DestTokenAddressLength   uint8    `json:"dest_token_address_length"`
-	TokenReceiverLength      uint8    `json:"token_receiver_length"`
-	ExtraDataLength          uint8    `json:"extra_data_length"`
+	Amount                   *big.Int  `json:"amount"`
+	SourceTokenAddress       ByteSlice `json:"source_token_address"`
+	DestTokenAddress         ByteSlice `json:"dest_token_address"`
+	TokenReceiver            ByteSlice `json:"token_receiver"`
+	ExtraData                ByteSlice `json:"extra_data"`
+	Version                  uint8     `json:"version"`
+	SourceTokenAddressLength uint8     `json:"source_token_address_length"`
+	DestTokenAddressLength   uint8     `json:"dest_token_address_length"`
+	TokenReceiverLength      uint8     `json:"token_receiver_length"`
+	ExtraDataLength          uint8     `json:"extra_data_length"`
 }
 
 // Encode returns the canonical encoding of this token transfer.
@@ -143,26 +143,26 @@ func DecodeTokenTransfer(data []byte) (*TokenTransfer, error) {
 
 // Message represents the chain-agnostic CCIP message format.
 type Message struct {
-	Sender        []byte `json:"sender"`
-	Data          []byte `json:"data"`
-	OnRampAddress []byte `json:"on_ramp_address"`
-	TokenTransfer []byte `json:"token_transfer"`
+	Sender        UnknownAddress `json:"sender"`
+	Data          ByteSlice      `json:"data"`
+	OnRampAddress UnknownAddress `json:"on_ramp_address"`
+	TokenTransfer ByteSlice      `json:"token_transfer"`
 	// This is CCVAggregator
-	OffRampAddress       []byte        `json:"off_ramp_address"`
-	DestBlob             []byte        `json:"dest_blob"`
-	Receiver             []byte        `json:"receiver"`
-	SourceChainSelector  ChainSelector `json:"source_chain_selector"`
-	DestChainSelector    ChainSelector `json:"dest_chain_selector"`
-	Nonce                Nonce         `json:"nonce"`
-	Finality             uint16        `json:"finality"`
-	DestBlobLength       uint16        `json:"dest_blob_length"`
-	TokenTransferLength  uint16        `json:"token_transfer_length"`
-	DataLength           uint16        `json:"data_length"`
-	ReceiverLength       uint8         `json:"receiver_length"`
-	SenderLength         uint8         `json:"sender_length"`
-	Version              uint8         `json:"version"`
-	OffRampAddressLength uint8         `json:"off_ramp_address_length"`
-	OnRampAddressLength  uint8         `json:"on_ramp_address_length"`
+	OffRampAddress       UnknownAddress `json:"off_ramp_address"`
+	DestBlob             ByteSlice      `json:"dest_blob"`
+	Receiver             UnknownAddress `json:"receiver"`
+	SourceChainSelector  ChainSelector  `json:"source_chain_selector"`
+	DestChainSelector    ChainSelector  `json:"dest_chain_selector"`
+	Nonce                Nonce          `json:"nonce"`
+	Finality             uint16         `json:"finality"`
+	DestBlobLength       uint16         `json:"dest_blob_length"`
+	TokenTransferLength  uint16         `json:"token_transfer_length"`
+	DataLength           uint16         `json:"data_length"`
+	ReceiverLength       uint8          `json:"receiver_length"`
+	SenderLength         uint8          `json:"sender_length"`
+	Version              uint8          `json:"version"`
+	OffRampAddressLength uint8          `json:"off_ramp_address_length"`
+	OnRampAddressLength  uint8          `json:"on_ramp_address_length"`
 }
 
 // Encode returns the canonical encoding of this message.
@@ -360,8 +360,8 @@ func (m *Message) MessageID() (Bytes32, error) {
 // ReceiptWithBlob represents a chain-agnostic receipt with blob.
 type ReceiptWithBlob struct {
 	Issuer            UnknownAddress `json:"issuer"`
-	Blob              []byte         `json:"blob"`
-	ExtraArgs         []byte         `json:"extra_args"`
+	Blob              ByteSlice      `json:"blob"`
+	ExtraArgs         ByteSlice      `json:"extra_args"`
 	DestGasLimit      uint64         `json:"dest_gas_limit"`
 	DestBytesOverhead uint32         `json:"dest_bytes_overhead"`
 }
@@ -369,7 +369,7 @@ type ReceiptWithBlob struct {
 // CCV represents a Cross-Chain Verifier configuration.
 type CCV struct {
 	CCVAddress UnknownAddress
-	Args       []byte
+	Args       ByteSlice
 	ArgsLen    uint16
 }
 
@@ -377,8 +377,8 @@ type CCV struct {
 type CCVData struct {
 	SourceVerifierAddress UnknownAddress    `json:"source_verifier_address"`
 	DestVerifierAddress   UnknownAddress    `json:"dest_verifier_address"`
-	CCVData               []byte            `json:"ccv_data"`
-	BlobData              []byte            `json:"blob_data"`
+	CCVData               ByteSlice         `json:"ccv_data"`
+	BlobData              ByteSlice         `json:"blob_data"`
 	ReceiptBlobs          []ReceiptWithBlob `json:"receipt_blobs"`
 	Message               Message           `json:"message"`
 	Nonce                 Nonce             `json:"nonce"`


### PR DESCRIPTION
Creates a `/v1/messageid/:messageid` path. Additionally this PR contains some slight updates to the protocol types to allow for automatic (un)/marshalling to hex strings instead of base64