### PR TITLE
poc: std HeadTracker and RMNCurseReader conformance

### DIFF
--- a/integration/pkg/accessors/evm/evm_source_reader_test.go
+++ b/integration/pkg/accessors/evm/evm_source_reader_test.go
@@ -1,0 +1,261 @@
+package evm
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm/gobindings/generated/latest/onramp"
+	"github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm/gobindings/generated/latest/rmn_remote"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	evmclient "github.com/smartcontractkit/chainlink-evm/pkg/client"
+
+	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/sourcereader"
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess/headtrackerconformance"
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess/rmncurseconformance"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+// clientOracle implements [headtrackerconformance.Oracle] by reading the same
+// EVM [evmclient.Client] the head path uses, so the conformance suite compares
+// the SourceReader/HeadTracker view to the node's canonical header at each number.
+type clientOracle struct{ c evmclient.Client }
+
+func (o *clientOracle) BlockHeaderByNumber(ctx context.Context, n uint64) (*protocol.BlockHeader, error) {
+	h, err := o.c.HeadByNumber(ctx, new(big.Int).SetUint64(n))
+	if err != nil {
+		return nil, err
+	}
+	if h == nil {
+		return nil, fmt.Errorf("nil head at block %d", n)
+	}
+	if h.Number < 0 {
+		return nil, fmt.Errorf("invalid negative block number: %d", h.Number)
+	}
+	return &protocol.BlockHeader{
+		Number:     uint64(h.Number),
+		Hash:       protocol.Bytes32(h.Hash),
+		ParentHash: protocol.Bytes32(h.ParentHash),
+		Timestamp:  h.Timestamp,
+	}, nil
+}
+
+// TestSourceReader_HeadTrackerConformance runs the shared head tracker suite
+// against [SourceReader] using go-ethereum's simulated chain plus the
+// integration [sourcereader.SimpleHeadTrackerWrapper] and [evmclient.SimulatedBackendClient].
+// This is a proof-of-concept that chain-specific wiring matches [Oracle] ground truth.
+func TestSourceReader_HeadTrackerConformance(t *testing.T) {
+	// Simulated default chain is 1337; must match [evmclient.NewSimulatedBackendClient] chainID.
+	chainID := big.NewInt(1337)
+	backend := simulated.NewBackend(types.GenesisAlloc{}, simulated.WithBlockGasLimit(10_000_000))
+	t.Cleanup(func() { _ = backend.Close() })
+
+	// Enough blocks for SimpleHeadTrackerWrapper: finalized = latest - confirmation depth (15).
+	for range 32 {
+		_ = backend.Commit()
+	}
+
+	cl := evmclient.NewSimulatedBackendClient(t, backend, chainID)
+	lggr := logger.Test(t)
+	ht := sourcereader.NewSimpleHeadTrackerWrapper(cl, lggr)
+
+	topic := onramp.OnRampCCIPMessageSent{}.Topic().Hex()
+	sr, err := NewEVMSourceReader(
+		cl,
+		ht,
+		// Plausible non-zero test addresses; constructor does not need live contracts for head reads.
+		common.HexToAddress("0x0000000000000000000000000000000000000001"),
+		common.HexToAddress("0x0000000000000000000000000000000000000002"),
+		topic,
+		protocol.ChainSelector(1),
+		lggr,
+		nil,
+	)
+	require.NoError(t, err)
+
+	oracle := &clientOracle{c: cl}
+	// [sourcereader.SimpleHeadTrackerWrapper.LatestSafeBlock] returns (nil, nil) — not an Ethereum L1 "safe" tag.
+	headtrackerconformance.Run(t, nil, headtrackerconformance.Config{
+		HeadTracker: sr,
+		Oracle:      oracle,
+		Safe:        headtrackerconformance.SafeMustBeNil,
+	})
+}
+
+// evmSimRMNHarness deploys the RMN Remote contract on the same simulated chain
+// as the reader and curses/uncurses via the owner key.
+type evmSimRMNHarness struct {
+	t   *testing.T
+	b   *simulated.Backend
+	c   *evmclient.SimulatedBackendClient
+	chainID *big.Int
+	auth  *bind.TransactOpts
+	rmn   *rmn_remote.RMNRemote
+	adr   common.Address
+}
+
+func newEVMSimRMNHarness(t *testing.T, b *simulated.Backend, c *evmclient.SimulatedBackendClient, key *ecdsa.PrivateKey, chainID *big.Int) *evmSimRMNHarness {
+	t.Helper()
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	auth, err := bind.NewKeyedTransactorWithChainID(key, chainID)
+	require.NoError(t, err, "NewKeyedTransactorWithChainID")
+	require.Equal(t, from, auth.From, "owner is deployer for curse operations")
+	return &evmSimRMNHarness{
+		t:   t,
+		b:   b,
+		c:   c,
+		chainID: chainID,
+		auth:  auth,
+	}
+}
+
+// DeployRMN implements [rmncurseconformance.RMNCurseHarness]. Idempotent: second
+// call returns the same [protocol.UnknownAddress].
+func (h *evmSimRMNHarness) DeployRMN(ctx context.Context) (protocol.UnknownAddress, error) {
+	if h.rmn != nil {
+		return evmAddressToUnknown(h.adr), nil
+	}
+	h.auth.GasLimit = 10_000_000
+	h.auth.Context = ctx
+	const localChainSelector uint64 = 1
+	// legacy IRMN not used by curse/reader tests (address(0))
+	addr, tx, rmn, err := rmn_remote.DeployRMNRemote(h.auth, h.c, localChainSelector, common.Address{})
+	if err != nil {
+		return nil, err
+	}
+	_ = h.b.Commit()
+	receipt, err := bind.WaitMined(ctx, h.c, tx)
+	if err != nil {
+		return nil, err
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return nil, fmt.Errorf("rmn remote deploy reverted, status %d", receipt.Status)
+	}
+	h.adr, h.rmn = addr, rmn
+	return evmAddressToUnknown(h.adr), nil
+}
+
+func (h *evmSimRMNHarness) CurseRMN(ctx context.Context, subjects []protocol.Bytes16) error {
+	if h.rmn == nil {
+		return fmt.Errorf("DeployRMN must be called first")
+	}
+	conv := make([][16]byte, len(subjects))
+	for i := range subjects {
+		conv[i] = subjects[i]
+	}
+	h.auth.GasLimit = 4_000_000
+	h.auth.Context = ctx
+	tx, err := h.rmn.Curse0(h.auth, conv)
+	if err != nil {
+		return err
+	}
+	_ = h.b.Commit()
+	receipt, err := bind.WaitMined(ctx, h.c, tx)
+	if err != nil {
+		return err
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("Curse0 reverted, status %d", receipt.Status)
+	}
+	return nil
+}
+
+func (h *evmSimRMNHarness) ClearRMNCurses(ctx context.Context) error {
+	if h.rmn == nil {
+		return fmt.Errorf("DeployRMN must be called first")
+	}
+	subs, err := h.rmn.GetCursedSubjects(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return err
+	}
+	if len(subs) == 0 {
+		return nil
+	}
+	h.auth.GasLimit = 4_000_000
+	h.auth.Context = ctx
+	tx, err := h.rmn.Uncurse0(h.auth, subs)
+	if err != nil {
+		return err
+	}
+	_ = h.b.Commit()
+	receipt, err := bind.WaitMined(ctx, h.c, tx)
+	if err != nil {
+		return err
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("Uncurse0 reverted, status %d", receipt.Status)
+	}
+	return nil
+}
+
+// evmAddressToUnknown encodes a 20-byte EVM [common.Address] as a chain-agnostic
+// [protocol.UnknownAddress] (length 20) for the conformance API.
+func evmAddressToUnknown(a common.Address) protocol.UnknownAddress {
+	return protocol.UnknownAddress(append([]byte{}, a[:]...))
+}
+
+// unknownToCommon requires len(addr)==20; used when wiring the reader to the
+// same RMN as the harness.
+func unknownToEVMAddress(a protocol.UnknownAddress) (common.Address, error) {
+	if len(a) != 20 {
+		return common.Address{}, fmt.Errorf("evm: UnknownAddress must be 20 bytes, got %d", len(a))
+	}
+	var o common.Address
+	copy(o[:], a)
+	return o, nil
+}
+
+// TestSourceReader_RMNCurseReaderConformance runs [rmncurseconformance.Run]
+// against a simulated chain with a real RMN Remote and [SourceReader.GetRMNCursedSubjects].
+func TestSourceReader_RMNCurseReaderConformance(t *testing.T) {
+	chainID := big.NewInt(1337)
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	owner := crypto.PubkeyToAddress(key.PublicKey)
+	oneEth := new(big.Int).Mul(big.NewInt(1_000_000_000_000_000_000), big.NewInt(1000))
+	backend := simulated.NewBackend(types.GenesisAlloc{
+		owner: {Balance: oneEth},
+	}, simulated.WithBlockGasLimit(10_000_000))
+	t.Cleanup(func() { _ = backend.Close() })
+	for range 5 {
+		_ = backend.Commit()
+	}
+	cl := evmclient.NewSimulatedBackendClient(t, backend, chainID)
+	lggr := logger.Test(t)
+	ht := sourcereader.NewSimpleHeadTrackerWrapper(cl, lggr)
+	topic := onramp.OnRampCCIPMessageSent{}.Topic().Hex()
+
+	harness := newEVMSimRMNHarness(t, backend, cl, key, chainID)
+	onRamp := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+	ctx := context.Background()
+	rmncurseconformance.Run(t, ctx, rmncurseconformance.Config{
+		Harness: harness,
+		NewReader: func(ctx context.Context, rmnAddr protocol.UnknownAddress) (chainaccess.RMNCurseReader, error) {
+			rmnEVM, err := unknownToEVMAddress(rmnAddr)
+			if err != nil {
+				return nil, err
+			}
+			return NewEVMSourceReader(
+				cl,
+				ht,
+				onRamp,
+				rmnEVM,
+				topic,
+				protocol.ChainSelector(1),
+				lggr,
+				nil,
+			)
+		},
+	})
+}

--- a/pkg/chainaccess/headtrackerconformance/conformance.go
+++ b/pkg/chainaccess/headtrackerconformance/conformance.go
@@ -1,0 +1,135 @@
+package headtrackerconformance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+// Oracle is an independent read path to verify HeadTracker output (e.g. direct
+// JSON-RPC to a node, not the HeadTracker stack). Implementations should
+// return the same canonical [protocol.BlockHeader] fields a full node would
+// return for that block height.
+type Oracle interface {
+	BlockHeaderByNumber(ctx context.Context, number uint64) (*protocol.BlockHeader, error)
+}
+
+// SafeExpectation defines how [chainaccess.HeadTracker.LatestSafeBlock] should behave for the test run.
+type SafeExpectation int
+
+const (
+	// SafeAny: both (nil, nil) and a non-nil safe header are valid; if non-nil, it must match the oracle.
+	SafeAny SafeExpectation = iota
+	// SafeMustBeNil: the chain has no "safe" concept; LatestSafeBlock must return (nil, nil).
+	SafeMustBeNil
+	// SafeMustBePresent: the chain has a safe head; LatestSafeBlock must return a non-nil header
+	// that matches the oracle and (with the same [LatestAndFinalizedBlock] snapshot) satisfies
+	// finalized.Number <= safe.Number <= latest.Number when applicable.
+	SafeMustBePresent
+)
+
+// Config wires a [chainaccess.HeadTracker], an [Oracle], and safe-head expectations.
+type Config struct {
+	HeadTracker chainaccess.HeadTracker
+	Oracle      Oracle
+	Safe        SafeExpectation
+}
+
+// Run executes the conformance subtests. ctx may be nil (uses [context.Background]).
+// Panics in tests are avoided by using require from testify; callers use *testing.T as usual.
+func Run(t *testing.T, ctx context.Context, cfg Config) {
+	t.Helper()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	require.NotNil(t, cfg.HeadTracker, "HeadTracker")
+	require.NotNil(t, cfg.Oracle, "Oracle")
+
+	t.Run("LatestAndFinalizedBlock", func(t *testing.T) {
+		latest, fin, err := cfg.HeadTracker.LatestAndFinalizedBlock(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, latest, "latest")
+		require.NotNil(t, fin, "finalized")
+		headersOrderedByNumber(t, fin, latest, "finalized and latest")
+		assertHeaderMatchesOracle(t, ctx, cfg.Oracle, "latest", latest)
+		assertHeaderMatchesOracle(t, ctx, cfg.Oracle, "finalized", fin)
+	})
+
+	t.Run("LatestAndFinalizedBlock_invariants", func(t *testing.T) {
+		// Parent chain sanity: if parent of latest is at latest-1 in the simple case,
+		// implementations may still be correct with gaps; we only require finalized <= latest.
+		latest, fin, err := cfg.HeadTracker.LatestAndFinalizedBlock(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, latest)
+		require.NotNil(t, fin)
+		require.LessOrEqual(t, fin.Number, latest.Number)
+	})
+
+	t.Run("LatestSafeBlock", func(t *testing.T) {
+		// Snapshot latest/fin and safe in order so ordering checks use one view as much as possible.
+		latest, fin, err := cfg.HeadTracker.LatestAndFinalizedBlock(ctx)
+		require.NoError(t, err)
+		safe, err := cfg.HeadTracker.LatestSafeBlock(ctx)
+		require.NoError(t, err)
+
+		switch cfg.Safe {
+		case SafeMustBeNil:
+			require.Nil(t, safe)
+		case SafeMustBePresent:
+			require.NotNil(t, safe, "expected non-nil safe block")
+			require.NotNil(t, latest, "expected non-nil latest for safe ordering check")
+			require.NotNil(t, fin, "expected non-nil finalized for safe ordering check")
+			require.LessOrEqual(t, fin.Number, safe.Number, "finalized should be at or before safe")
+			require.LessOrEqual(t, safe.Number, latest.Number, "safe should be at or before latest")
+			assertHeaderMatchesOracle(t, ctx, cfg.Oracle, "safe", safe)
+		case SafeAny:
+			if safe == nil {
+				return
+			}
+			if latest != nil && fin != nil {
+				require.LessOrEqual(t, fin.Number, safe.Number)
+				require.LessOrEqual(t, safe.Number, latest.Number)
+			}
+			assertHeaderMatchesOracle(t, ctx, cfg.Oracle, "safe", safe)
+		}
+	})
+}
+
+func assertHeaderMatchesOracle(
+	t *testing.T,
+	ctx context.Context,
+	oracle Oracle,
+	role string,
+	h *protocol.BlockHeader,
+) {
+	t.Helper()
+	if h == nil {
+		return
+	}
+	gt, err := oracle.BlockHeaderByNumber(ctx, h.Number)
+	require.NoError(t, err, "oracle BlockHeaderByNumber for %s at %d", role, h.Number)
+	require.NotNil(t, gt, "ground truth for %s at %d", role, h.Number)
+	require.Equal(t, h.Hash, gt.Hash, "hash %s", role)
+	require.Equal(t, h.ParentHash, gt.ParentHash, "parent hash %s", role)
+	if !h.Timestamp.IsZero() && !gt.Timestamp.IsZero() {
+		// Node and tracker may differ by rounding; 2s is generous for integration.
+		d := h.Timestamp.Sub(gt.Timestamp)
+		if d < 0 {
+			d = -d
+		}
+		require.LessOrEqual(t, d, 2*time.Second, "timestamp %s", role)
+	}
+}
+
+func headersOrderedByNumber(t *testing.T, a, b *protocol.BlockHeader, what string) {
+	t.Helper()
+	if a == nil || b == nil {
+		return
+	}
+	require.LessOrEqual(t, a.Number, b.Number, "%s: first header number should be <= second", what)
+}

--- a/pkg/chainaccess/headtrackerconformance/conformance_test.go
+++ b/pkg/chainaccess/headtrackerconformance/conformance_test.go
@@ -1,0 +1,127 @@
+package headtrackerconformance_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess/headtrackerconformance"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+// fakeHT is a minimal chainaccess.HeadTracker for self-tests of the harness.
+type fakeHT struct {
+	latest, finalized, safe *protocol.BlockHeader
+	// safeMode: 0 = (nil, nil) for safe; 1 = return f.safe; 2 = (nil, nil) for safe must be nil; 3 = return f.safe (alias of 1)
+	safeMode int
+}
+
+func (f *fakeHT) LatestAndFinalizedBlock(ctx context.Context) (latest, finalized *protocol.BlockHeader, err error) {
+	return f.latest, f.finalized, nil
+}
+
+func (f *fakeHT) LatestSafeBlock(ctx context.Context) (safe *protocol.BlockHeader, err error) {
+	switch f.safeMode {
+	case 0, 2:
+		return nil, nil
+	case 1, 3:
+		return f.safe, nil
+	default:
+		return f.safe, nil
+	}
+}
+
+// fakeNumberOracle is a [headtrackerconformance.Oracle] for tests.
+type fakeNumberOracle struct {
+	headersByNumber map[uint64]*protocol.BlockHeader
+	errByNumber     map[uint64]error
+}
+
+func (f *fakeNumberOracle) BlockHeaderByNumber(ctx context.Context, number uint64) (*protocol.BlockHeader, error) {
+	if f.errByNumber != nil {
+		if e, ok := f.errByNumber[number]; ok {
+			return nil, e
+		}
+	}
+	h := f.headersByNumber[number]
+	if h == nil {
+		return nil, errNoSuchBlock
+	}
+	return h, nil
+}
+
+var errNoSuchBlock = errFake("no such block")
+
+type errFake string
+
+func (e errFake) Error() string { return string(e) }
+
+func b(n uint64, h0, p0 byte) *protocol.BlockHeader {
+	var hash, parent protocol.Bytes32
+	hash[0] = h0
+	parent[0] = p0
+	return &protocol.BlockHeader{
+		Number:     n,
+		Hash:       hash,
+		ParentHash: parent,
+		Timestamp:  time.Unix(1700000000+int64(n), 0).UTC(),
+	}
+}
+
+func TestRun_passesForMatchingFakes_SafeAny_nilSafe(t *testing.T) {
+	latest := b(100, 1, 9)
+	fin := b(90, 2, 8)
+	m := map[uint64]*protocol.BlockHeader{100: latest, 90: fin, 95: b(95, 3, 2)}
+	ht := &fakeHT{latest: latest, finalized: fin, safe: m[95], safeMode: 0}
+	oracle := &fakeNumberOracle{headersByNumber: m}
+
+	headtrackerconformance.Run(t, context.Background(), headtrackerconformance.Config{
+		HeadTracker: ht,
+		Oracle:      oracle,
+		Safe:        headtrackerconformance.SafeAny,
+	})
+}
+
+func TestRun_SafeAny_nonNilSafe(t *testing.T) {
+	latest := b(100, 1, 9)
+	fin := b(90, 2, 8)
+	safe := b(95, 3, 2)
+	m := map[uint64]*protocol.BlockHeader{100: latest, 90: fin, 95: safe}
+	ht := &fakeHT{latest: latest, finalized: fin, safe: safe, safeMode: 1}
+	oracle := &fakeNumberOracle{headersByNumber: m}
+
+	headtrackerconformance.Run(t, context.Background(), headtrackerconformance.Config{
+		HeadTracker: ht,
+		Oracle:      oracle,
+		Safe:        headtrackerconformance.SafeAny,
+	})
+}
+
+func TestRun_SafeMustBeNil(t *testing.T) {
+	latest := b(10, 1, 0)
+	fin := b(5, 2, 0)
+	m := map[uint64]*protocol.BlockHeader{10: latest, 5: fin}
+	ht := &fakeHT{latest: latest, finalized: fin, safeMode: 2}
+	oracle := &fakeNumberOracle{headersByNumber: m}
+
+	headtrackerconformance.Run(t, context.Background(), headtrackerconformance.Config{
+		HeadTracker: ht,
+		Oracle:      oracle,
+		Safe:        headtrackerconformance.SafeMustBeNil,
+	})
+}
+
+func TestRun_SafeMustBePresent(t *testing.T) {
+	latest := b(100, 1, 9)
+	fin := b(90, 2, 8)
+	safe := b(95, 3, 2)
+	m := map[uint64]*protocol.BlockHeader{100: latest, 90: fin, 95: safe}
+	ht := &fakeHT{latest: latest, finalized: fin, safe: safe, safeMode: 1}
+	oracle := &fakeNumberOracle{headersByNumber: m}
+
+	headtrackerconformance.Run(t, context.Background(), headtrackerconformance.Config{
+		HeadTracker: ht,
+		Oracle:      oracle,
+		Safe:        headtrackerconformance.SafeMustBePresent,
+	})
+}

--- a/pkg/chainaccess/headtrackerconformance/doc.go
+++ b/pkg/chainaccess/headtrackerconformance/doc.go
@@ -1,0 +1,8 @@
+// Package headtrackerconformance provides shared contract tests for
+// chainaccess.HeadTracker implementations. Implementations supply a HeadTracker
+// plus an Oracle (typically raw RPC or height-based reads) to compare against
+// ground truth via [Oracle.BlockHeaderByNumber].
+//
+// Tests are intended as integration opt-in: wire a live [HeadTracker] and
+// [Oracle] in your test package and call [Run].
+package headtrackerconformance

--- a/pkg/chainaccess/rmncurseconformance/conformance.go
+++ b/pkg/chainaccess/rmncurseconformance/conformance.go
@@ -1,0 +1,125 @@
+package rmncurseconformance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+// RMNCurseHarness mutates on-chain (or in-chain) RMN Remote curse state for
+// tests. It is not part of [chainaccess.RMNCurseReader]. Implementations are
+// chain-specific; EVM can deploy RMNRemote, [CurseRMN] via Curse, and
+// [ClearRMNCurses] via Uncurse.
+type RMNCurseHarness interface {
+	// DeployRMN deploys or ensures an RMN Remote–equivalent and returns the
+	// address the [chainaccess.RMNCurseReader] under test must use. Second
+	// and later calls may return the same address if idempotent, or an error
+	// if a second deploy is not supported.
+	DeployRMN(ctx context.Context) (rmnAddress protocol.UnknownAddress, err error)
+	// CurseRMN curses the given subjects (e.g. chain selectors or global
+	// curse as [protocol.Bytes16]).
+	CurseRMN(ctx context.Context, subjects []protocol.Bytes16) error
+	// ClearRMNCurses removes all curses so a subsequent
+	// [chainaccess.RMNCurseReader.GetRMNCursedSubjects] returns the empty
+	// slice (or the chain’s pre-curse baseline). Safe to call when already clear.
+	ClearRMNCurses(ctx context.Context) error
+}
+
+// NewReaderFn builds a [chainaccess.RMNCurseReader] for the contract at
+// rmnAddress, which must be the one returned from [RMNCurseHarness.DeployRMN].
+type NewReaderFn func(ctx context.Context, rmnAddress protocol.UnknownAddress) (chainaccess.RMNCurseReader, error)
+
+// Config drives [Run]. Cases nil uses [DefaultCases].
+type Config struct {
+	Harness   RMNCurseHarness
+	NewReader NewReaderFn
+	// Cases custom matrix; if nil, [DefaultCases] is used.
+	Cases []Case
+}
+
+// Case is one apply→read round-trip (clear is done before/after in [Run]).
+type Case struct {
+	Name    string
+	Subjects []protocol.Bytes16
+}
+
+// DefaultCases is a small baseline used when [Config.Cases] is nil.
+func DefaultCases() []Case {
+	return []Case{
+		{
+			Name:    "three_distinct_subjects",
+			Subjects: threeSampleSubjects(),
+		},
+	}
+}
+
+func threeSampleSubjects() []protocol.Bytes16 {
+	// Non-global, non-zero, distinct [16]byte chain-subject stand-ins.
+	return []protocol.Bytes16{
+		subjectWithSuffix(0x11),
+		subjectWithSuffix(0x22),
+		subjectWithSuffix(0x33),
+	}
+}
+
+func subjectWithSuffix(b byte) (s protocol.Bytes16) {
+	s[15] = b
+	return s
+}
+
+// Run deploys (via harness), builds the reader, then for each [Case] clears,
+// curses the expected set, checks [chainaccess.RMNCurseReader.GetRMNCursedSubjects]
+// (order-independent), and clears again. A nil ctx uses [context.Background].
+func Run(t *testing.T, ctx context.Context, cfg Config) {
+	t.Helper()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	require.NotNil(t, cfg.Harness, "Harness")
+	require.NotNil(t, cfg.NewReader, "NewReader")
+
+	cases := cfg.Cases
+	if len(cases) == 0 {
+		cases = DefaultCases()
+	}
+
+	rmnAddr, err := cfg.Harness.DeployRMN(ctx)
+	require.NoError(t, err, "DeployRMN")
+	if len(rmnAddr) == 0 {
+		require.Fail(t, "DeployRMN returned empty UnknownAddress")
+	}
+
+	reader, err := cfg.NewReader(ctx, rmnAddr)
+	require.NoError(t, err, "NewReader")
+	require.NotNil(t, reader, "NewReader must not return a nil interface value")
+
+	for _, c := range cases {
+		if c.Name == "" {
+			c.Name = "unnamed_case"
+		}
+		t.Run(c.Name, func(t *testing.T) {
+			t.Helper()
+			err := cfg.Harness.ClearRMNCurses(ctx)
+			require.NoError(t, err, "ClearRMNCurses (start)")
+
+			got, err := reader.GetRMNCursedSubjects(ctx)
+			require.NoError(t, err, "GetRMNCursedSubjects after clear")
+			require.Empty(t, got, "subjects should be empty after clear")
+
+			err = cfg.Harness.CurseRMN(ctx, c.Subjects)
+			require.NoError(t, err, "CurseRMN")
+
+			got, err = reader.GetRMNCursedSubjects(ctx)
+			require.NoError(t, err, "GetRMNCursedSubjects after curse")
+			// On-chain getCursedSubjects order is not specified; assert multiset match.
+			require.ElementsMatch(t, c.Subjects, got, "cursed subjects")
+
+			err = cfg.Harness.ClearRMNCurses(ctx)
+			require.NoError(t, err, "ClearRMNCurses (end)")
+		})
+	}
+}

--- a/pkg/chainaccess/rmncurseconformance/conformance_test.go
+++ b/pkg/chainaccess/rmncurseconformance/conformance_test.go
@@ -1,0 +1,63 @@
+package rmncurseconformance_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess/rmncurseconformance"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+// fakeReader implements [chainaccess.RMNCurseReader] using state from [fakeHarness].
+type fakeReader struct{ h *fakeHarness }
+
+func (f *fakeReader) GetRMNCursedSubjects(_ context.Context) ([]protocol.Bytes16, error) {
+	if f == nil || f.h == nil {
+		return nil, nil
+	}
+	return append([]protocol.Bytes16{}, f.h.cursed...), nil
+}
+
+// fakeHarness implements [rmncurseconformance.RMNCurseHarness] in memory.
+type fakeHarness struct {
+	cursed  []protocol.Bytes16
+	rmnAddr protocol.UnknownAddress
+	persist bool
+}
+
+func (f *fakeHarness) DeployRMN(_ context.Context) (protocol.UnknownAddress, error) {
+	if f.persist && len(f.rmnAddr) > 0 {
+		return f.rmnAddr, nil
+	}
+	f.rmnAddr = protocol.UnknownAddress{0x1: 0xab, 19: 0xcc}
+	return f.rmnAddr, nil
+}
+
+func (f *fakeHarness) CurseRMN(_ context.Context, subjects []protocol.Bytes16) error {
+	f.cursed = append(f.cursed[:0], subjects...)
+	return nil
+}
+
+func (f *fakeHarness) ClearRMNCurses(_ context.Context) error {
+	f.cursed = nil
+	return nil
+}
+
+func TestRun_fakes(t *testing.T) {
+	f := &fakeHarness{persist: true}
+	rmncurseconformance.Run(t, context.Background(), rmncurseconformance.Config{
+		Harness: f,
+		NewReader: func(_ context.Context, rmn protocol.UnknownAddress) (chainaccess.RMNCurseReader, error) {
+			_ = rmn
+			return &fakeReader{h: f}, nil
+		},
+	})
+}
+
+func TestDefaultCases_subjectShape(t *testing.T) {
+	c := rmncurseconformance.DefaultCases()
+	require.Greater(t, len(c[0].Subjects), 0)
+}

--- a/pkg/chainaccess/rmncurseconformance/doc.go
+++ b/pkg/chainaccess/rmncurseconformance/doc.go
@@ -1,0 +1,6 @@
+// Package rmncurseconformance provides shared contract tests for
+// chainaccess.RMNCurseReader. Implementations supply a test harness
+// (deploy + curse + clear) and a factory to build a reader for the
+// deployed RMN Remote address. Chain teams implement the harness and wire
+// a reader (e.g. NewEVMSourceReader) to the same deployment the harness uses.
+package rmncurseconformance


### PR DESCRIPTION
This PR is a PoC of a suite of conformance tests for some accessor interfaces (currently just RMNCurseReader and HeadTracker).

This was me guiding the AI through a lot of it, but I think there can be improvements, mainly around e.g. the RMNCurseReader, since we might be able to use the standard `CurseAdapter` from the deployment API instead of the custom harness for this suite, but that would look a bit complex for the PoC.

I provided samples of how the conformance suites would be run for the existing EVM source reader.