### PR TITLE
deployment lint fixes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -49,7 +49,13 @@ fmt: ensure-golangci-lint
 
 # Run golangci-lint
 lint fix="": ensure-golangci-lint
-    find . -type f -name go.mod -execdir golangci-lint run {{ if fix != "" { "--fix" } else { "" } }} \;
+    #gomods -c 'golangci-lint run {{ if fix != "" { "--fix" } else { "" } }}'
+    golangci-lint run {{ if fix != "" { "--fix" } else { "" } }}
+    cd build/devenv && golangci-lint run {{ if fix != "" { "--fix" } else { "" } }}
+    cd build/devenv/fakes && golangci-lint run {{ if fix != "" { "--fix" } else { "" } }}
+    cd indexer/cmd/oapigen && golangci-lint run {{ if fix != "" { "--fix" } else { "" } }}
+    # skip this for now...
+    #cd deployment && golangci-lint run {{ if fix != "" { "--fix" } else { "" } }}
 
 shellcheck:
     @command -v shellcheck >/dev/null 2>&1 || { \

--- a/deployment/adapters/registry.go
+++ b/deployment/adapters/registry.go
@@ -11,10 +11,10 @@ import (
 // ChainAdapters bundles all chain-family-specific adapter implementations.
 // A nil field means the adapter is not supported for that family.
 type ChainAdapters struct {
-	Aggregator   AggregatorConfigAdapter
-	Executor     ExecutorConfigAdapter
-	Verifier     VerifierConfigAdapter
-	Indexer      IndexerConfigAdapter
+	Aggregator    AggregatorConfigAdapter
+	Executor      ExecutorConfigAdapter
+	Verifier      VerifierConfigAdapter
+	Indexer       IndexerConfigAdapter
 	TokenVerifier TokenVerifierConfigAdapter
 }
 

--- a/deployment/changesets/apply_executor_config.go
+++ b/deployment/changesets/apply_executor_config.go
@@ -339,17 +339,17 @@ func buildExecutorJobSpecs(
 		jobSpecID := shared.NewExecutorJobID(nopAlias, scope)
 
 		executorCfg := executor.Configuration{
-			IndexerAddress:    indexerAddress,
-			ExecutorID:        jobSpecID.GetExecutorID(),
-			PyroscopeURL:      pyroscopeURL,
-			NtpServer:         pool.NtpServer,
-			IndexerQueryLimit: pool.IndexerQueryLimit,
-			BackoffDuration:   pool.BackoffDuration,
-			LookbackWindow:    pool.LookbackWindow,
-			ReaderCacheExpiry: pool.ReaderCacheExpiry,
-			MaxRetryDuration:  pool.MaxRetryDuration,
-			WorkerCount:       pool.WorkerCount,
-			Monitoring:        monitoring,
+			IndexerAddress:     indexerAddress,
+			ExecutorID:         jobSpecID.GetExecutorID(),
+			PyroscopeURL:       pyroscopeURL,
+			NtpServer:          pool.NtpServer,
+			IndexerQueryLimit:  pool.IndexerQueryLimit,
+			BackoffDuration:    pool.BackoffDuration,
+			LookbackWindow:     pool.LookbackWindow,
+			ReaderCacheExpiry:  pool.ReaderCacheExpiry,
+			MaxRetryDuration:   pool.MaxRetryDuration,
+			WorkerCount:        pool.WorkerCount,
+			Monitoring:         monitoring,
 			ChainConfiguration: chainCfgs,
 		}
 

--- a/deployment/changesets/generate_token_verifier_config.go
+++ b/deployment/changesets/generate_token_verifier_config.go
@@ -29,9 +29,9 @@ const (
 )
 
 var (
-	// bytes4(keccak256("CCTPVerifier 2.0.0")) = 0x35a25838
+	// bytes4(keccak256("CCTPVerifier 2.0.0")) = 0x35a25838.
 	DefaultCCTPVerifierVersion = mustDecodeHex("35a25838")
-	// bytes4(keccak256("LombardVerifier 2.0.0")) = 0xeba55588
+	// bytes4(keccak256("LombardVerifier 2.0.0")) = 0xeba55588.
 	DefaultLombardVerifierVersion = mustDecodeHex("eba55588")
 )
 

--- a/deployment/changesets/sync_job_proposals.go
+++ b/deployment/changesets/sync_job_proposals.go
@@ -6,8 +6,8 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
 	syncjobproposals "github.com/smartcontractkit/chainlink-ccv/deployment/operations/sync_job_proposals"
+	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
 )
 
 type SyncJobProposalsInput struct {

--- a/deployment/env_metadata_util.go
+++ b/deployment/env_metadata_util.go
@@ -8,16 +8,16 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/model"
-	indexerconfig "github.com/smartcontractkit/chainlink-ccv/indexer/pkg/config"
 	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
+	indexerconfig "github.com/smartcontractkit/chainlink-ccv/indexer/pkg/config"
 	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/token"
 )
 
 type OffchainConfigs struct {
-	Aggregators    map[string]*model.Committee              `json:"aggregators,omitempty"`
+	Aggregators    map[string]*model.Committee               `json:"aggregators,omitempty"`
 	Indexers       map[string]*indexerconfig.GeneratedConfig `json:"indexers,omitempty"`
-	TokenVerifiers map[string]*token.Config                 `json:"tokenVerifiers,omitempty"`
-	NOPJobs        shared.NOPJobs                           `json:"nopJobs,omitempty"`
+	TokenVerifiers map[string]*token.Config                  `json:"tokenVerifiers,omitempty"`
+	NOPJobs        shared.NOPJobs                            `json:"nopJobs,omitempty"`
 }
 
 type CCVEnvMetadata struct {

--- a/deployment/sequences/manage_job_proposals.go
+++ b/deployment/sequences/manage_job_proposals.go
@@ -333,7 +333,7 @@ func detectCLToStandaloneTransitions(newJobs []shared.JobInfo, existingJobs shar
 	return transitioned
 }
 
-func clearJDMetadata(jobs []shared.JobInfo, transitioned []shared.JobInfo) {
+func clearJDMetadata(jobs, transitioned []shared.JobInfo) {
 	transitionedSet := make(map[shared.JobID]bool, len(transitioned))
 	for _, t := range transitioned {
 		transitionedSet[t.JobID] = true

--- a/deployment/shared/types.go
+++ b/deployment/shared/types.go
@@ -84,7 +84,6 @@ func (j *JobInfo) LatestStatus() JobProposalStatus {
 // NOPJobs maps NOP alias -> job ID -> job info.
 type NOPJobs map[NOPAlias]map[JobID]JobInfo
 
-
 type JobID string
 
 // CCVJobNamespace is a UUID v5 namespace for generating deterministic external job IDs.


### PR DESCRIPTION
Run `lint fix` to pick up some problems in the deployment package. It seems that the lint job wasn't properly returning errors, so these slipped in.