### PR TITLE
bootstrap: GenericConfig helper to get multiple concrete chain configs.

### DIFF
--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -17,6 +17,7 @@ type JobSpec struct {
 	AppConfig     string `toml:"appConfig"`
 }
 
+// GetGenericConfig decodes the AppConfig field into chainaccess.GenericConfig.
 func (js JobSpec) GetGenericConfig() (chainaccess.GenericConfig, error) {
 	var gcfg chainaccess.GenericConfig
 	if _, err := toml.Decode(js.AppConfig, &gcfg); err != nil {
@@ -25,6 +26,9 @@ func (js JobSpec) GetGenericConfig() (chainaccess.GenericConfig, error) {
 	return gcfg, nil
 }
 
+// GetAppConfig decodes the app config into the provided object. An error is returned
+// if there are any fields aside from blockchain_infos that are left undecoded. See
+// chainaccess.GenericConfig for details about why blockchain_infos is ignored.
 func (js JobSpec) GetAppConfig(cfg any) error {
 	md, err := toml.Decode(js.AppConfig, cfg)
 	if err != nil {

--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -31,7 +31,7 @@ func (js JobSpec) GetAppConfig(cfg any) error {
 		return fmt.Errorf("error decoding app config: %w", err)
 	}
 
-	// Filter out undecoded fields under blockchain_infos.
+	// Filter out undecoded fields under blockchain_info.
 	var undecoded []string
 	for _, key := range md.Undecoded() {
 		if key[0] != "blockchain_infos" {

--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -31,7 +31,7 @@ func (js JobSpec) GetAppConfig(cfg any) error {
 		return fmt.Errorf("error decoding app config: %w", err)
 	}
 
-	// Filter out undecoded fields under blockchain_info.
+	// Filter out undecoded fields under blockchain_infos.
 	var undecoded []string
 	for _, key := range md.Undecoded() {
 		if key[0] != "blockchain_infos" {

--- a/executor/config.go
+++ b/executor/config.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"time"
-
-	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 )
 
 const (
@@ -19,11 +17,6 @@ const (
 	IndexerQueryLimitDefault = 100
 	IndexerQueryLimitMax     = 10000
 )
-
-type ConfigWithBlockchainInfo[T any] struct {
-	Configuration
-	BlockchainInfos chainaccess.Infos[T] `toml:"blockchain_infos"`
-}
 
 // Configuration is the complete set of information an executor needs to operate normally.
 // We can use time.Duration directly in this config because burntSushi can parse duration from strings.

--- a/executor/config.go
+++ b/executor/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/url"
 	"time"
+
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 )
 
 const (
@@ -17,6 +19,11 @@ const (
 	IndexerQueryLimitDefault = 100
 	IndexerQueryLimitMax     = 10000
 )
+
+type ConfigWithBlockchainInfo[T any] struct {
+	Configuration
+	BlockchainInfos chainaccess.Infos[T] `toml:"blockchain_infos"`
+}
 
 // Configuration is the complete set of information an executor needs to operate normally.
 // We can use time.Duration directly in this config because burntSushi can parse duration from strings.

--- a/integration/pkg/accessors/evm/factory_constructor.go
+++ b/integration/pkg/accessors/evm/factory_constructor.go
@@ -37,26 +37,9 @@ var _ chainaccess.AccessorFactoryConstructor = CreateEVMAccessorFactory
 func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) {
 	// Convert Infos[string] -> Infos[evm.Info]
 	evmInfos := make(map[string]Info)
-
-	// TODO: This could be a helper on the generic config object.
-	for _, selector := range genericConfig.ChainConfig.GetAllChainSelectors() {
-		// Verify chain family.
-		isEvm, err := chainsel.IsEvm(uint64(selector))
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine if selector(%d) is evm: %w", selector, err)
-		}
-		if !isEvm {
-			lggr.Debugw("skipping non-EVM chain selector in EVM accessor factory construction", "chainSelector", selector)
-			continue
-		}
-
-		var info Info
-		if err = genericConfig.GetConcreteConfig(selector, &info); err != nil {
-			return nil, fmt.Errorf("failed to decode EVM info for selector(%d): %w", selector, err)
-		}
-
-		lggr.Infow("loaded EVM chain info for selector", "chainSelector", selector, "chainID", info.ChainID, "uniqueChainName", info.UniqueChainName)
-		evmInfos[selector.String()] = info
+	err := genericConfig.GetAllConcreteConfig(chainsel.FamilyEVM, &evmInfos)
+	if err != nil {
+		return nil, fmt.Errorf("error getting evm info: %s", err)
 	}
 
 	return CreateAccessorFactory(context.Background(), lggr, genericConfig, evmInfos)

--- a/integration/pkg/accessors/evm/factory_constructor.go
+++ b/integration/pkg/accessors/evm/factory_constructor.go
@@ -36,7 +36,7 @@ var _ chainaccess.AccessorFactoryConstructor = CreateEVMAccessorFactory
 // very unusual for a config to have more than one of Committee/Token/Executor configs.
 func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) {
 	// Convert Infos[string] -> Infos[evm.Info]
-	evmInfos := make(map[string]Info)
+	evmInfos := make(chainaccess.Infos[Info])
 	err := genericConfig.GetAllConcreteConfig(chainsel.FamilyEVM, &evmInfos)
 	if err != nil {
 		return nil, fmt.Errorf("error getting evm info: %s", err)

--- a/integration/pkg/accessors/evm/factory_constructor.go
+++ b/integration/pkg/accessors/evm/factory_constructor.go
@@ -35,11 +35,11 @@ var _ chainaccess.AccessorFactoryConstructor = CreateEVMAccessorFactory
 // It will take all config values it needs from all available config. Note that it would be
 // very unusual for a config to have more than one of Committee/Token/Executor configs.
 func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) {
-	// Convert Infos[string] -> Infos[evm.Info]
+	// Convert generic chain config -> Infos[evm.Info]
 	evmInfos := make(chainaccess.Infos[Info])
 	err := genericConfig.GetAllConcreteConfig(chainsel.FamilyEVM, &evmInfos)
 	if err != nil {
-		return nil, fmt.Errorf("error getting evm info: %s", err)
+		return nil, fmt.Errorf("error getting evm info: %w", err)
 	}
 
 	return CreateAccessorFactory(context.Background(), lggr, genericConfig, evmInfos)

--- a/pkg/chainaccess/generic_config_test.go
+++ b/pkg/chainaccess/generic_config_test.go
@@ -255,4 +255,3 @@ ClusterName = "mainnet-beta"
 		assert.Contains(t, err.Error(), "failed to marshal info")
 	})
 }
-

--- a/pkg/chainaccess/generic_config_test.go
+++ b/pkg/chainaccess/generic_config_test.go
@@ -212,6 +212,15 @@ ClusterName = "mainnet-beta"
 		assert.Contains(t, err.Error(), "pointer to a map")
 	})
 
+	t.Run("returns error when map key type is not string", func(t *testing.T) {
+		// Infos[T] requires string keys; a non-string key map must be rejected
+		// before SetMapIndex is called, otherwise it panics at runtime.
+		bad := make(map[protocol.ChainSelector]evmChainConfig)
+		err := gc.GetAllConcreteConfig("evm", &bad)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "map key must be string")
+	})
+
 	t.Run("returns error when target is not a pointer", func(t *testing.T) {
 		bad := make(chainaccess.Infos[evmChainConfig])
 		err := gc.GetAllConcreteConfig("evm", bad)

--- a/pkg/chainaccess/generic_config_test.go
+++ b/pkg/chainaccess/generic_config_test.go
@@ -175,31 +175,31 @@ ClusterName = "mainnet-beta"
 	require.NoError(t, err)
 
 	t.Run("decodes EVM entries with EVM-specific shape", func(t *testing.T) {
-		result := make(map[protocol.ChainSelector]evmChainConfig)
+		var result chainaccess.Infos[evmChainConfig]
 		err := gc.GetAllConcreteConfig("evm", &result)
 		require.NoError(t, err)
 
 		require.Len(t, result, 1)
-		info, ok := result[evmSelector]
+		info, ok := result[evmSelector.String()]
 		require.True(t, ok, "expected evm selector to be present")
 		assert.Equal(t, "https://mainnet.infura.io", info.RPCURL)
 		assert.Equal(t, int64(1), info.ChainID)
 	})
 
 	t.Run("decodes Solana entries with Solana-specific shape", func(t *testing.T) {
-		result := make(map[protocol.ChainSelector]solanaChainConfig)
+		var result chainaccess.Infos[solanaChainConfig]
 		err := gc.GetAllConcreteConfig("solana", &result)
 		require.NoError(t, err)
 
 		require.Len(t, result, 1)
-		info, ok := result[solanaSelector]
+		info, ok := result[solanaSelector.String()]
 		require.True(t, ok, "expected solana selector to be present")
 		assert.Equal(t, "wss://api.mainnet-beta.solana.com", info.WSEndpoint)
 		assert.Equal(t, "mainnet-beta", info.ClusterName)
 	})
 
 	t.Run("returns empty map when no chains match the family", func(t *testing.T) {
-		result := make(map[protocol.ChainSelector]evmChainConfig)
+		var result chainaccess.Infos[evmChainConfig]
 		err := gc.GetAllConcreteConfig("aptos", &result)
 		require.NoError(t, err)
 		assert.Empty(t, result)
@@ -213,14 +213,14 @@ ClusterName = "mainnet-beta"
 	})
 
 	t.Run("returns error when target is not a pointer", func(t *testing.T) {
-		bad := make(map[protocol.ChainSelector]evmChainConfig)
+		bad := make(chainaccess.Infos[evmChainConfig])
 		err := gc.GetAllConcreteConfig("evm", bad)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "pointer to a map")
 	})
 
 	t.Run("initialises a nil map automatically", func(t *testing.T) {
-		var result map[protocol.ChainSelector]evmChainConfig
+		var result chainaccess.Infos[evmChainConfig]
 		err := gc.GetAllConcreteConfig("evm", &result)
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -235,7 +235,7 @@ ClusterName = "mainnet-beta"
 				"999999999999": map[string]any{"RPCUrl": "https://unknown"},
 			},
 		}
-		result := make(map[protocol.ChainSelector]evmChainConfig)
+		var result chainaccess.Infos[evmChainConfig]
 		err := gc.GetAllConcreteConfig("evm", &result)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get the chain selector family")
@@ -249,9 +249,10 @@ ClusterName = "mainnet-beta"
 				evmSelector.String(): make(chan int),
 			},
 		}
-		result := make(map[protocol.ChainSelector]evmChainConfig)
+		var result chainaccess.Infos[evmChainConfig]
 		err := gc.GetAllConcreteConfig("evm", &result)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to marshal info")
 	})
 }
+

--- a/pkg/chainaccess/generic_config_test.go
+++ b/pkg/chainaccess/generic_config_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
 )
@@ -104,6 +106,24 @@ ChainID = "1"
 		assert.Contains(t, err.Error(), "failed to marshal info")
 	})
 
+	t.Run("returns error when config contains fields unknown to the target type", func(t *testing.T) {
+		gc := chainaccess.GenericConfig{
+			ChainConfig: chainaccess.Infos[any]{
+				"123": map[string]any{
+					"KnownField":   "hello",
+					"UnknownField": "surprise",
+				},
+			},
+		}
+		type strictTarget struct {
+			KnownField string `toml:"KnownField"`
+		}
+		var target strictTarget
+		err := gc.GetConcreteConfig(protocol.ChainSelector(123), &target)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown fields")
+	})
+
 	t.Run("decode error when target type is incompatible with marshaled TOML", func(t *testing.T) {
 		// Store an array value so the marshaled TOML contains an array field.
 		// Decoding that array into an int target field causes a type-mismatch error.
@@ -121,5 +141,117 @@ ChainID = "1"
 		err := gc.GetConcreteConfig(protocol.ChainSelector(123), &target)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to unmarshal info")
+	})
+}
+
+// evmChainConfig holds EVM-specific fields — e.g. an HTTP RPC endpoint.
+type evmChainConfig struct {
+	RPCURL  string `toml:"RPCUrl"`
+	ChainID int64  `toml:"ChainID"`
+}
+
+// solanaChainConfig holds Solana-specific fields — e.g. a WebSocket endpoint and cluster name.
+type solanaChainConfig struct {
+	WSEndpoint  string `toml:"WSEndpoint"`
+	ClusterName string `toml:"ClusterName"`
+}
+
+func TestGenericConfig_GetAllConcreteConfig(t *testing.T) {
+	evmSelector := protocol.ChainSelector(chainsel.ETHEREUM_MAINNET.Selector)
+	solanaSelector := protocol.ChainSelector(chainsel.SOLANA_MAINNET.Selector)
+
+	// Note: blockchain_infos keys are bare integers — no quotes.
+	rawCfg := `
+[blockchain_infos.` + evmSelector.String() + `]
+RPCUrl = "https://mainnet.infura.io"
+ChainID = 1
+
+[blockchain_infos.` + solanaSelector.String() + `]
+WSEndpoint = "wss://api.mainnet-beta.solana.com"
+ClusterName = "mainnet-beta"
+`
+	var gc chainaccess.GenericConfig
+	_, err := toml.Decode(rawCfg, &gc)
+	require.NoError(t, err)
+
+	t.Run("decodes EVM entries with EVM-specific shape", func(t *testing.T) {
+		result := make(map[protocol.ChainSelector]evmChainConfig)
+		err := gc.GetAllConcreteConfig("evm", &result)
+		require.NoError(t, err)
+
+		require.Len(t, result, 1)
+		info, ok := result[evmSelector]
+		require.True(t, ok, "expected evm selector to be present")
+		assert.Equal(t, "https://mainnet.infura.io", info.RPCURL)
+		assert.Equal(t, int64(1), info.ChainID)
+	})
+
+	t.Run("decodes Solana entries with Solana-specific shape", func(t *testing.T) {
+		result := make(map[protocol.ChainSelector]solanaChainConfig)
+		err := gc.GetAllConcreteConfig("solana", &result)
+		require.NoError(t, err)
+
+		require.Len(t, result, 1)
+		info, ok := result[solanaSelector]
+		require.True(t, ok, "expected solana selector to be present")
+		assert.Equal(t, "wss://api.mainnet-beta.solana.com", info.WSEndpoint)
+		assert.Equal(t, "mainnet-beta", info.ClusterName)
+	})
+
+	t.Run("returns empty map when no chains match the family", func(t *testing.T) {
+		result := make(map[protocol.ChainSelector]evmChainConfig)
+		err := gc.GetAllConcreteConfig("aptos", &result)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns error when target is not a pointer to a map", func(t *testing.T) {
+		var bad []evmChainConfig
+		err := gc.GetAllConcreteConfig("evm", &bad)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pointer to a map")
+	})
+
+	t.Run("returns error when target is not a pointer", func(t *testing.T) {
+		bad := make(map[protocol.ChainSelector]evmChainConfig)
+		err := gc.GetAllConcreteConfig("evm", bad)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pointer to a map")
+	})
+
+	t.Run("initialises a nil map automatically", func(t *testing.T) {
+		var result map[protocol.ChainSelector]evmChainConfig
+		err := gc.GetAllConcreteConfig("evm", &result)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("returns error when a selector key is not a recognised chain", func(t *testing.T) {
+		// Selector 999999999999 is not in the chain-selectors library, so
+		// GetSelectorFamily will fail, covering that error branch.
+		gc := chainaccess.GenericConfig{
+			ChainConfig: chainaccess.Infos[any]{
+				"999999999999": map[string]any{"RPCUrl": "https://unknown"},
+			},
+		}
+		result := make(map[protocol.ChainSelector]evmChainConfig)
+		err := gc.GetAllConcreteConfig("evm", &result)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get the chain selector family")
+	})
+
+	t.Run("returns error when a matched chain config cannot be decoded into the target type", func(t *testing.T) {
+		// A channel value cannot be marshaled to TOML, so GetConcreteConfig will
+		// return an error for the matching EVM chain, exercising that branch.
+		gc := chainaccess.GenericConfig{
+			ChainConfig: chainaccess.Infos[any]{
+				evmSelector.String(): make(chan int),
+			},
+		}
+		result := make(map[protocol.ChainSelector]evmChainConfig)
+		err := gc.GetAllConcreteConfig("evm", &result)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to marshal info")
 	})
 }

--- a/pkg/chainaccess/registry.go
+++ b/pkg/chainaccess/registry.go
@@ -71,9 +71,10 @@ type GenericConfig struct {
 	CommitteeConfig
 }
 
-// GetAllConcreteConfig populates target, which must be a pointer to a map[protocol.ChainSelector]T,
-// with the decoded chain configs for every chain selector present in ChainConfig.
-// The selector parameter is unused and kept for interface compatibility.
+// GetAllConcreteConfig populates target, which must be a pointer to an Infos[T]
+// (i.e. *map[string]T), with the decoded chain configs for every chain selector
+// in ChainConfig that belongs to the given family. The map key is the chain
+// selector formatted as a decimal string, matching the Infos key convention.
 func (gc GenericConfig) GetAllConcreteConfig(family string, target any) error {
 	rv := reflect.ValueOf(target)
 	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Map {
@@ -97,7 +98,7 @@ func (gc GenericConfig) GetAllConcreteConfig(family string, target any) error {
 		if err := gc.GetConcreteConfig(sel, elem.Interface()); err != nil {
 			return err
 		}
-		mapVal.SetMapIndex(reflect.ValueOf(sel), elem.Elem())
+		mapVal.SetMapIndex(reflect.ValueOf(sel.String()), elem.Elem())
 	}
 	return nil
 }

--- a/pkg/chainaccess/registry.go
+++ b/pkg/chainaccess/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"reflect"
 	"sync"
 
 	"github.com/BurntSushi/toml"
@@ -70,6 +71,37 @@ type GenericConfig struct {
 	CommitteeConfig
 }
 
+// GetAllConcreteConfig populates target, which must be a pointer to a map[protocol.ChainSelector]T,
+// with the decoded chain configs for every chain selector present in ChainConfig.
+// The selector parameter is unused and kept for interface compatibility.
+func (gc GenericConfig) GetAllConcreteConfig(family string, target any) error {
+	rv := reflect.ValueOf(target)
+	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Map {
+		return fmt.Errorf("GetAllConcreteConfig: target must be a pointer to a map, got %T", target)
+	}
+	mapVal := rv.Elem()
+	if mapVal.IsNil() {
+		mapVal.Set(reflect.MakeMap(mapVal.Type()))
+	}
+	elemType := mapVal.Type().Elem()
+
+	for _, sel := range gc.ChainConfig.GetAllChainSelectors() {
+		fam, err := chainsel.GetSelectorFamily(uint64(sel))
+		if err != nil {
+			return fmt.Errorf("GetAllConcreteConfig: failed to get the chain selector family: %w", err)
+		}
+		if fam != family {
+			continue
+		}
+		elem := reflect.New(elemType)
+		if err := gc.GetConcreteConfig(sel, elem.Interface()); err != nil {
+			return err
+		}
+		mapVal.SetMapIndex(reflect.ValueOf(sel), elem.Elem())
+	}
+	return nil
+}
+
 func (gc GenericConfig) GetConcreteConfig(selector protocol.ChainSelector, target any) error {
 	info, ok := gc.ChainConfig[selector.String()]
 	if !ok {
@@ -80,10 +112,14 @@ func (gc GenericConfig) GetConcreteConfig(selector protocol.ChainSelector, targe
 		return fmt.Errorf("failed to marshal info for selector '%s': %w", selector.String(), err)
 	}
 
-	_, err = toml.Decode(string(data), target)
+	md, err := toml.Decode(string(data), target)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal info for selector '%s': %w", selector.String(), err)
 	}
+	if len(md.Undecoded()) > 0 {
+		return fmt.Errorf("chain selector '%s' contains unknown fields: %s", selector.String(), md.Undecoded())
+	}
+
 	return nil
 }
 

--- a/pkg/chainaccess/registry.go
+++ b/pkg/chainaccess/registry.go
@@ -80,6 +80,9 @@ func (gc GenericConfig) GetAllConcreteConfig(family string, target any) error {
 	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Map {
 		return fmt.Errorf("GetAllConcreteConfig: target must be a pointer to a map, got %T", target)
 	}
+	if rv.Elem().Type().Key().Kind() != reflect.String {
+		return fmt.Errorf("GetAllConcreteConfig: map key must be string (Infos[T] uses string keys), got %s", rv.Elem().Type().Key())
+	}
 	mapVal := rv.Elem()
 	if mapVal.IsNil() {
 		mapVal.Set(reflect.MakeMap(mapVal.Type()))
@@ -118,7 +121,7 @@ func (gc GenericConfig) GetConcreteConfig(selector protocol.ChainSelector, targe
 		return fmt.Errorf("failed to unmarshal info for selector '%s': %w", selector.String(), err)
 	}
 	if len(md.Undecoded()) > 0 {
-		return fmt.Errorf("chain selector '%s' contains unknown fields: %s", selector.String(), md.Undecoded())
+		return fmt.Errorf("chain selector '%s' contains unknown fields: %v", selector.String(), md.Undecoded())
 	}
 
 	return nil


### PR DESCRIPTION
Extract a reusable block of code from the evm factory and put it on the GenericConfig object for other integrations to use.