### PR TITLE
CCIP-9669 finality checker metrics interface

### DIFF
--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -666,6 +666,7 @@ func (m *CCIP17EVM) SendMessageWithNonce(ctx context.Context, dest uint64, field
 		msg,
 	)
 	if err != nil {
+		l.Error().Err(err).Str("rtr", rout.Address().String()).Msg("failed to send message")
 		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("failed to get fee: %w", err)
 	}
 

--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -666,7 +666,6 @@ func (m *CCIP17EVM) SendMessageWithNonce(ctx context.Context, dest uint64, field
 		msg,
 	)
 	if err != nil {
-		l.Error().Err(err).Str("rtr", rout.Address().String()).Msg("failed to send message")
 		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("failed to get fee: %w", err)
 	}
 

--- a/executor/interfaces.go
+++ b/executor/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	ccvcommon "github.com/smartcontractkit/chainlink-ccv/common"
 	commonmetrics "github.com/smartcontractkit/chainlink-ccv/common/metrics"
 	v1 "github.com/smartcontractkit/chainlink-ccv/indexer/pkg/api/handlers/v1"
 	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/common"
@@ -72,6 +73,8 @@ type Monitoring interface {
 
 // MetricLabeler provides all metric recording functionality for the indexer.
 type MetricLabeler interface {
+	ccvcommon.CurseCheckerMetrics
+
 	// With returns a new metrics labeler with the given key-value pairs.
 	With(keyValues ...string) MetricLabeler
 	// RecordMessageExecutionLatency records the duration of the full ExecuteMessage operation.
@@ -106,8 +109,4 @@ type MetricLabeler interface {
 	// has entered an unrecoverable failure state (e.g. the execution attempt
 	// poller permanently failed). This should trigger an alert.
 	IncrementDestinationReaderCriticalFailure(ctx context.Context, destChainSelector protocol.ChainSelector)
-	// SetRemoteChainCursed sets value 1 if source chain is cursed
-	SetRemoteChainCursed(ctx context.Context, localSelector, remoteSelector protocol.ChainSelector, cursed bool)
-	// SetLocalChainGlobalCursed sets value 1 if source chain is cursed
-	SetLocalChainGlobalCursed(ctx context.Context, localSelector protocol.ChainSelector, globalCurse bool)
 }

--- a/verifier/pkg/interfaces.go
+++ b/verifier/pkg/interfaces.go
@@ -5,10 +5,11 @@ import vtypes "github.com/smartcontractkit/chainlink-ccv/verifier/pkg/vtypes"
 // Type aliases - the actual definitions live in verifier/pkg/vtypes.
 // These aliases preserve backward compatibility for all existing consumers of verifier/pkg.
 type (
-	MessageSigner         = vtypes.MessageSigner
-	VerificationResult    = vtypes.VerificationResult
-	Verifier              = vtypes.Verifier
-	MessageLatencyTracker = vtypes.MessageLatencyTracker
-	Monitoring            = vtypes.Monitoring
-	MetricLabeler         = vtypes.MetricLabeler
+	MessageSigner          = vtypes.MessageSigner
+	VerificationResult     = vtypes.VerificationResult
+	Verifier               = vtypes.Verifier
+	MessageLatencyTracker  = vtypes.MessageLatencyTracker
+	Monitoring             = vtypes.Monitoring
+	MetricLabeler          = vtypes.MetricLabeler
+	FinalityCheckerMetrics = vtypes.FinalityCheckerMetrics
 )

--- a/verifier/pkg/sourcereader/finality_checker.go
+++ b/verifier/pkg/sourcereader/finality_checker.go
@@ -42,7 +42,7 @@ type FinalityViolationCheckerService struct {
 	sourceReader  chainaccess.SourceReader
 	chainSelector protocol.ChainSelector
 	lggr          logger.Logger
-	metrics       verifier.MetricLabeler
+	metrics       verifier.FinalityCheckerMetrics
 
 	// Stored finalized blocks (keyed by block number)
 	finalizedBlocks map[uint64]protocol.BlockHeader
@@ -59,7 +59,7 @@ func NewFinalityViolationCheckerService(
 	sourceReader chainaccess.SourceReader,
 	chainSelector protocol.ChainSelector,
 	lggr logger.Logger,
-	metrics verifier.MetricLabeler,
+	metrics verifier.FinalityCheckerMetrics,
 ) (*FinalityViolationCheckerService, error) {
 	if sourceReader == nil {
 		return nil, fmt.Errorf("sourceReader cannot be nil")

--- a/verifier/pkg/vtypes/interfaces.go
+++ b/verifier/pkg/vtypes/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/smartcontractkit/chainlink-ccv/common"
 	commonmetrics "github.com/smartcontractkit/chainlink-ccv/common/metrics"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
 )
@@ -48,8 +49,16 @@ type Monitoring interface {
 	commonmetrics.ServiceMetrics
 }
 
+type FinalityCheckerMetrics interface {
+	// SetVerifierFinalityViolated sets value 1 if finality violated
+	SetVerifierFinalityViolated(ctx context.Context, selector protocol.ChainSelector, violated bool)
+}
+
 // MetricLabeler provides all metric recording functionality for the verifier.
 type MetricLabeler interface {
+	FinalityCheckerMetrics
+	common.CurseCheckerMetrics
+
 	// With returns a new metrics labeler with the given key-value pairs.
 	With(keyValues ...string) MetricLabeler
 
@@ -115,12 +124,6 @@ type MetricLabeler interface {
 	RecordSourceChainSafeBlock(ctx context.Context, blockNum int64)
 	// RecordReorgTrackedSeqNums records the number of sequence numbers being tracked due to reorg.
 	RecordReorgTrackedSeqNums(ctx context.Context, count int64)
-	// SetVerifierFinalityViolated sets value 1 if finality violated
-	SetVerifierFinalityViolated(ctx context.Context, selector protocol.ChainSelector, violated bool)
-	// SetRemoteChainCursed sets value 1 if source chain is cursed
-	SetRemoteChainCursed(ctx context.Context, localSelector, remoteSelector protocol.ChainSelector, cursed bool)
-	// SetLocalChainGlobalCursed sets value 1 if source chain is cursed
-	SetLocalChainGlobalCursed(ctx context.Context, localSelector protocol.ChainSelector, globalCurse bool)
 
 	// HTTP API metrics
 


### PR DESCRIPTION
Refactor metric interfaces in executor and verifier to tighten ownership and separate checker-specific metrics.

#### Executor
* `MetricLabeler` now embeds `ccvcommon.CurseCheckerMetrics`.
* Removed the curse-related methods that were previously inlined on `MetricLabeler`.

#### Verifier
* Added a new `FinalityCheckerMetrics` interface for finality violation metrics.
* `MetricLabeler` now embeds both `FinalityCheckerMetrics` and `common.CurseCheckerMetrics`.
* Moved the relevant methods out of `MetricLabeler` and into the dedicated interfaces.

#### Finality checker service
* `FinalityViolationCheckerService` now depends on `FinalityCheckerMetrics` instead of the broader `MetricLabeler`.
* Updated the constructor to match the new interface boundary.

#### Shared verifier interfaces
* Exported `FinalityCheckerMetrics` from `verifier/pkg`