### PR TITLE
Remove generics from service factory.

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap/zapcore"
 
@@ -41,39 +42,38 @@ type ServiceDeps struct {
 }
 
 // ServiceFactory is an interface implemented by the application that seeks to be bootstrapped.
-type ServiceFactory[AppConfig any] interface {
+type ServiceFactory interface {
 	// Start starts the service with the parsed config received from JD.
-	Start(ctx context.Context, appConfig AppConfig, deps ServiceDeps) error
+	Start(ctx context.Context, spec JobSpec, deps ServiceDeps) error
 	// Stop stops the service.
 	Stop(ctx context.Context) error
 }
 
 // A runner adapts a [ServiceFactory] to the [lifecycle.JobRunner] interface.
-type runner[AppConfig any] struct {
-	fac  ServiceFactory[AppConfig]
+type runner struct {
+	fac  ServiceFactory
 	deps ServiceDeps
 }
 
-var _ lifecycle.JobRunner = (*runner[any])(nil)
+var _ lifecycle.JobRunner = (*runner)(nil)
 
 // StartJob implements [lifecycle.JobRunner].
-func (r *runner[AppConfig]) StartJob(ctx context.Context, spec string) error {
-	var appConfig AppConfig
-	err := parseTOMLStrict(spec, &appConfig)
+func (r *runner) StartJob(ctx context.Context, config string) error {
+	var spec JobSpec
+	_, err := toml.Decode(config, &spec)
 	if err != nil {
-		return fmt.Errorf("failed to parse app config toml: %w", err)
+		return fmt.Errorf("bootstrap: failed to parse config: %w", err)
 	}
-
-	return r.fac.Start(ctx, appConfig, r.deps)
+	return r.fac.Start(ctx, spec, r.deps)
 }
 
 // StopJob implements [lifecycle.JobRunner].
-func (r *runner[AppConfig]) StopJob(ctx context.Context) error {
+func (r *runner) StopJob(ctx context.Context) error {
 	return r.fac.Stop(ctx)
 }
 
 // A Bootstrapper manages the lifecycle of a CCIP standalone application.
-type Bootstrapper[AppConfig any] struct {
+type Bootstrapper struct {
 	lggr logger.Logger
 
 	// bootstrapper component configs
@@ -83,21 +83,21 @@ type Bootstrapper[AppConfig any] struct {
 	infoServer       *infoServer
 
 	// application
-	appCfg *AppConfig
-	fac    ServiceFactory[AppConfig]
+	appCfg *string
+	fac    ServiceFactory
 	name   string
 
 	logLevel zapcore.Level
 }
 
 // NewBootstrapper creates a new [Bootstrapper] with the given config and service factory.
-func NewBootstrapper[AppConfig any](
+func NewBootstrapper(
 	name string,
 	lggr logger.Logger,
-	fac ServiceFactory[AppConfig],
-	opts ...Option[AppConfig],
-) (*Bootstrapper[AppConfig], error) {
-	b := &Bootstrapper[AppConfig]{
+	fac ServiceFactory,
+	opts ...Option,
+) (*Bootstrapper, error) {
+	b := &Bootstrapper{
 		lggr:     lggr,
 		fac:      fac,
 		name:     name,
@@ -138,12 +138,22 @@ func NewBootstrapper[AppConfig any](
 }
 
 // startWithAppConfig is a passthrough to the application's Start function.
-func (b *Bootstrapper[AppConfig]) startWithAppConfig(ctx context.Context) error {
-	return b.fac.Start(ctx, *b.appCfg, ServiceDeps{})
+func (b *Bootstrapper) startWithAppConfig(ctx context.Context) error {
+	if b.appCfg == nil {
+		return fmt.Errorf("bootstrapper has no app config")
+	}
+	js := JobSpec{
+		Name:          "no-jd",
+		ExternalJobID: "",
+		SchemaVersion: 0,
+		Type:          "",
+		AppConfig:     *b.appCfg,
+	}
+	return b.fac.Start(ctx, js, ServiceDeps{})
 }
 
 // startWithJDLifecycle initializes all components required for the JD lifecycle manager and starts it.
-func (b *Bootstrapper[AppConfig]) startWithJDLifecycle(ctx context.Context) error {
+func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 	db, err := connectToDB(ctx, b.config.DB.URL)
 	if err != nil {
 		return fmt.Errorf("failed to connect to bootstrapper database: %w", err)
@@ -165,7 +175,7 @@ func (b *Bootstrapper[AppConfig]) startWithJDLifecycle(ctx context.Context) erro
 		return fmt.Errorf("failed to create service deps: %w", err)
 	}
 
-	jobRunner := &runner[AppConfig]{fac: b.fac, deps: deps}
+	jobRunner := &runner{fac: b.fac, deps: deps}
 	lifecycleManager, err := lifecycle.NewManager(lifecycle.Config{
 		JDClient: jdClient,
 		JobStore: jobstore.NewPostgresStore(db),
@@ -191,7 +201,7 @@ func (b *Bootstrapper[AppConfig]) startWithJDLifecycle(ctx context.Context) erro
 }
 
 // Start initializes the keystore, connects to JD, and starts the lifecycle manager.
-func (b *Bootstrapper[AppConfig]) Start(ctx context.Context) error {
+func (b *Bootstrapper) Start(ctx context.Context) error {
 	if b.config != nil {
 		return b.startWithJDLifecycle(ctx)
 	}
@@ -203,7 +213,7 @@ func (b *Bootstrapper[AppConfig]) Start(ctx context.Context) error {
 }
 
 // Stop shuts down the lifecycle manager and info server.
-func (b *Bootstrapper[AppConfig]) Stop(ctx context.Context) error {
+func (b *Bootstrapper) Stop(ctx context.Context) error {
 	if err := b.lifecycleManager.Stop(); err != nil {
 		return fmt.Errorf("failed to stop lifecycle manager: %w", err)
 	}
@@ -266,11 +276,11 @@ func initializeKeystore(ctx context.Context, lggr logger.Logger, db *sqlx.DB, ks
 }
 
 // Option configures a [Bootstrapper].
-type Option[AppConfig any] func(*Bootstrapper[AppConfig]) error
+type Option func(*Bootstrapper) error
 
 // WithLogLevel sets the log level for the logger passed to the application.
-func WithLogLevel[AppConfig any](logLevel zapcore.Level) Option[AppConfig] {
-	return func(b *Bootstrapper[AppConfig]) error {
+func WithLogLevel(logLevel zapcore.Level) Option {
+	return func(b *Bootstrapper) error {
 		b.logLevel = logLevel
 		return nil
 	}
@@ -278,8 +288,8 @@ func WithLogLevel[AppConfig any](logLevel zapcore.Level) Option[AppConfig] {
 
 // WithJD tells the bootstrapper to load config from JD and start the JD lifecycle manager.
 // This is the default option if no AppConfig is provided.
-func WithJD[AppConfig any]() Option[AppConfig] {
-	return func(b *Bootstrapper[AppConfig]) error {
+func WithJD() Option {
+	return func(b *Bootstrapper) error {
 		b.config = &Config{}
 		return nil
 	}
@@ -288,37 +298,33 @@ func WithJD[AppConfig any]() Option[AppConfig] {
 // WithBootstrapperConfigPath sets the bootstrapper config file path. If not set, the bootstrapper will look
 // for the config path in the BOOTSTRAPPER_CONFIG_PATH environment variable, and if that is not
 // set, it will default to DefaultConfigPath.
-func WithBootstrapperConfigPath[AppConfig any](path string) Option[AppConfig] {
-	return func(b *Bootstrapper[AppConfig]) error {
+func WithBootstrapperConfigPath(path string) Option {
+	return func(b *Bootstrapper) error {
 		b.configPath = path
 		return nil
 	}
 }
 
 // WithTOMLAppConfig tells bootstrap to load the application config from a given filepath instead of JD.
-func WithTOMLAppConfig[AppConfig any](configFilePath string) Option[AppConfig] {
-	return func(b *Bootstrapper[AppConfig]) error {
+func WithTOMLAppConfig(configFilePath string) Option {
+	return func(b *Bootstrapper) error {
 		configFilePath = filepath.Clean(configFilePath)
 		cfg, err := os.ReadFile(configFilePath)
 		if err != nil {
 			return err
 		}
-		var appConfig AppConfig
-		err = parseTOMLStrict(string(cfg), &appConfig)
-		if err != nil {
-			return err
-		}
-		b.appCfg = &appConfig
+		cfgs := string(cfg)
+		b.appCfg = &cfgs
 		return nil
 	}
 }
 
 // Run is a convenience function that loads config, creates a bootstrapper,
 // starts it, and blocks until SIGINT or SIGTERM is received.
-func Run[AppConfig any](
+func Run(
 	name string,
-	fac ServiceFactory[AppConfig],
-	opts ...Option[AppConfig],
+	fac ServiceFactory,
+	opts ...Option,
 ) error {
 	lggr, err := logger.NewWith(logging.DevelopmentConfig(zapcore.InfoLevel))
 	if err != nil {

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -110,7 +111,12 @@ type spyServiceFactoryDummy struct {
 	stopFn  func(context.Context) error
 }
 
-func (s *spyServiceFactoryDummy) Start(ctx context.Context, appConfig dummyAppConfig, deps ServiceDeps) error {
+func (s *spyServiceFactoryDummy) Start(ctx context.Context, spec JobSpec, deps ServiceDeps) error {
+	var appConfig dummyAppConfig
+	_, err := toml.Decode(spec.AppConfig, &appConfig)
+	if err != nil {
+		return err
+	}
 	if s.startFn != nil {
 		return s.startFn(ctx, appConfig, deps)
 	}
@@ -124,7 +130,7 @@ func (s *spyServiceFactoryDummy) Stop(ctx context.Context) error {
 	return nil
 }
 
-var _ ServiceFactory[dummyAppConfig] = (*spyServiceFactoryDummy)(nil)
+var _ ServiceFactory = (*spyServiceFactoryDummy)(nil)
 
 // --- runner tests ---
 
@@ -141,26 +147,13 @@ func TestRunner(t *testing.T) {
 				return nil
 			},
 		}
-		r := &runner[dummyAppConfig]{fac: fac, deps: ServiceDeps{}}
+		r := &runner{fac: fac, deps: ServiceDeps{}}
 
-		spec := `name = "test-name"
+		cfg := `name = "test-name"
 count = 42`
-		require.NoError(t, r.StartJob(ctx, spec))
-	})
-
-	t.Run("rejects TOML with undecoded fields", func(t *testing.T) {
-		t.Parallel()
-		fac := &spyServiceFactoryDummy{}
-		r := &runner[dummyAppConfig]{fac: fac, deps: ServiceDeps{}}
-
-		// extra field "unknown" is not in dummyAppConfig, so strict decode fails
-		spec := `name = "x"
-count = 1
-unknown = true`
-		err := r.StartJob(ctx, spec)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to parse app config toml")
-		require.Contains(t, err.Error(), "undecoded fields")
+		spec, err := toml.Marshal(JobSpec{AppConfig: cfg})
+		require.NoError(t, err)
+		require.NoError(t, r.StartJob(ctx, string(spec)))
 	})
 
 	t.Run("delegates start", func(t *testing.T) {
@@ -172,7 +165,7 @@ unknown = true`
 				return nil
 			},
 		}
-		r := &runner[any]{fac: fac, deps: ServiceDeps{}}
+		r := &runner{fac: fac, deps: ServiceDeps{}}
 
 		// runner parses spec as TOML into AppConfig, then calls fac.Start(ctx, appConfig, deps)
 		// use empty TOML so parseTomlStrict[any] succeeds (no undecoded fields)
@@ -189,7 +182,7 @@ unknown = true`
 				return nil
 			},
 		}
-		r := &runner[any]{fac: fac, deps: ServiceDeps{}}
+		r := &runner{fac: fac, deps: ServiceDeps{}}
 
 		require.NoError(t, r.StopJob(ctx))
 		require.True(t, stopped)
@@ -202,7 +195,7 @@ unknown = true`
 				return errors.New("boom")
 			},
 		}
-		r := &runner[any]{fac: fac, deps: ServiceDeps{}}
+		r := &runner{fac: fac, deps: ServiceDeps{}}
 		require.EqualError(t, r.StartJob(ctx, ""), "boom")
 	})
 
@@ -213,7 +206,7 @@ unknown = true`
 				return errors.New("stop failed")
 			},
 		}
-		r := &runner[any]{fac: fac, deps: ServiceDeps{}}
+		r := &runner{fac: fac, deps: ServiceDeps{}}
 		require.EqualError(t, r.StopJob(ctx), "stop failed")
 	})
 }
@@ -222,7 +215,7 @@ unknown = true`
 
 type mockServiceFactory struct{}
 
-func (m *mockServiceFactory) Start(ctx context.Context, appConfig any, deps ServiceDeps) error {
+func (m *mockServiceFactory) Start(ctx context.Context, spec JobSpec, deps ServiceDeps) error {
 	return nil
 }
 
@@ -230,16 +223,16 @@ func (m *mockServiceFactory) Stop(ctx context.Context) error {
 	return nil
 }
 
-var _ ServiceFactory[any] = (*mockServiceFactory)(nil)
+var _ ServiceFactory = (*mockServiceFactory)(nil)
 
 type spyServiceFactory struct {
 	startFn func(context.Context, any, ServiceDeps) error
 	stopFn  func(context.Context) error
 }
 
-func (s *spyServiceFactory) Start(ctx context.Context, appConfig any, deps ServiceDeps) error {
+func (s *spyServiceFactory) Start(ctx context.Context, spec JobSpec, deps ServiceDeps) error {
 	if s.startFn != nil {
-		return s.startFn(ctx, appConfig, deps)
+		return s.startFn(ctx, spec, deps)
 	}
 	return nil
 }

--- a/cmd/executor/servicefactory.go
+++ b/cmd/executor/servicefactory.go
@@ -60,7 +60,7 @@ type factory[T any] struct {
 
 // NewServiceFactory creates a new ServiceFactory for the executor service.
 // T is the chain config type for this family (e.g. blockchain.Info for EVM).
-func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExecutorComponentsFunc[T]) bootstrap.ServiceFactory[bootstrap.JobSpec] {
+func NewServiceFactory[T any](chainFamily string, createComponentsFunc CreateExecutorComponentsFunc[T]) bootstrap.ServiceFactory {
 	return &factory[T]{
 		createComponentsFunc: createComponentsFunc,
 		chainFamily:          chainFamily,

--- a/verifier/cmd/committee/main.go
+++ b/verifier/cmd/committee/main.go
@@ -38,7 +38,7 @@ func main() {
 		cmd.NewCommitteeVerifierServiceFactory[evm.Info](
 			chainsel.FamilyEVM,
 			deprecatedCreateAccessorFactory),
-		bootstrap.WithLogLevel[bootstrap.JobSpec](zapcore.InfoLevel),
+		bootstrap.WithLogLevel(zapcore.InfoLevel),
 	); err != nil {
 		panic(fmt.Sprintf("failed to run EVM committee verifier: %s", err.Error()))
 	}

--- a/verifier/cmd/servicefactory.go
+++ b/verifier/cmd/servicefactory.go
@@ -76,7 +76,7 @@ type factory[T any] struct {
 func NewServiceFactory[T any](
 	chainFamily string,
 	createAccessorFactoryFunc CreateAccessorFactoryFunc[T],
-) bootstrap.ServiceFactory[bootstrap.JobSpec] {
+) bootstrap.ServiceFactory {
 	return NewCommitteeVerifierServiceFactory(chainFamily, createAccessorFactoryFunc)
 }
 
@@ -85,7 +85,7 @@ func NewServiceFactory[T any](
 func NewCommitteeVerifierServiceFactory[T any](
 	chainFamily string,
 	createAccessorFactoryFunc CreateAccessorFactoryFunc[T],
-) bootstrap.ServiceFactory[bootstrap.JobSpec] {
+) bootstrap.ServiceFactory {
 	return &factory[T]{
 		createAccessorFactoryFunc: createAccessorFactoryFunc,
 		chainFamily:               chainFamily,

--- a/verifier/cmd/token/main.go
+++ b/verifier/cmd/token/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"go.uber.org/zap/zapcore"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -50,7 +51,7 @@ func main() {
 			createAccessorFactoryFunc: evm.CreateAccessorFactory,
 		},
 		// TODO: remove the AppConfig generic type to streamline this API, update factory to accept config as a string.
-		bootstrap.WithTOMLAppConfig[token.ConfigWithBlockchainInfos[evm.Info]](configPath),
+		bootstrap.WithTOMLAppConfig(configPath),
 	)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to run token verifier: %v\n", err)
@@ -59,7 +60,7 @@ func main() {
 }
 
 type tokenVerifierFactory[T any] struct {
-	bootstrap.ServiceFactory[token.Config]
+	bootstrap.ServiceFactory
 
 	// TODO: rather than creating the factory in the bootstrap layer, can we pass in a registry?
 	createAccessorFactoryFunc chainaccess.CreateAccessorFactory[T]
@@ -96,7 +97,13 @@ func (tvf *tokenVerifierFactory[T]) Stop(ctx context.Context) error {
 }
 
 // Start starts the service with the parsed config received from the bootstrapper.
-func (tvf *tokenVerifierFactory[T]) Start(ctx context.Context, appConfig token.ConfigWithBlockchainInfos[T], deps bootstrap.ServiceDeps) error {
+func (tvf *tokenVerifierFactory[T]) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootstrap.ServiceDeps) error {
+	var appConfig token.ConfigWithBlockchainInfos[T]
+	_, err := toml.Decode(spec.AppConfig, &appConfig)
+	if err != nil {
+		return fmt.Errorf("unable to decode app config: %w", err)
+	}
+
 	var errs []error
 	if tvf.createAccessorFactoryFunc == nil {
 		errs = append(errs, fmt.Errorf("createAccessorFactoryFunc is required but was nil"))
@@ -140,7 +147,7 @@ func (tvf *tokenVerifierFactory[T]) Start(ctx context.Context, appConfig token.C
 		CommitteeConfig: cfg.CommitteeConfig,
 	}
 
-	_, err := cmd.StartPyroscope(tvf.lggr, cfg.PyroscopeURL, "tokenVerifier")
+	_, err = cmd.StartPyroscope(tvf.lggr, cfg.PyroscopeURL, "tokenVerifier")
 	if err != nil {
 		tvf.lggr.Errorw("Failed to start pyroscope", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
With #1007 the service factories now use `bootstrap.JobSpec` unconditionally, so generics are no longer needed.