### PR TITLE
Use bootstrap.JobSpec in apps and devenv.

### DIFF
--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -1,0 +1,9 @@
+package bootstrap
+
+// JobSpec is the specification for a commit verifier job, pushed by JD.
+type JobSpec struct {
+	ExternalJobID string `toml:"externalJobID"`
+	SchemaVersion int    `toml:"schemaVersion"`
+	Type          string `toml:"type"`
+	AppConfig     string `toml:"appConfig"`
+}

--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -1,6 +1,6 @@
 package bootstrap
 
-// JobSpec is the specification for a commit verifier job, pushed by JD.
+// JobSpec is the specification for a bootstrap service job, pushed by JD.
 type JobSpec struct {
 	Name          string `toml:"name"`
 	ExternalJobID string `toml:"externalJobID"`

--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -2,6 +2,7 @@ package bootstrap
 
 // JobSpec is the specification for a commit verifier job, pushed by JD.
 type JobSpec struct {
+	Name          string `toml:"name"`
 	ExternalJobID string `toml:"externalJobID"`
 	SchemaVersion int    `toml:"schemaVersion"`
 	Type          string `toml:"type"`

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -2077,31 +2077,6 @@ func (ejs ExecutorJobSpec) ToBootstrapJobSpec() bootstrap.JobSpec {
 	}
 }
 
-// ParseVerifierConfigFromJobSpec extracts the inner commit.Config from a verifier job spec.
-func ParseVerifierConfigFromJobSpec(spec bootstrap.JobSpec) (*commit.Config, error) {
-	var cfg commit.Config
-	if err := toml.Unmarshal([]byte(spec.AppConfig), &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse verifier config from job spec: %w", err)
-	}
-
-	return &cfg, nil
-}
-
-// ParseExecutorConfigFromJobSpec extracts the inner executor.Configuration from an executor job spec.
-func ParseExecutorConfigFromJobSpec(jobSpec string) (*executor.Configuration, error) {
-	var spec ExecutorJobSpec
-	if err := toml.Unmarshal([]byte(jobSpec), &spec); err != nil {
-		return nil, fmt.Errorf("failed to parse job spec: %w", err)
-	}
-
-	var cfg executor.Configuration
-	if err := toml.Unmarshal([]byte(spec.ExecutorConfig), &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse executor config from job spec: %w", err)
-	}
-
-	return &cfg, nil
-}
-
 // extractAndValidateDisableFinalityCheckers extracts DisableFinalityCheckers from verifiers
 // in a committee and validates that all verifiers have the same setting.
 func extractAndValidateDisableFinalityCheckers(committeeName string, verifiers []*committeeverifier.Input) (disableFinalityCheckersPerFamily map[string][]string, err error) {
@@ -2111,7 +2086,7 @@ func extractAndValidateDisableFinalityCheckers(committeeName string, verifiers [
 
 	disableFinalityCheckersPerFamily = make(map[string][]string)
 	for _, ver := range verifiers {
-		// if already set, check if its the same value
+		// if already set, check if it's the same value
 		if _, ok := disableFinalityCheckersPerFamily[ver.ChainFamily]; ok {
 			if !slicesEqual(disableFinalityCheckersPerFamily[ver.ChainFamily], ver.DisableFinalityCheckers) {
 				return nil, fmt.Errorf(

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -2037,6 +2037,13 @@ type VerifierJobSpec struct {
 	CommitteeVerifierConfig string `toml:"committeeVerifierConfig"`
 }
 
+// ExecutorJobSpec represents the structure of an executor job spec TOML.
+type ExecutorJobSpec struct {
+	SchemaVersion  int    `toml:"schemaVersion"`
+	Type           string `toml:"type"`
+	ExecutorConfig string `toml:"executorConfig"`
+}
+
 // ParseVerifierConfigFromJobSpec extracts the inner commit.Config from a verifier job spec.
 func ParseVerifierConfigFromJobSpec(jobSpec string) (*commit.Config, error) {
 	var spec VerifierJobSpec
@@ -2050,13 +2057,6 @@ func ParseVerifierConfigFromJobSpec(jobSpec string) (*commit.Config, error) {
 	}
 
 	return &cfg, nil
-}
-
-// ExecutorJobSpec represents the structure of an executor job spec TOML.
-type ExecutorJobSpec struct {
-	SchemaVersion  int    `toml:"schemaVersion"`
-	Type           string `toml:"type"`
-	ExecutorConfig string `toml:"executorConfig"`
 }
 
 // ParseExecutorConfigFromJobSpec extracts the inner executor.Configuration from an executor job spec.

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -545,8 +545,8 @@ func generateExecutorJobSpecs(
 	impls []cciptestinterfaces.CCIP17Configuration,
 	topology *ccipOffchain.EnvironmentTopology,
 	ds datastore.MutableDataStore,
-) (map[string]bootstrap.JobSpec, error) {
-	executorJobSpecs := make(map[string]bootstrap.JobSpec)
+) (map[string]string, error) {
+	executorJobSpecs := make(map[string]string)
 
 	if len(in.Executor) == 0 {
 		return executorJobSpecs, nil
@@ -590,31 +590,17 @@ func generateExecutorJobSpecs(
 				return nil, fmt.Errorf("failed to get executor job spec for %s: %w", exec.ContainerName, err)
 			}
 
-			// TODO: Use bootstrap.JobSpec in CLD to avoid this conversion here
-			var executorSpec ExecutorJobSpec
-			{
-				md, err := toml.Decode(job.Spec, &executorSpec)
-				if err != nil {
-					return nil, fmt.Errorf("failed to decode verifier job spec for %s: %w", exec.ContainerName, err)
-				}
-				if len(md.Undecoded()) > 0 {
-					L.Warn().
-						Str("spec", job.Spec).
-						Str("undecoded fields", fmt.Sprintf("%v", md.Undecoded())).
-						Msg("Undecoded fields in executor job spec")
-					return nil, fmt.Errorf("unknown fields in executor job spec for %s: %v", exec.ContainerName, md.Undecoded())
-				}
-				executorJobSpecs[exec.ContainerName] = executorSpec.ToBootstrapJobSpec()
-			}
+			jobSpec := job.Spec
+			executorJobSpecs[exec.ContainerName] = jobSpec
 
 			// Extract inner config from job spec for standalone mode
-			var cfg executor.Configuration
-			if err := toml.Unmarshal([]byte(executorSpec.ExecutorConfig), &cfg); err != nil {
+			execCfg, err := ParseExecutorConfigFromJobSpec(jobSpec)
+			if err != nil {
 				return nil, fmt.Errorf("failed to parse executor config from job spec: %w", err)
 			}
 
 			// Marshal the inner config back to TOML for standalone mode
-			configBytes, err := toml.Marshal(cfg)
+			configBytes, err := toml.Marshal(execCfg)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal executor config: %w", err)
 			}
@@ -1901,7 +1887,7 @@ func registerExecutorsWithJD(ctx context.Context, executors []*executorsvc.Input
 func proposeJobsToExecutors(
 	ctx context.Context,
 	executors []*executorsvc.Input,
-	executorJobSpecs map[string]bootstrap.JobSpec,
+	executorJobSpecs map[string]string,
 	blockchainOutputs []*blockchain.Output,
 	jdClient offchain.Client,
 ) error {
@@ -2098,6 +2084,21 @@ func (ejs ExecutorJobSpec) ToBootstrapJobSpec() bootstrap.JobSpec {
 		Type:          ejs.Type,
 		AppConfig:     ejs.ExecutorConfig,
 	}
+}
+
+// ParseExecutorConfigFromJobSpec extracts the inner executor.Configuration from an executor job spec.
+func ParseExecutorConfigFromJobSpec(jobSpec string) (*executor.Configuration, error) {
+	var spec ExecutorJobSpec
+	if err := toml.Unmarshal([]byte(jobSpec), &spec); err != nil {
+		return nil, fmt.Errorf("failed to parse job spec: %w", err)
+	}
+
+	var cfg executor.Configuration
+	if err := toml.Unmarshal([]byte(spec.ExecutorConfig), &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse executor config from job spec: %w", err)
+	}
+
+	return &cfg, nil
 }
 
 // extractAndValidateDisableFinalityCheckers extracts DisableFinalityCheckers from verifiers

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -593,9 +593,16 @@ func generateExecutorJobSpecs(
 			// TODO: Use bootstrap.JobSpec in CLD to avoid this conversion here
 			var executorSpec ExecutorJobSpec
 			{
-				_, err = toml.Decode(job.Spec, &executorSpec)
+				md, err := toml.Decode(job.Spec, &executorSpec)
 				if err != nil {
 					return nil, fmt.Errorf("failed to decode verifier job spec for %s: %w", exec.ContainerName, err)
+				}
+				if len(md.Undecoded()) > 0 {
+					L.Warn().
+						Str("spec", job.Spec).
+						Str("undecoded fields", fmt.Sprintf("%v", md.Undecoded())).
+						Msg("Undecoded fields in executor job spec")
+					return nil, fmt.Errorf("unknown fields in executor job spec for %s: %v", exec.ContainerName, md.Undecoded())
 				}
 				executorJobSpecs[exec.ContainerName] = executorSpec.ToBootstrapJobSpec()
 			}
@@ -768,8 +775,16 @@ func generateVerifierJobSpecs(
 
 					// TODO: Use bootstrap.JobSpec in CLD to avoid this conversion here
 					var verifierJobSpec VerifierJobSpec
-					if _, err := toml.Decode(job.Spec, &verifierJobSpec); err != nil {
+					md, err := toml.Decode(job.Spec, &verifierJobSpec)
+					if err != nil {
 						return nil, fmt.Errorf("failed to decode verifier job spec for %s: %w", ver.ContainerName, err)
+					}
+					if len(md.Undecoded()) > 0 {
+						L.Warn().
+							Str("spec", job.Spec).
+							Str("undecoded fields", fmt.Sprintf("%v", md.Undecoded())).
+							Msg("Undecoded fields in executor job spec")
+						return nil, fmt.Errorf("unknown fields in verifier job spec for %s aggregator: %v", ver.ContainerName, md.Undecoded())
 					}
 
 					allJobSpecs = append(allJobSpecs, verifierJobSpec.ToBootstrapJobSpec())
@@ -2049,6 +2064,8 @@ type IndexerSecret struct {
 
 // VerifierJobSpec represents the structure of a verifier job spec TOML.
 type VerifierJobSpec struct {
+	Name                    string `toml:"name"`
+	ExternalJobID           string `toml:"externalJobID"`
 	SchemaVersion           int    `toml:"schemaVersion"`
 	Type                    string `toml:"type"`
 	CommitteeVerifierConfig string `toml:"committeeVerifierConfig"`
@@ -2056,6 +2073,8 @@ type VerifierJobSpec struct {
 
 func (vjs VerifierJobSpec) ToBootstrapJobSpec() bootstrap.JobSpec {
 	return bootstrap.JobSpec{
+		Name:          vjs.Name,
+		ExternalJobID: vjs.ExternalJobID,
 		SchemaVersion: vjs.SchemaVersion,
 		Type:          vjs.Type,
 		AppConfig:     vjs.CommitteeVerifierConfig,
@@ -2064,6 +2083,8 @@ func (vjs VerifierJobSpec) ToBootstrapJobSpec() bootstrap.JobSpec {
 
 // ExecutorJobSpec represents the structure of an executor job spec TOML.
 type ExecutorJobSpec struct {
+	Name           string `toml:"name"`
+	ExternalJobID  string `toml:"externalJobID"`
 	SchemaVersion  int    `toml:"schemaVersion"`
 	Type           string `toml:"type"`
 	ExecutorConfig string `toml:"executorConfig"`
@@ -2071,6 +2092,8 @@ type ExecutorJobSpec struct {
 
 func (ejs ExecutorJobSpec) ToBootstrapJobSpec() bootstrap.JobSpec {
 	return bootstrap.JobSpec{
+		Name:          ejs.Name,
+		ExternalJobID: ejs.ExternalJobID,
 		SchemaVersion: ejs.SchemaVersion,
 		Type:          ejs.Type,
 		AppConfig:     ejs.ExecutorConfig,

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
 
 	ccipAdapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 	ccipChangesets "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/changesets"
@@ -544,8 +545,8 @@ func generateExecutorJobSpecs(
 	impls []cciptestinterfaces.CCIP17Configuration,
 	topology *ccipOffchain.EnvironmentTopology,
 	ds datastore.MutableDataStore,
-) (map[string]string, error) {
-	executorJobSpecs := make(map[string]string)
+) (map[string]bootstrap.JobSpec, error) {
+	executorJobSpecs := make(map[string]bootstrap.JobSpec)
 
 	if len(in.Executor) == 0 {
 		return executorJobSpecs, nil
@@ -588,17 +589,25 @@ func generateExecutorJobSpecs(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get executor job spec for %s: %w", exec.ContainerName, err)
 			}
-			jobSpec := job.Spec
-			executorJobSpecs[exec.ContainerName] = jobSpec
+
+			// TODO: Use bootstrap.JobSpec in CLD to avoid this conversion here
+			var executorSpec ExecutorJobSpec
+			{
+				_, err = toml.Decode(job.Spec, &executorSpec)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode verifier job spec for %s: %w", exec.ContainerName, err)
+				}
+				executorJobSpecs[exec.ContainerName] = executorSpec.ToBootstrapJobSpec()
+			}
 
 			// Extract inner config from job spec for standalone mode
-			execCfg, err := ParseExecutorConfigFromJobSpec(jobSpec)
-			if err != nil {
+			var cfg executor.Configuration
+			if err := toml.Unmarshal([]byte(executorSpec.ExecutorConfig), &cfg); err != nil {
 				return nil, fmt.Errorf("failed to parse executor config from job spec: %w", err)
 			}
 
 			// Marshal the inner config back to TOML for standalone mode
-			configBytes, err := toml.Marshal(execCfg)
+			configBytes, err := toml.Marshal(cfg)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal executor config: %w", err)
 			}
@@ -678,8 +687,8 @@ func generateVerifierJobSpecs(
 	topology *ccipOffchain.EnvironmentTopology,
 	sharedTLSCerts *services.TLSCertPaths,
 	ds datastore.MutableDataStore,
-) (map[string][]string, error) {
-	verifierJobSpecs := make(map[string][]string)
+) (map[string][]bootstrap.JobSpec, error) {
+	verifierJobSpecs := make(map[string][]bootstrap.JobSpec)
 
 	if len(in.Verifier) == 0 {
 		return verifierJobSpecs, nil
@@ -749,14 +758,21 @@ func generateVerifierJobSpecs(
 					continue
 				}
 
-				allJobSpecs := make([]string, 0, len(aggNames))
+				allJobSpecs := make([]bootstrap.JobSpec, 0, len(aggNames))
 				for _, aggName := range aggNames {
 					jobSpecID := shared.NewVerifierJobID(shared.NOPAlias(ver.NOPAlias), aggName, shared.VerifierJobScope{CommitteeQualifier: committeeName})
 					job, err := ccipOffchain.GetJob(output.DataStore.Seal(), shared.NOPAlias(ver.NOPAlias), jobSpecID.ToJobID())
 					if err != nil {
 						return nil, fmt.Errorf("failed to get verifier job spec for %s aggregator %s: %w", ver.ContainerName, aggName, err)
 					}
-					allJobSpecs = append(allJobSpecs, job.Spec)
+
+					// TODO: Use bootstrap.JobSpec in CLD to avoid this conversion here
+					var verifierJobSpec VerifierJobSpec
+					if _, err := toml.Decode(job.Spec, &verifierJobSpec); err != nil {
+						return nil, fmt.Errorf("failed to decode verifier job spec for %s: %w", ver.ContainerName, err)
+					}
+
+					allJobSpecs = append(allJobSpecs, verifierJobSpec.ToBootstrapJobSpec())
 				}
 
 				verifierJobSpecs[ver.NOPAlias] = allJobSpecs
@@ -766,10 +782,11 @@ func generateVerifierJobSpecs(
 				// single-aggregator committees the modulo collapses to 0, so all
 				// verifiers share the one aggregator — matching the non-HA model.
 				ownedAggIdx := ver.NodeIndex % len(aggNames)
-				verCfg, err := ParseVerifierConfigFromJobSpec(allJobSpecs[ownedAggIdx])
-				if err != nil {
+				var verCfg commit.Config
+				if err := toml.Unmarshal([]byte(allJobSpecs[ownedAggIdx].AppConfig), &verCfg); err != nil {
 					return nil, fmt.Errorf("failed to parse verifier config from job spec: %w", err)
 				}
+
 				configBytes, err := toml.Marshal(verCfg)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal verifier config: %w", err)
@@ -1431,7 +1448,7 @@ func NewEnvironment() (in *Cfg, err error) {
 	// Each verifier owns one aggregator (NodeIndex % numAggs). Select the
 	// corresponding job spec so proposeJobsToStandaloneVerifiers gets a
 	// single spec per container.
-	ownedJobSpecs := make(map[string]string, len(verifierJobSpecs))
+	ownedJobSpecs := make(map[string]bootstrap.JobSpec, len(verifierJobSpecs))
 	for _, ver := range in.Verifier {
 		specs := verifierJobSpecs[ver.NOPAlias]
 		if len(specs) > 0 {
@@ -1869,7 +1886,7 @@ func registerExecutorsWithJD(ctx context.Context, executors []*executorsvc.Input
 func proposeJobsToExecutors(
 	ctx context.Context,
 	executors []*executorsvc.Input,
-	executorJobSpecs map[string]string,
+	executorJobSpecs map[string]bootstrap.JobSpec,
 	blockchainOutputs []*blockchain.Output,
 	jdClient offchain.Client,
 ) error {
@@ -2037,6 +2054,14 @@ type VerifierJobSpec struct {
 	CommitteeVerifierConfig string `toml:"committeeVerifierConfig"`
 }
 
+func (vjs VerifierJobSpec) ToBootstrapJobSpec() bootstrap.JobSpec {
+	return bootstrap.JobSpec{
+		SchemaVersion: vjs.SchemaVersion,
+		Type:          vjs.Type,
+		AppConfig:     vjs.CommitteeVerifierConfig,
+	}
+}
+
 // ExecutorJobSpec represents the structure of an executor job spec TOML.
 type ExecutorJobSpec struct {
 	SchemaVersion  int    `toml:"schemaVersion"`
@@ -2044,15 +2069,18 @@ type ExecutorJobSpec struct {
 	ExecutorConfig string `toml:"executorConfig"`
 }
 
-// ParseVerifierConfigFromJobSpec extracts the inner commit.Config from a verifier job spec.
-func ParseVerifierConfigFromJobSpec(jobSpec string) (*commit.Config, error) {
-	var spec VerifierJobSpec
-	if err := toml.Unmarshal([]byte(jobSpec), &spec); err != nil {
-		return nil, fmt.Errorf("failed to parse job spec: %w", err)
+func (ejs ExecutorJobSpec) ToBootstrapJobSpec() bootstrap.JobSpec {
+	return bootstrap.JobSpec{
+		SchemaVersion: ejs.SchemaVersion,
+		Type:          ejs.Type,
+		AppConfig:     ejs.ExecutorConfig,
 	}
+}
 
+// ParseVerifierConfigFromJobSpec extracts the inner commit.Config from a verifier job spec.
+func ParseVerifierConfigFromJobSpec(spec bootstrap.JobSpec) (*commit.Config, error) {
 	var cfg commit.Config
-	if err := toml.Unmarshal([]byte(spec.CommitteeVerifierConfig), &cfg); err != nil {
+	if err := toml.Unmarshal([]byte(spec.AppConfig), &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse verifier config from job spec: %w", err)
 	}
 
@@ -2201,7 +2229,7 @@ func registerStandaloneVerifiersWithJD(ctx context.Context, verifiers []*committ
 func proposeJobsToStandaloneVerifiers(
 	ctx context.Context,
 	verifiers []*committeeverifier.Input,
-	verifierJobSpecs map[string]string,
+	verifierJobSpecs map[string]bootstrap.JobSpec,
 	blockchainOutputs []*blockchain.Output,
 	jdClient offchain.Client,
 ) error {

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -545,8 +545,8 @@ func generateExecutorJobSpecs(
 	impls []cciptestinterfaces.CCIP17Configuration,
 	topology *ccipOffchain.EnvironmentTopology,
 	ds datastore.MutableDataStore,
-) (map[string]string, error) {
-	executorJobSpecs := make(map[string]string)
+) (map[string]bootstrap.JobSpec, error) {
+	executorJobSpecs := make(map[string]bootstrap.JobSpec)
 
 	if len(in.Executor) == 0 {
 		return executorJobSpecs, nil
@@ -590,17 +590,31 @@ func generateExecutorJobSpecs(
 				return nil, fmt.Errorf("failed to get executor job spec for %s: %w", exec.ContainerName, err)
 			}
 
-			jobSpec := job.Spec
-			executorJobSpecs[exec.ContainerName] = jobSpec
+			// TODO: Use bootstrap.JobSpec in CLD to avoid this conversion here
+			var executorSpec ExecutorJobSpec
+			{
+				md, err := toml.Decode(job.Spec, &executorSpec)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode verifier job spec for %s: %w", exec.ContainerName, err)
+				}
+				if len(md.Undecoded()) > 0 {
+					L.Warn().
+						Str("spec", job.Spec).
+						Str("undecoded fields", fmt.Sprintf("%v", md.Undecoded())).
+						Msg("Undecoded fields in executor job spec")
+					return nil, fmt.Errorf("unknown fields in executor job spec for %s: %v", exec.ContainerName, md.Undecoded())
+				}
+				executorJobSpecs[exec.ContainerName] = executorSpec.ToBootstrapJobSpec()
+			}
 
 			// Extract inner config from job spec for standalone mode
-			execCfg, err := ParseExecutorConfigFromJobSpec(jobSpec)
-			if err != nil {
+			var cfg executor.Configuration
+			if err := toml.Unmarshal([]byte(executorSpec.ExecutorConfig), &cfg); err != nil {
 				return nil, fmt.Errorf("failed to parse executor config from job spec: %w", err)
 			}
 
 			// Marshal the inner config back to TOML for standalone mode
-			configBytes, err := toml.Marshal(execCfg)
+			configBytes, err := toml.Marshal(cfg)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal executor config: %w", err)
 			}
@@ -1887,7 +1901,7 @@ func registerExecutorsWithJD(ctx context.Context, executors []*executorsvc.Input
 func proposeJobsToExecutors(
 	ctx context.Context,
 	executors []*executorsvc.Input,
-	executorJobSpecs map[string]string,
+	executorJobSpecs map[string]bootstrap.JobSpec,
 	blockchainOutputs []*blockchain.Output,
 	jdClient offchain.Client,
 ) error {
@@ -2084,21 +2098,6 @@ func (ejs ExecutorJobSpec) ToBootstrapJobSpec() bootstrap.JobSpec {
 		Type:          ejs.Type,
 		AppConfig:     ejs.ExecutorConfig,
 	}
-}
-
-// ParseExecutorConfigFromJobSpec extracts the inner executor.Configuration from an executor job spec.
-func ParseExecutorConfigFromJobSpec(jobSpec string) (*executor.Configuration, error) {
-	var spec ExecutorJobSpec
-	if err := toml.Unmarshal([]byte(jobSpec), &spec); err != nil {
-		return nil, fmt.Errorf("failed to parse job spec: %w", err)
-	}
-
-	var cfg executor.Configuration
-	if err := toml.Unmarshal([]byte(spec.ExecutorConfig), &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse executor config from job spec: %w", err)
-	}
-
-	return &cfg, nil
 }
 
 // extractAndValidateDisableFinalityCheckers extracts DisableFinalityCheckers from verifiers

--- a/build/devenv/services/committeeverifier/base.go
+++ b/build/devenv/services/committeeverifier/base.go
@@ -16,7 +16,6 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
-
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/jobs"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services"
@@ -92,7 +91,7 @@ type Input struct {
 	AggregatorOutput *services.AggregatorOutput `toml:"-"`
 
 	// GeneratedJobSpecs contains all job specs for this verifier, one per aggregator in the committee.
-	GeneratedJobSpecs []string `toml:"-"`
+	GeneratedJobSpecs []bootstrap.JobSpec `toml:"-"`
 
 	// GeneratedConfig is the verifier configuration TOML derived from
 	// GeneratedJobSpecs[NodeIndex % numAggregators].
@@ -104,16 +103,10 @@ type Input struct {
 // added to the inner config. This is needed for standalone verifiers which require blockchain
 // connection information (CL nodes get this from their own chain config).
 // TODO: we stick with the job spec so that there isn't special logic for standalone verifiers.
-func (v *Input) RebuildVerifierJobSpecWithBlockchainInfos(jobSpec string, blockchainInfos map[string]any) (string, error) {
-	// Parse the outer job spec first.
-	var spec commit.JobSpec
-	if _, err := toml.Decode(jobSpec, &spec); err != nil {
-		return "", fmt.Errorf("failed to parse job spec: %w", err)
-	}
-
+func (v *Input) RebuildVerifierJobSpecWithBlockchainInfos(spec bootstrap.JobSpec, blockchainInfos map[string]any) (string, error) {
 	// Parse the inner config next.
 	var cfg commit.Config
-	if _, err := toml.Decode(spec.CommitteeVerifierConfig, &cfg); err != nil {
+	if _, err := toml.Decode(spec.AppConfig, &cfg); err != nil {
 		return "", fmt.Errorf("failed to parse verifier config from job spec: %w", err)
 	}
 
@@ -129,7 +122,7 @@ func (v *Input) RebuildVerifierJobSpecWithBlockchainInfos(jobSpec string, blockc
 	}
 
 	// Rebuild the job spec with the enhanced config
-	spec.CommitteeVerifierConfig = string(innerConfigBytes)
+	spec.AppConfig = string(innerConfigBytes)
 	outerSpecBytes, err := toml.Marshal(spec)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal job spec: %w", err)

--- a/build/devenv/services/executor/base.go
+++ b/build/devenv/services/executor/base.go
@@ -100,14 +100,9 @@ type Output struct {
 // RebuildExecutorJobSpecWithBlockchainInfos takes a job spec and rebuilds it with blockchain infos
 // added to the inner config. This is needed for standalone executors which require blockchain
 // connection information (CL nodes get this from their own chain config).
-func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(jobSpec string, blockchainInfos map[string]any) (string, error) {
-	var spec executorpkg.JobSpec
-	if _, err := toml.Decode(jobSpec, &spec); err != nil {
-		return "", fmt.Errorf("failed to parse job spec: %w", err)
-	}
-
+func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(spec bootstrap.JobSpec, blockchainInfos map[string]any) (string, error) {
 	var cfg executorpkg.Configuration
-	if _, err := toml.Decode(spec.ExecutorConfig, &cfg); err != nil {
+	if _, err := toml.Decode(spec.AppConfig, &cfg); err != nil {
 		return "", fmt.Errorf("failed to parse executor config from job spec: %w", err)
 	}
 
@@ -126,7 +121,7 @@ func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(jobSpec string, blockc
 		return "", fmt.Errorf("failed to marshal enhanced config: %w", err)
 	}
 
-	spec.ExecutorConfig = string(innerConfigBytes)
+	spec.AppConfig = string(innerConfigBytes)
 	outerSpecBytes, err := toml.Marshal(spec)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal job spec: %w", err)

--- a/build/devenv/services/executor/base.go
+++ b/build/devenv/services/executor/base.go
@@ -100,9 +100,13 @@ type Output struct {
 // RebuildExecutorJobSpecWithBlockchainInfos takes a job spec and rebuilds it with blockchain infos
 // added to the inner config. This is needed for standalone executors which require blockchain
 // connection information (CL nodes get this from their own chain config).
-func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(spec bootstrap.JobSpec, blockchainInfos map[string]any) (string, error) {
+func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(jobSpec string, blockchainInfos map[string]any) (string, error) {
+	var spec executorpkg.JobSpec
+	if _, err := toml.Decode(jobSpec, &spec); err != nil {
+		return "", fmt.Errorf("failed to parse job spec: %w", err)
+	}
 	var cfg executorpkg.Configuration
-	if _, err := toml.Decode(spec.AppConfig, &cfg); err != nil {
+	if _, err := toml.Decode(spec.ExecutorConfig, &cfg); err != nil {
 		return "", fmt.Errorf("failed to parse executor config from job spec: %w", err)
 	}
 
@@ -121,7 +125,7 @@ func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(spec bootstrap.JobSpec
 		return "", fmt.Errorf("failed to marshal enhanced config: %w", err)
 	}
 
-	spec.AppConfig = string(innerConfigBytes)
+	spec.ExecutorConfig = string(innerConfigBytes)
 	outerSpecBytes, err := toml.Marshal(spec)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal job spec: %w", err)

--- a/build/devenv/services/executor/base.go
+++ b/build/devenv/services/executor/base.go
@@ -100,13 +100,9 @@ type Output struct {
 // RebuildExecutorJobSpecWithBlockchainInfos takes a job spec and rebuilds it with blockchain infos
 // added to the inner config. This is needed for standalone executors which require blockchain
 // connection information (CL nodes get this from their own chain config).
-func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(jobSpec string, blockchainInfos map[string]any) (string, error) {
-	var spec executorpkg.JobSpec
-	if _, err := toml.Decode(jobSpec, &spec); err != nil {
-		return "", fmt.Errorf("failed to parse job spec: %w", err)
-	}
+func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(spec bootstrap.JobSpec, blockchainInfos map[string]any) (string, error) {
 	var cfg executorpkg.Configuration
-	if _, err := toml.Decode(spec.ExecutorConfig, &cfg); err != nil {
+	if _, err := toml.Decode(spec.AppConfig, &cfg); err != nil {
 		return "", fmt.Errorf("failed to parse executor config from job spec: %w", err)
 	}
 
@@ -125,7 +121,7 @@ func (v *Input) RebuildExecutorJobSpecWithBlockchainInfos(jobSpec string, blockc
 		return "", fmt.Errorf("failed to marshal enhanced config: %w", err)
 	}
 
-	spec.ExecutorConfig = string(innerConfigBytes)
+	spec.AppConfig = string(innerConfigBytes)
 	outerSpecBytes, err := toml.Marshal(spec)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal job spec: %w", err)

--- a/cmd/executor/servicefactory.go
+++ b/cmd/executor/servicefactory.go
@@ -60,7 +60,7 @@ type factory[T any] struct {
 
 // NewServiceFactory creates a new ServiceFactory for the executor service.
 // T is the chain config type for this family (e.g. blockchain.Info for EVM).
-func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExecutorComponentsFunc[T]) bootstrap.ServiceFactory[bootstrap.JobSpec] {
+func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExecutorComponentsFunc[T]) bootstrap.ServiceFactory[executor.JobSpec] {
 	return &factory[T]{
 		createComponentsFunc: createComponentsFunc,
 		chainFamily:          chainFamily,
@@ -68,13 +68,13 @@ func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExe
 }
 
 // Start implements [bootstrap.ServiceFactory].
-func (f *factory[T]) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootstrap.ServiceDeps) error {
+func (f *factory[T]) Start(ctx context.Context, spec executor.JobSpec, deps bootstrap.ServiceDeps) error {
 	lggr := logger.Sugared(logger.Named(deps.Logger, "Executor"))
 	f.lggr = lggr
 
 	lggr.Infow("Starting executor service", "spec", spec)
 
-	executorConfig, blockchainInfos, err := executor.LoadConfigWithBlockchainInfos[T](spec.AppConfig)
+	executorConfig, blockchainInfos, err := executor.LoadConfigWithBlockchainInfos[T](spec.ExecutorConfig)
 	if err != nil {
 		lggr.Errorw("Failed to load configuration", "error", err)
 		return fmt.Errorf("failed to load configuration: %w", err)

--- a/cmd/executor/servicefactory.go
+++ b/cmd/executor/servicefactory.go
@@ -60,7 +60,7 @@ type factory[T any] struct {
 
 // NewServiceFactory creates a new ServiceFactory for the executor service.
 // T is the chain config type for this family (e.g. blockchain.Info for EVM).
-func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExecutorComponentsFunc[T]) bootstrap.ServiceFactory[executor.JobSpec] {
+func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExecutorComponentsFunc[T]) bootstrap.ServiceFactory[bootstrap.JobSpec] {
 	return &factory[T]{
 		createComponentsFunc: createComponentsFunc,
 		chainFamily:          chainFamily,
@@ -68,13 +68,13 @@ func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExe
 }
 
 // Start implements [bootstrap.ServiceFactory].
-func (f *factory[T]) Start(ctx context.Context, spec executor.JobSpec, deps bootstrap.ServiceDeps) error {
+func (f *factory[T]) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootstrap.ServiceDeps) error {
 	lggr := logger.Sugared(logger.Named(deps.Logger, "Executor"))
 	f.lggr = lggr
 
 	lggr.Infow("Starting executor service", "spec", spec)
 
-	executorConfig, blockchainInfos, err := executor.LoadConfigWithBlockchainInfos[T](spec.ExecutorConfig)
+	executorConfig, blockchainInfos, err := executor.LoadConfigWithBlockchainInfos[T](spec.AppConfig)
 	if err != nil {
 		lggr.Errorw("Failed to load configuration", "error", err)
 		return fmt.Errorf("failed to load configuration: %w", err)

--- a/cmd/executor/servicefactory.go
+++ b/cmd/executor/servicefactory.go
@@ -60,7 +60,7 @@ type factory[T any] struct {
 
 // NewServiceFactory creates a new ServiceFactory for the executor service.
 // T is the chain config type for this family (e.g. blockchain.Info for EVM).
-func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExecutorComponentsFunc[T]) bootstrap.ServiceFactory[executor.JobSpec] {
+func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExecutorComponentsFunc[T]) bootstrap.ServiceFactory[bootstrap.JobSpec] {
 	return &factory[T]{
 		createComponentsFunc: createComponentsFunc,
 		chainFamily:          chainFamily,
@@ -68,13 +68,13 @@ func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExe
 }
 
 // Start implements [bootstrap.ServiceFactory].
-func (f *factory[T]) Start(ctx context.Context, spec executor.JobSpec, deps bootstrap.ServiceDeps) error {
+func (f *factory[T]) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootstrap.ServiceDeps) error {
 	lggr := logger.Sugared(logger.Named(deps.Logger, "Executor"))
 	f.lggr = lggr
 
 	lggr.Infow("Starting executor service", "spec", spec)
 
-	executorConfig, blockchainInfos, err := executor.LoadConfigWithBlockchainInfos[T](spec)
+	executorConfig, blockchainInfos, err := executor.LoadConfigWithBlockchainInfos[T](spec.AppConfig)
 	if err != nil {
 		lggr.Errorw("Failed to load configuration", "error", err)
 		return fmt.Errorf("failed to load configuration: %w", err)

--- a/executor/job.go
+++ b/executor/job.go
@@ -1,0 +1,9 @@
+package executor
+
+// JobSpec is the specification for an executor job, pushed by JD.
+type JobSpec struct {
+	ExternalJobID  string `toml:"externalJobID"`
+	SchemaVersion  int    `toml:"schemaVersion"`
+	Type           string `toml:"type"`
+	ExecutorConfig string `toml:"executorConfig"`
+}

--- a/executor/job.go
+++ b/executor/job.go
@@ -1,9 +1,0 @@
-package executor
-
-// JobSpec is the specification for an executor job, pushed by JD.
-type JobSpec struct {
-	ExternalJobID  string `toml:"externalJobID"`
-	SchemaVersion  int    `toml:"schemaVersion"`
-	Type           string `toml:"type"`
-	ExecutorConfig string `toml:"executorConfig"`
-}

--- a/executor/load.go
+++ b/executor/load.go
@@ -22,9 +22,9 @@ type cfgWithBlockchainInfos[T any] struct {
 // blockchain.Info for EVM). Strict decode is applied: any unknown key in the
 // config (including under blockchain_infos.<selector>) causes an error.
 // The returned Configuration has defaults applied via GetNormalizedConfig.
-func LoadConfigWithBlockchainInfos[T any](spec JobSpec) (*Configuration, chainaccess.Infos[T], error) {
+func LoadConfigWithBlockchainInfos[T any](cfg string) (*Configuration, chainaccess.Infos[T], error) {
 	var decodeTarget cfgWithBlockchainInfos[T]
-	md, err := toml.Decode(spec.ExecutorConfig, &decodeTarget)
+	md, err := toml.Decode(cfg, &decodeTarget)
 	if err != nil {
 		return nil, chainaccess.Infos[T]{}, fmt.Errorf("failed to decode executor config: %w", err)
 	}

--- a/integration/pkg/accessors/evm/evm_source_reader.go
+++ b/integration/pkg/accessors/evm/evm_source_reader.go
@@ -224,7 +224,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 			"messageId", common.Bytes2Hex(event.MessageId[:]))
 		decodedMsg, err := protocol.DecodeMessage(event.EncodedMessage)
 		if err != nil {
-			r.lggr.Errorw("Failed to decode message", "error", err)
+			r.lggr.Errorw("Failed to decode message", "error", err, "rawMessage", event.EncodedMessage)
 			continue // to next message
 		}
 		r.lggr.Infow("Decoded message",

--- a/verifier/cmd/committee/main.go
+++ b/verifier/cmd/committee/main.go
@@ -38,7 +38,7 @@ func main() {
 		cmd.NewCommitteeVerifierServiceFactory[evm.Info](
 			chainsel.FamilyEVM,
 			deprecatedCreateAccessorFactory),
-		bootstrap.WithLogLevel[commit.JobSpec](zapcore.InfoLevel),
+		bootstrap.WithLogLevel[bootstrap.JobSpec](zapcore.InfoLevel),
 	); err != nil {
 		panic(fmt.Sprintf("failed to run EVM committee verifier: %s", err.Error()))
 	}

--- a/verifier/cmd/servicefactory.go
+++ b/verifier/cmd/servicefactory.go
@@ -76,7 +76,7 @@ type factory[T any] struct {
 func NewServiceFactory[T any](
 	chainFamily string,
 	createAccessorFactoryFunc CreateAccessorFactoryFunc[T],
-) bootstrap.ServiceFactory[commit.JobSpec] {
+) bootstrap.ServiceFactory[bootstrap.JobSpec] {
 	return NewCommitteeVerifierServiceFactory(chainFamily, createAccessorFactoryFunc)
 }
 
@@ -85,7 +85,7 @@ func NewServiceFactory[T any](
 func NewCommitteeVerifierServiceFactory[T any](
 	chainFamily string,
 	createAccessorFactoryFunc CreateAccessorFactoryFunc[T],
-) bootstrap.ServiceFactory[commit.JobSpec] {
+) bootstrap.ServiceFactory[bootstrap.JobSpec] {
 	return &factory[T]{
 		createAccessorFactoryFunc: createAccessorFactoryFunc,
 		chainFamily:               chainFamily,
@@ -93,7 +93,7 @@ func NewCommitteeVerifierServiceFactory[T any](
 }
 
 // Start implements [bootstrap.ServiceFactory].
-func (f *factory[T]) Start(ctx context.Context, spec commit.JobSpec, deps bootstrap.ServiceDeps) error {
+func (f *factory[T]) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootstrap.ServiceDeps) error {
 	lggr := logger.Sugared(logger.Named(deps.Logger, "CommitteeVerifier"))
 	f.lggr = lggr
 
@@ -101,7 +101,7 @@ func (f *factory[T]) Start(ctx context.Context, spec commit.JobSpec, deps bootst
 
 	protocol.InitChainSelectorCache()
 
-	config, blockchainInfos, err := commit.LoadConfigWithBlockchainInfos[T](spec)
+	config, blockchainInfos, err := commit.LoadConfigWithBlockchainInfos[T](spec.AppConfig)
 	if err != nil {
 		lggr.Errorw("Failed to load configuration", "error", err)
 		return fmt.Errorf("failed to load configuration: %w", err)

--- a/verifier/pkg/commit/job.go
+++ b/verifier/pkg/commit/job.go
@@ -1,9 +1,0 @@
-package commit
-
-// JobSpec is the specification for a commit verifier job, pushed by JD.
-type JobSpec struct {
-	ExternalJobID           string `toml:"externalJobID"`
-	SchemaVersion           int    `toml:"schemaVersion"`
-	Type                    string `toml:"type"`
-	CommitteeVerifierConfig string `toml:"committeeVerifierConfig"`
-}

--- a/verifier/pkg/commit/load.go
+++ b/verifier/pkg/commit/load.go
@@ -20,9 +20,9 @@ type cfgWithBlockchainInfos[T any] struct {
 // into a strongly-typed chainaccess.Infos[T]. The type T is chosen by the caller (e.g.
 // blockchain.Info for EVM). Strict decode is applied: any unknown key in the config
 // (including under blockchain_infos.<selector>) causes an error.
-func LoadConfigWithBlockchainInfos[T any](spec JobSpec) (*Config, chainaccess.Infos[T], error) {
+func LoadConfigWithBlockchainInfos[T any](cfg string) (*Config, chainaccess.Infos[T], error) {
 	var decodeTarget cfgWithBlockchainInfos[T]
-	md, err := toml.Decode(spec.CommitteeVerifierConfig, &decodeTarget)
+	md, err := toml.Decode(cfg, &decodeTarget)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to decode committee verifier config: %w", err)
 	}

--- a/verifier/pkg/commit/load_test.go
+++ b/verifier/pkg/commit/load_test.go
@@ -34,9 +34,8 @@ Type = "evm"
 Family = "evm"
 UniqueChainName = "chain-1"
 `
-	spec := JobSpec{CommitteeVerifierConfig: tomlConfig}
 
-	cfg, infos, err := LoadConfigWithBlockchainInfos[testChainInfo](spec)
+	cfg, infos, err := LoadConfigWithBlockchainInfos[testChainInfo](tomlConfig)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	require.NotNil(t, infos)
@@ -58,9 +57,7 @@ func TestLoadConfigWithBlockchainInfos_UnknownTopLevelKey_ReturnsError(t *testin
 	tomlConfig := `
 typo_key = "should fail"
 `
-	spec := JobSpec{CommitteeVerifierConfig: tomlConfig}
-
-	_, _, err := LoadConfigWithBlockchainInfos[testChainInfo](spec)
+	_, _, err := LoadConfigWithBlockchainInfos[testChainInfo](tomlConfig)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown fields")
 	assert.Contains(t, err.Error(), "typo_key")
@@ -71,9 +68,7 @@ func TestLoadConfigWithBlockchainInfos_UnknownKeyUnderBlockchainInfos_ReturnsErr
 [blockchain_infos."1"]
 UnknownField = "should fail"
 `
-	spec := JobSpec{CommitteeVerifierConfig: tomlConfig}
-
-	_, _, err := LoadConfigWithBlockchainInfos[testChainInfo](spec)
+	_, _, err := LoadConfigWithBlockchainInfos[testChainInfo](tomlConfig)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown fields")
 	assert.Contains(t, err.Error(), "blockchain_infos")
@@ -81,9 +76,7 @@ UnknownField = "should fail"
 
 func TestLoadConfigWithBlockchainInfos_EmptyBlockchainInfos(t *testing.T) {
 	tomlConfig := ``
-	spec := JobSpec{CommitteeVerifierConfig: tomlConfig}
-
-	cfg, infos, err := LoadConfigWithBlockchainInfos[testChainInfo](spec)
+	cfg, infos, err := LoadConfigWithBlockchainInfos[testChainInfo](tomlConfig)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Empty(t, infos, "blockchain_infos should be nil or empty when key is absent")


### PR DESCRIPTION
Convert `VerifierJobSpec` and `ExecutorJobSpec` to a generic `bootstrap.JobSpec` that can be used on all app types.

This will simplify the AccessorRegistry by avoiding generics with config types and allowing shared config handling.