### PR TITLE
Update rc containers to allow main packages with multiple files.

### DIFF
--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -11,12 +11,12 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
-    cd aggregator/cmd && CGO_ENABLED=0 go build -ldflags='-s -w' .
+    cd aggregator/cmd && CGO_ENABLED=0 go build -out aggregator -ldflags='-s -w' .
 
 FROM alpine:latest
 WORKDIR /app
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /app/aggregator/cmd/cmd bin/aggregator
+COPY --from=builder /app/aggregator/cmd/aggregator bin/aggregator
 COPY --from=builder /app/aggregator/migrations /migrations
 RUN ln -s /migrations /app/migrations || true
 CMD ["/app/bin/aggregator"]

--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -11,12 +11,12 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
-    cd aggregator && CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/aggregator cmd/main.go
+    cd aggregator/cmd && CGO_ENABLED=0 go build -ldflags='-s -w' .
 
 FROM alpine:latest
 WORKDIR /app
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/aggregator bin/
+COPY --from=builder /app/aggregator/cmd/cmd bin/aggregator
 COPY --from=builder /app/aggregator/migrations /migrations
 RUN ln -s /migrations /app/migrations || true
 CMD ["/app/bin/aggregator"]

--- a/build/devenv/Justfile
+++ b/build/devenv/Justfile
@@ -64,11 +64,11 @@ build-docker-dev-ci:
 # Build all the services for production
 build-docker-rc:
     @just fakes/build
-    @just ../../services/pricer/build-rc
-    @just ../../services/verifier/build-rc
-    @just ../../services/executor/build-rc
-    @just ../../services/indexer/build-rc
-    @just ../../services/aggregator/build-rc
+    @just ../../pricer/build-rc
+    @just ../../verifier/build-rc
+    @just ../../executor/build-rc
+    @just ../../indexer/build-rc
+    @just ../../aggregator/build-rc
 
 # Rebuild CLI
 cli:

--- a/executor/Dockerfile
+++ b/executor/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 WORKDIR /cmd/executor
 RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
-    CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/executor main.go
+    CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/executor .
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -11,10 +11,10 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
-    cd indexer && CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/indexer cmd/main.go
+    cd indexer/cmd && CGO_ENABLED=0 go build -ldflags='-s -w' .
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/indexer /bin/
+COPY --from=builder /app/indexer/cmd/cmd /bin/indexer
 COPY --from=builder /app/indexer/migrations ./migrations
 CMD ["/bin/indexer"]

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -11,10 +11,10 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
-    cd indexer/cmd && CGO_ENABLED=0 go build -ldflags='-s -w' .
+    cd indexer/cmd && CGO_ENABLED=0 go build -out indexer -ldflags='-s -w' .
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /app/indexer/cmd/cmd /bin/indexer
+COPY --from=builder /app/indexer/cmd/indexer /bin/indexer
 COPY --from=builder /app/indexer/migrations ./migrations
 CMD ["/bin/indexer"]

--- a/pricer/Dockerfile
+++ b/pricer/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 WORKDIR /pricer/cmd
 RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-s -w' -o /bin/pricer main.go
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-s -w' -o /bin/pricer .
 
 # Release on alpine to keep size small
 FROM alpine:latest

--- a/verifier/Dockerfile
+++ b/verifier/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /cmd/verifier/${VERIFIER_TYPE}
 
 RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
-    CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/verifier main.go
+    CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/verifier .
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
One of the rc container builds stopped working because the `main.go` file was split into two parts. This PR updates all containers to build the package rather than the a specific file.