### PR TITLE
Adds e2e tests to simulate NOP downsizing

### DIFF
--- a/build/devenv/cciptestinterfaces/interface.go
+++ b/build/devenv/cciptestinterfaces/interface.go
@@ -151,10 +151,14 @@ type Chain interface {
 	GetRoundRobinUser() func() *bind.TransactOpts
 }
 
+type Signers struct {
+	Signers   [][]byte
+	Threshold uint8
+}
+
 type OnChainCommittees struct {
-	CommitteeQualifier string
-	Signers            [][]byte
-	Threshold          uint8
+	CommitteeQualifier   string
+	SignersBySourceChain map[uint64]Signers
 }
 
 // OnChainConfigurable defines methods that allows devenv to

--- a/build/devenv/env.toml
+++ b/build/devenv/env.toml
@@ -106,6 +106,7 @@ cl_nodes_funding_link = 50
 
 
 # Tertiary Verifier Setup
+# Tertiary verifier secures/enables chain 1337 with 2/3, chain 2337 with 1/2, and chain 3337 with 1/1
 [[verifier]]
   image = "verifier:dev"
   container_name = "tertiary-verifier-1"
@@ -114,6 +115,7 @@ cl_nodes_funding_link = 50
   root_path = "../../"
   committee_name = "tertiary"
   node_index = 0
+  enabled_chains = ["1337", "2337"]
   [verifier.db]
     image = "postgres:16-alpine"
     name = "tertiary-verifier-1-db"
@@ -128,11 +130,26 @@ cl_nodes_funding_link = 50
   root_path = "../../"
   committee_name = "tertiary"
   node_index = 1
+  enabled_chains = ["1337", "2337"]
   [verifier.db]
     image = "postgres:16-alpine"
     name = "tertiary-verifier-2-db"
     port = 8437
 
+
+[[verifier]]
+  image = "verifier:dev"
+  container_name = "tertiary-verifier-3"
+  port = 8650
+  source_code_path = "../verifier"
+  root_path = "../../"
+    committee_name = "tertiary"
+  node_index = 2
+  enabled_chains = ["1337", "3337"]
+  [verifier.db]
+    image = "postgres:16-alpine"
+    name = "tertiary-verifier-3-db"
+    port = 8438
 
 [[token_verifier]]
   mode = "standalone"
@@ -141,7 +158,6 @@ cl_nodes_funding_link = 50
   port = 8700
   source_code_path = "../verifier"
   root_path = "../../"
-
 
 [[executor]]
   image = "executor:dev"
@@ -368,6 +384,12 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
   source_code_path = "../aggregator"
   root_path = "../../"
 
+  # tertiary verifier is composed of a 3 committee verifiers and the 3 chains are secured with different thresholds
+  [aggregator.threshold_per_source]
+    1337 = 2
+    2337 = 1
+    3337 = 1
+
   [aggregator.db]
     image = "postgres:16-alpine"
     host_port  = 7434
@@ -389,6 +411,12 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+    client_id = "tertiary-verifier-3"
+    description = "Development tertiary verifier 3"
+    enabled = true
+    groups = ["verifiers"]
+
+  [[aggregator.api_clients]]
   client_id = "monitoring"
   description = "Monitoring and infrastructure client"
   enabled = true
@@ -399,7 +427,7 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
   description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
-  # Environment variables for sensitive configuration
+
   [aggregator.env]
     storage_connection_url = "postgresql://aggregator:aggregator@tertiary-aggregator-db:5432/aggregator?sslmode=disable"
     redis_address = "tertiary-aggregator-redis:6379"

--- a/build/devenv/gencfg/gencfg.go
+++ b/build/devenv/gencfg/gencfg.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v2"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm/deployment/v1_7_0/operations/committee_verifier"
 	executor_operations "github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm/deployment/v1_7_0/operations/executor"
 	offrampoperations "github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm/deployment/v1_7_0/operations/offramp"
@@ -81,11 +82,12 @@ func GenerateConfigs(cldDomain string, verifierPubKeys []string, numExecutors in
 		rmnRemoteAddresses                   = make(map[string]string)
 		rmnRemoteAddressesUint64             = make(map[uint64]string)
 		offRampAddresses                     = make(map[uint64]string)
-		thresholdPerSource                   = make(map[uint64]uint8)
+		thresholdPerSource                   = make(map[string]uint8)
 	)
 
 	for _, ref := range addressRefs {
 		chainSelectorStr := strconv.FormatUint(ref.ChainSelector, 10)
+		chainID, _ := chainsel.GetChainIDFromSelector(ref.ChainSelector)
 		switch ref.Type {
 		case datastore.ContractType(onrampoperations.ContractType):
 			onRampAddresses[chainSelectorStr] = ref.Address
@@ -101,7 +103,7 @@ func GenerateConfigs(cldDomain string, verifierPubKeys []string, numExecutors in
 		case datastore.ContractType(offrampoperations.ContractType):
 			offRampAddresses[ref.ChainSelector] = ref.Address
 		}
-		thresholdPerSource[ref.ChainSelector] = ocrThreshold(len(verifierPubKeys))
+		thresholdPerSource[chainID] = ocrThreshold(len(verifierPubKeys))
 	}
 
 	tempDir, err := os.MkdirTemp("", "ccv-configs")

--- a/build/devenv/tests/services/aggregator_test.go
+++ b/build/devenv/tests/services/aggregator_test.go
@@ -403,6 +403,8 @@ func (f *aggregatorTestFixture) assertHonestQuorumReached(t *testing.T, ctx cont
 // setupAggregatorTestFixture creates the test infrastructure with 2-of-3 quorum.
 func setupAggregatorTestFixture(t *testing.T) *aggregatorTestFixture {
 	committeeName := "test"
+	// 2337: selector: 12922642891491394802
+	sourceChainId := "2337"
 	sourceChainSel := uint64(12922642891491394802)
 	destChainSel := uint64(2)
 	verifierAddress := "0x68B1D87F95878fE05B998F19b66F4baba5De1aed"
@@ -429,8 +431,8 @@ func setupAggregatorTestFixture(t *testing.T) *aggregatorTestFixture {
 		CommitteeVerifierResolverAddresses: map[uint64]string{
 			sourceChainSel: verifierAddress,
 		},
-		ThresholdPerSource: map[uint64]uint8{
-			sourceChainSel: 2, // 2-of-3 threshold
+		ThresholdPerSource: map[string]uint8{
+			sourceChainId: 2, // 2-of-3 threshold
 		},
 		AggregationChannelBufferSize: 1, // Minimal buffer for channel exhaustion tests
 		BackgroundWorkerCount:        1, // Single worker = slow drain for deterministic tests


### PR DESCRIPTION
Changes are larger than anticipated due to the lack of support for per-source-chain signer+threshold. Introduces an additional configuration in env.toml/[[verifier]] called enabled_chains to designate that a perticular verifier node secures only certain chains.

Also changes the ordering of some operations in environment.go but it's mostly self-explanatory.

CCIP-8191