### PR TITLE
bootstrap: allow explicit key declarations via WithKey

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -297,13 +297,20 @@ func initializeKeystore(ctx context.Context, lggr logger.Logger, db *sqlx.DB, ks
 		return nil, nil, fmt.Errorf("failed to load keystore: %w", err)
 	}
 
+	var csaKeyName string
 	for _, k := range requiredKeys {
 		if err := keys.EnsureKey(ctx, lggr, ks, k.name, k.purpose, k.keyType); err != nil {
-			return nil, nil, fmt.Errorf("failed to ensure %s key: %w", k.purpose, err)
+			return nil, nil, fmt.Errorf("failed to ensure key %q (purpose=%q, type=%v): %w", k.name, k.purpose, k.keyType, err)
+		}
+		if k.purpose == "csa" {
+			csaKeyName = k.name
 		}
 	}
+	if csaKeyName == "" {
+		return nil, nil, fmt.Errorf("no key with purpose %q declared; a CSA key is required for JD communication", "csa")
+	}
 
-	csaSigner, err := keys.NewCSASigner(ctx, ks, keys.DefaultCSAKeyName)
+	csaSigner, err := keys.NewCSASigner(ctx, ks, csaKeyName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get csa signer: %w", err)
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -288,12 +288,7 @@ func initializeKeystore(ctx context.Context, lggr logger.Logger, db *sqlx.DB, ks
 		return nil, nil, fmt.Errorf("failed to load keystore: %w", err)
 	}
 
-	defaultKeys := []keyToInit{
-		{keys.DefaultCSAKeyName, "csa", keystore.Ed25519},
-		{keys.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256},
-		{keys.DefaultEdDSASigningKeyName, "signing", keystore.Ed25519},
-	}
-	for _, k := range append(defaultKeys, requiredKeys...) {
+	for _, k := range requiredKeys {
 		if err := keys.EnsureKey(ctx, lggr, ks, k.name, k.purpose, k.keyType); err != nil {
 			return nil, nil, fmt.Errorf("failed to ensure %s key: %w", k.purpose, err)
 		}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -94,6 +94,7 @@ type Bootstrapper struct {
 	config           *Config
 	lifecycleManager *lifecycle.Manager
 	infoServer       *infoServer
+	keys             []keyToInit
 
 	// application
 	appCfg *string
@@ -180,7 +181,7 @@ func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 		return fmt.Errorf("failed to connect to bootstrapper database: %w", err)
 	}
 
-	keyStore, csaSigner, err := initializeKeystore(ctx, b.lggr, db, b.config.Keystore.Password)
+	keyStore, csaSigner, err := initializeKeystore(ctx, b.lggr, db, b.config.Keystore.Password, b.keys)
 	if err != nil {
 		return fmt.Errorf("failed to initialize keystore: %w", err)
 	}
@@ -281,22 +282,18 @@ func newServiceDeps(keyStore keystore.Keystore, logLevel zapcore.Level, name str
 	}, nil
 }
 
-func initializeKeystore(ctx context.Context, lggr logger.Logger, db *sqlx.DB, ksPassword string) (keystore.Keystore, crypto.Signer, error) {
+func initializeKeystore(ctx context.Context, lggr logger.Logger, db *sqlx.DB, ksPassword string, requiredKeys []keyToInit) (keystore.Keystore, crypto.Signer, error) {
 	ks, err := keystore.LoadKeystore(ctx, keys.NewPGStorage(db, "default"), ksPassword)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load keystore: %w", err)
 	}
 
-	requiredKeys := []struct {
-		name    string
-		purpose string
-		keyType keystore.KeyType
-	}{
+	defaultKeys := []keyToInit{
 		{keys.DefaultCSAKeyName, "csa", keystore.Ed25519},
 		{keys.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256},
 		{keys.DefaultEdDSASigningKeyName, "signing", keystore.Ed25519},
 	}
-	for _, k := range requiredKeys {
+	for _, k := range append(defaultKeys, requiredKeys...) {
 		if err := keys.EnsureKey(ctx, lggr, ks, k.name, k.purpose, k.keyType); err != nil {
 			return nil, nil, fmt.Errorf("failed to ensure %s key: %w", k.purpose, err)
 		}
@@ -317,6 +314,24 @@ type Option func(*Bootstrapper) error
 func WithLogLevel(logLevel zapcore.Level) Option {
 	return func(b *Bootstrapper) error {
 		b.logLevel = logLevel
+		return nil
+	}
+}
+
+type keyToInit struct {
+	name    string
+	purpose string
+	keyType keystore.KeyType
+}
+
+// WithKey tells the bootstrapper about keys that must be available, they are initialized if needed.
+func WithKey(name, purpose string, keyType keystore.KeyType) Option {
+	return func(b *Bootstrapper) error {
+		b.keys = append(b.keys, keyToInit{
+			name:    name,
+			purpose: purpose,
+			keyType: keyType,
+		})
 		return nil
 	}
 }

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -340,7 +340,6 @@ func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 	}
 }
 
-
 // WithJD tells the bootstrapper to load config from JD and start the JD lifecycle manager.
 // This is the default option if no AppConfig is provided.
 func WithJD() Option {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -123,6 +123,15 @@ func NewBootstrapper(
 		}
 	}
 
+	// Backwards compatibility: if no keys are declared, initialize the original default set.
+	if len(b.keys) == 0 {
+		b.keys = []keyToInit{
+			{keys.DefaultCSAKeyName, "csa", keystore.Ed25519},
+			{keys.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256},
+			{keys.DefaultEdDSASigningKeyName, "signing", keystore.Ed25519},
+		}
+	}
+
 	// If no configuration is provided, default to JD lifecycle manager with config loaded from the default path.
 	if b.appCfg == nil && b.config == nil {
 		b.config = &Config{}
@@ -330,6 +339,7 @@ func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 		return nil
 	}
 }
+
 
 // WithJD tells the bootstrapper to load config from JD and start the JD lifecycle manager.
 // This is the default option if no AppConfig is provided.

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -328,7 +328,11 @@ type keyToInit struct {
 	keyType keystore.KeyType
 }
 
-// WithKey tells the bootstrapper about keys that must be available, they are initialized if needed.
+// WithKey declares a key that the bootstrapper must ensure exists, creating it if absent.
+// When no WithKey options are provided, the bootstrapper applies a default set of three keys:
+// keys.DefaultCSAKeyName (Ed25519), keys.DefaultECDSASigningKeyName (ECDSA_S256), and
+// keys.DefaultEdDSASigningKeyName (Ed25519). Passing one or more WithKey options suppresses
+// those defaults entirely; the caller is responsible for declaring every key it requires.
 func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 	return func(b *Bootstrapper) error {
 		b.keys = append(b.keys, keyToInit{

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -124,6 +124,7 @@ func NewBootstrapper(
 	}
 
 	// Backwards compatibility: if no keys are declared, initialize the original default set.
+	// Deprecated: we should remove these once all apps and integrations define required keys.
 	if len(b.keys) == 0 {
 		b.keys = []keyToInit{
 			{keys.DefaultCSAKeyName, "csa", keystore.Ed25519},
@@ -135,6 +136,21 @@ func NewBootstrapper(
 	// If no configuration is provided, default to JD lifecycle manager with config loaded from the default path.
 	if b.appCfg == nil && b.config == nil {
 		b.config = &Config{}
+	}
+
+	// JD mode requires a CSA key for node authentication. Inject the default if the caller
+	// did not explicitly declare one, so callers only need to list their application keys.
+	if b.config != nil {
+		hasCSA := false
+		for _, k := range b.keys {
+			if k.purpose == "csa" {
+				hasCSA = true
+				break
+			}
+		}
+		if !hasCSA {
+			b.keys = append([]keyToInit{{keys.DefaultCSAKeyName, "csa", keystore.Ed25519}}, b.keys...)
+		}
 	}
 
 	if b.config != nil {
@@ -353,6 +369,9 @@ func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 
 // WithJD tells the bootstrapper to load config from JD and start the JD lifecycle manager.
 // This is the default option if no AppConfig is provided.
+// JD mode requires a keystore and a CSA key for node authentication. The bootstrapper
+// automatically provisions keys.DefaultCSAKeyName unless a key with purpose "csa" is
+// already declared via WithKey.
 func WithJD() Option {
 	return func(b *Bootstrapper) error {
 		b.config = &Config{}

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -16,6 +17,8 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap/db"
+	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
+	"github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
@@ -132,6 +135,48 @@ func (s *spyServiceFactoryDummy) Stop(ctx context.Context) error {
 }
 
 var _ ServiceFactory = (*spyServiceFactoryDummy)(nil)
+
+// --- WithKey / NewBootstrapper key tests ---
+
+func TestNewBootstrapper_WithKey_Defaults(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+
+	// Create an empty temp TOML file so WithTOMLAppConfig succeeds without hitting JD config.
+	f, err := os.CreateTemp(t.TempDir(), "*.toml")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	b, err := NewBootstrapper("test", lggr, &mockServiceFactory{}, WithTOMLAppConfig(f.Name()))
+	require.NoError(t, err)
+
+	// No WithKey options → the three original defaults must be applied.
+	require.Len(t, b.keys, 3)
+	require.Equal(t, keys.DefaultCSAKeyName, b.keys[0].name)
+	require.Equal(t, keys.DefaultECDSASigningKeyName, b.keys[1].name)
+	require.Equal(t, keys.DefaultEdDSASigningKeyName, b.keys[2].name)
+}
+
+func TestNewBootstrapper_WithKey_Explicit(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+
+	f, err := os.CreateTemp(t.TempDir(), "*.toml")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	b, err := NewBootstrapper("test", lggr, &mockServiceFactory{},
+		WithTOMLAppConfig(f.Name()),
+		WithKey("my_csa", "csa", keystore.Ed25519),
+		WithKey("my_signing", "signing", keystore.ECDSA_S256),
+	)
+	require.NoError(t, err)
+
+	// Explicit WithKey options must suppress defaults and preserve order.
+	require.Len(t, b.keys, 2)
+	require.Equal(t, "my_csa", b.keys[0].name)
+	require.Equal(t, "my_signing", b.keys[1].name)
+}
 
 // --- runner tests ---
 

--- a/build/devenv/services/bootstrap.go
+++ b/build/devenv/services/bootstrap.go
@@ -150,12 +150,16 @@ func fetchBootstrapKeys(bootstrapURL string, keyNames []string) (BootstrapKeys, 
 		keyMap[k.KeyInfo.Name] = k
 	}
 
-	csaKey, ok := keyMap[bskeys.DefaultCSAKeyName]
-	if !ok {
-		return BootstrapKeys{}, fmt.Errorf("CSA key %q not found in response", bskeys.DefaultCSAKeyName)
+	// Confirm every requested name is present — a count match alone doesn't
+	// catch the server returning a different key with the same cardinality.
+	for _, name := range keyNames {
+		if _, ok := keyMap[name]; !ok {
+			return BootstrapKeys{}, fmt.Errorf("key %q not found in response", name)
+		}
 	}
+
 	result := BootstrapKeys{
-		CSAPublicKey: hex.EncodeToString(csaKey.KeyInfo.PublicKey),
+		CSAPublicKey: hex.EncodeToString(keyMap[bskeys.DefaultCSAKeyName].KeyInfo.PublicKey),
 	}
 
 	if ecdsaKeyResp, ok := keyMap[bskeys.DefaultECDSASigningKeyName]; ok {

--- a/build/devenv/services/bootstrap.go
+++ b/build/devenv/services/bootstrap.go
@@ -89,15 +89,14 @@ func GenerateBootstrapConfig(in BootstrapInput) ([]byte, error) {
 	return toml.Marshal(config)
 }
 
-// BootstrapKeys are the keys that are ensured to exist by the bootstrap library,
-// in hexadecimal format.
+// BootstrapKeys holds the public keys exposed by the bootstrap info-server.
 type BootstrapKeys struct {
-	// CSAPublicKey is the CSA public key used for JD communcations.
+	// CSAPublicKey is the CSA public key used for JD communications.
 	CSAPublicKey string `toml:"csa_public_key"`
-	// ECDSAPublicKey is the public key used to sign messages using ECDSA.
-	ECDSAPublicKey string `toml:"ecdsa_public_key"`
-	// ECDSAAddress is the Ethereum address derived from the ECDSA public key.
-	ECDSAAddress string `toml:"ecdsa_address"`
+	// ECDSAPublicKey is the ECDSA signing public key (verifier only).
+	ECDSAPublicKey string `toml:"ecdsa_public_key,omitempty"`
+	// ECDSAAddress is the Ethereum address derived from the ECDSA public key (verifier only).
+	ECDSAAddress string `toml:"ecdsa_address,omitempty"`
 }
 
 // GetExecutorBootstrapKeys fetches only the CSA key from the bootstrap server.
@@ -107,7 +106,7 @@ func GetExecutorBootstrapKeys(bootstrapURL string) (BootstrapKeys, error) {
 }
 
 // GetBootstrapKeys fetches the CSA and ECDSA keys from the bootstrap server.
-// Verifiers need both for JD registration and signing.
+// Verifiers need both for JD registration and committee signer registration.
 func GetBootstrapKeys(bootstrapURL string) (BootstrapKeys, error) {
 	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName, bskeys.DefaultECDSASigningKeyName})
 }
@@ -138,9 +137,6 @@ func fetchBootstrapKeys(bootstrapURL string, keyNames []string) (BootstrapKeys, 
 	var response keystore.GetKeysResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return BootstrapKeys{}, fmt.Errorf("failed to decode response: %w", err)
-	}
-	if len(response.Keys) != len(keyNames) {
-		return BootstrapKeys{}, fmt.Errorf("expected %d keys, got %d", len(keyNames), len(response.Keys))
 	}
 
 	// Build a name→key map; the keystore returns keys sorted alphabetically,

--- a/build/devenv/services/bootstrap.go
+++ b/build/devenv/services/bootstrap.go
@@ -143,16 +143,31 @@ func fetchBootstrapKeys(bootstrapURL string, keyNames []string, includeECDSA boo
 		return BootstrapKeys{}, fmt.Errorf("expected %d keys, got %d", len(keyNames), len(response.Keys))
 	}
 
+	// Build a name→key map; the keystore returns keys sorted alphabetically,
+	// not in request order, so positional indexing is unsafe.
+	keyMap := make(map[string]keystore.GetKeyResponse, len(response.Keys))
+	for _, k := range response.Keys {
+		keyMap[k.KeyInfo.Name] = k
+	}
+
+	csaKey, ok := keyMap[bskeys.DefaultCSAKeyName]
+	if !ok {
+		return BootstrapKeys{}, fmt.Errorf("CSA key %q not found in response", bskeys.DefaultCSAKeyName)
+	}
 	result := BootstrapKeys{
-		CSAPublicKey: hex.EncodeToString(response.Keys[0].KeyInfo.PublicKey),
+		CSAPublicKey: hex.EncodeToString(csaKey.KeyInfo.PublicKey),
 	}
 
 	if includeECDSA {
-		ecdsaPublicKey, err := crypto.UnmarshalPubkey(response.Keys[1].KeyInfo.PublicKey)
+		ecdsaKeyResp, ok := keyMap[bskeys.DefaultECDSASigningKeyName]
+		if !ok {
+			return BootstrapKeys{}, fmt.Errorf("ECDSA key %q not found in response", bskeys.DefaultECDSASigningKeyName)
+		}
+		ecdsaPublicKey, err := crypto.UnmarshalPubkey(ecdsaKeyResp.KeyInfo.PublicKey)
 		if err != nil {
 			return BootstrapKeys{}, fmt.Errorf("failed to unmarshal ECDSA public key: %w", err)
 		}
-		result.ECDSAPublicKey = hex.EncodeToString(response.Keys[1].KeyInfo.PublicKey)
+		result.ECDSAPublicKey = hex.EncodeToString(ecdsaKeyResp.KeyInfo.PublicKey)
 		result.ECDSAAddress = hex.EncodeToString(crypto.PubkeyToAddress(*ecdsaPublicKey).Bytes())
 	}
 

--- a/build/devenv/services/bootstrap.go
+++ b/build/devenv/services/bootstrap.go
@@ -103,16 +103,16 @@ type BootstrapKeys struct {
 // GetExecutorBootstrapKeys fetches only the CSA key from the bootstrap server.
 // Executors only need the CSA key for JD registration.
 func GetExecutorBootstrapKeys(bootstrapURL string) (BootstrapKeys, error) {
-	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName}, false)
+	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName})
 }
 
 // GetBootstrapKeys fetches the CSA and ECDSA keys from the bootstrap server.
 // Verifiers need both for JD registration and signing.
 func GetBootstrapKeys(bootstrapURL string) (BootstrapKeys, error) {
-	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName, bskeys.DefaultECDSASigningKeyName}, true)
+	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName, bskeys.DefaultECDSASigningKeyName})
 }
 
-func fetchBootstrapKeys(bootstrapURL string, keyNames []string, includeECDSA bool) (BootstrapKeys, error) {
+func fetchBootstrapKeys(bootstrapURL string, keyNames []string) (BootstrapKeys, error) {
 	request := keystore.GetKeysRequest{KeyNames: keyNames}
 	jsonRequest, err := json.Marshal(request)
 	if err != nil {
@@ -158,11 +158,7 @@ func fetchBootstrapKeys(bootstrapURL string, keyNames []string, includeECDSA boo
 		CSAPublicKey: hex.EncodeToString(csaKey.KeyInfo.PublicKey),
 	}
 
-	if includeECDSA {
-		ecdsaKeyResp, ok := keyMap[bskeys.DefaultECDSASigningKeyName]
-		if !ok {
-			return BootstrapKeys{}, fmt.Errorf("ECDSA key %q not found in response", bskeys.DefaultECDSASigningKeyName)
-		}
+	if ecdsaKeyResp, ok := keyMap[bskeys.DefaultECDSASigningKeyName]; ok {
 		ecdsaPublicKey, err := crypto.UnmarshalPubkey(ecdsaKeyResp.KeyInfo.PublicKey)
 		if err != nil {
 			return BootstrapKeys{}, fmt.Errorf("failed to unmarshal ECDSA public key: %w", err)

--- a/build/devenv/services/bootstrap.go
+++ b/build/devenv/services/bootstrap.go
@@ -98,19 +98,22 @@ type BootstrapKeys struct {
 	ECDSAPublicKey string `toml:"ecdsa_public_key"`
 	// ECDSAAddress is the Ethereum address derived from the ECDSA public key.
 	ECDSAAddress string `toml:"ecdsa_address"`
-	// EdDSAPublicKey is the public key used to sign messages using EdDSA.
-	EdDSAPublicKey string `toml:"ed25519_public_key"`
 }
 
-// GetBootstrapKeys fetches the keys that are ensured to exist by the bootstrap library.
-func GetBootstrapKeys(bootstrapURL string) (keys BootstrapKeys, err error) {
-	request := keystore.GetKeysRequest{
-		KeyNames: []string{
-			bskeys.DefaultCSAKeyName,
-			bskeys.DefaultECDSASigningKeyName,
-			bskeys.DefaultEdDSASigningKeyName,
-		},
-	}
+// GetExecutorBootstrapKeys fetches only the CSA key from the bootstrap server.
+// Executors only need the CSA key for JD registration.
+func GetExecutorBootstrapKeys(bootstrapURL string) (BootstrapKeys, error) {
+	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName}, false)
+}
+
+// GetBootstrapKeys fetches the CSA and ECDSA keys from the bootstrap server.
+// Verifiers need both for JD registration and signing.
+func GetBootstrapKeys(bootstrapURL string) (BootstrapKeys, error) {
+	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName, bskeys.DefaultECDSASigningKeyName}, true)
+}
+
+func fetchBootstrapKeys(bootstrapURL string, keyNames []string, includeECDSA bool) (BootstrapKeys, error) {
+	request := keystore.GetKeysRequest{KeyNames: keyNames}
 	jsonRequest, err := json.Marshal(request)
 	if err != nil {
 		return BootstrapKeys{}, fmt.Errorf("failed to marshal request: %w", err)
@@ -136,24 +139,22 @@ func GetBootstrapKeys(bootstrapURL string) (keys BootstrapKeys, err error) {
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return BootstrapKeys{}, fmt.Errorf("failed to decode response: %w", err)
 	}
-	if len(response.Keys) == 0 {
-		return BootstrapKeys{}, fmt.Errorf("no keys returned by bootstrap server")
-	}
-	if len(response.Keys) != 3 {
-		return BootstrapKeys{}, fmt.Errorf("expected 3 keys, got %d", len(response.Keys))
+	if len(response.Keys) != len(keyNames) {
+		return BootstrapKeys{}, fmt.Errorf("expected %d keys, got %d", len(keyNames), len(response.Keys))
 	}
 
-	// Transform ECDSA public key to Ethereum address.
-	ecdsaPublicKey, err := crypto.UnmarshalPubkey(response.Keys[1].KeyInfo.PublicKey)
-	if err != nil {
-		return BootstrapKeys{}, fmt.Errorf("failed to unmarshal ECDSA public key: %w", err)
+	result := BootstrapKeys{
+		CSAPublicKey: hex.EncodeToString(response.Keys[0].KeyInfo.PublicKey),
 	}
-	ecdsaAddress := crypto.PubkeyToAddress(*ecdsaPublicKey).Bytes()
 
-	return BootstrapKeys{
-		CSAPublicKey:   hex.EncodeToString(response.Keys[0].KeyInfo.PublicKey),
-		ECDSAPublicKey: hex.EncodeToString(response.Keys[1].KeyInfo.PublicKey),
-		ECDSAAddress:   hex.EncodeToString(ecdsaAddress),
-		EdDSAPublicKey: hex.EncodeToString(response.Keys[2].KeyInfo.PublicKey),
-	}, nil
+	if includeECDSA {
+		ecdsaPublicKey, err := crypto.UnmarshalPubkey(response.Keys[1].KeyInfo.PublicKey)
+		if err != nil {
+			return BootstrapKeys{}, fmt.Errorf("failed to unmarshal ECDSA public key: %w", err)
+		}
+		result.ECDSAPublicKey = hex.EncodeToString(response.Keys[1].KeyInfo.PublicKey)
+		result.ECDSAAddress = hex.EncodeToString(crypto.PubkeyToAddress(*ecdsaPublicKey).Bytes())
+	}
+
+	return result, nil
 }

--- a/build/devenv/services/executor/base.go
+++ b/build/devenv/services/executor/base.go
@@ -251,7 +251,7 @@ func launchExecutor(ctx context.Context, in *Input, outputs []*ctfblockchain.Out
 		return nil, fmt.Errorf("failed to get bootstrap mapped port: %w", err)
 	}
 	bootstrapURL := fmt.Sprintf("http://%s:%s", host, bootstrapMapped.Port())
-	bootstrapKeys, err := services.GetBootstrapKeys(bootstrapURL)
+	bootstrapKeys, err := services.GetExecutorBootstrapKeys(bootstrapURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get bootstrap keys: %w", err)
 	}

--- a/changelog/2026-04-29_bootstrap_withkey.md
+++ b/changelog/2026-04-29_bootstrap_withkey.md
@@ -1,0 +1,76 @@
+# Declarative key initialization via `WithKey`
+
+## Summary
+
+Services now declare exactly which keys they require at startup using `bootstrap.WithKey` options,
+rather than the bootstrapper unconditionally provisioning a fixed three-key set. Callers that pass
+no `WithKey` options get the original defaults unchanged.
+
+---
+
+## New: `bootstrap.WithKey`
+
+Pass one option per required key. Each key is created on first run if absent.
+
+```go
+bootstrap.Run(
+    "MyService",
+    myFactory,
+    bootstrap.WithKey(keys.DefaultCSAKeyName, "csa", keystore.Ed25519),
+    bootstrap.WithKey("my_signing_key",       "signing", keystore.ECDSA_S256),
+)
+```
+
+Services that pass **no** `WithKey` options continue to receive the original default set
+(CSA + ECDSA + EdDSA), so existing binaries that have not been updated are unaffected.
+
+---
+
+## Breaking change: executor provisions `default_evm_key`, not `DefaultECDSASigningKeyName`
+
+The standalone executor binary now explicitly declares its key set. The ECDSA signing key name
+changed from the shared default to an executor-specific name, and the EdDSA key is no longer
+provisioned at all.
+
+| Key | Before (implicit default) | After (explicit) |
+|-----|--------------------------|-----------------|
+| CSA | `DefaultCSAKeyName` | `DefaultCSAKeyName` (unchanged) |
+| ECDSA signing | `DefaultECDSASigningKeyName` | `"default_evm_key"` |
+| EdDSA signing | `DefaultEdDSASigningKeyName` | *(not provisioned)* |
+
+**Existing executor nodes** retain any keys already in the database. Only fresh nodes are
+affected — they will provision `default_evm_key` instead of `DefaultECDSASigningKeyName`.
+
+---
+
+## Breaking change: `BootstrapKeys.EdDSAPublicKey` removed (devenv)
+
+The `EdDSAPublicKey` field has been removed from `services.BootstrapKeys` in the devenv package.
+It was fetched from the bootstrap info-server but never consumed anywhere. Code that reads
+`.EdDSAPublicKey` will not compile and should be deleted.
+
+---
+
+## Breaking change: `GetBootstrapKeys` returns 2 keys, not 3 (devenv)
+
+`services.GetBootstrapKeys` now requests only CSA + ECDSA from the bootstrap info-server.
+The hardcoded `len != 3` assertion has been replaced with a check against the number of keys
+requested.
+
+A new `services.GetExecutorBootstrapKeys` function requests only the CSA key and is used by
+the executor devenv setup path.
+
+Before:
+```go
+keys, err := services.GetBootstrapKeys(bootstrapURL) // requested 3 keys
+_ = keys.EdDSAPublicKey                              // now removed
+```
+
+After:
+```go
+// For executors (CSA only):
+keys, err := services.GetExecutorBootstrapKeys(bootstrapURL)
+
+// For verifiers (CSA + ECDSA):
+keys, err := services.GetBootstrapKeys(bootstrapURL)
+```

--- a/cmd/executor/standalone/main.go
+++ b/cmd/executor/standalone/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
+	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
 	cmdexecutor "github.com/smartcontractkit/chainlink-ccv/cmd/executor"
 	_ "github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm" // evm accessor driver
 	"github.com/smartcontractkit/chainlink-common/keystore"
@@ -14,7 +15,8 @@ func main() {
 	err := bootstrap.Run(
 		"Executor",
 		cmdexecutor.NewFactory(),
-		bootstrap.WithKey("default_evm_key", "signing", keystore.ECDSA_S256),
+		bootstrap.WithKey(keys.DefaultCSAKeyName, "csa", keystore.Ed25519),   // node identity key for JD communication
+		bootstrap.WithKey("default_evm_key", "signing", keystore.ECDSA_S256), // EVM signing key for OffRamp transaction submission
 	)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to run executor: %v\n", err)

--- a/cmd/executor/standalone/main.go
+++ b/cmd/executor/standalone/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
-	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
 	cmdexecutor "github.com/smartcontractkit/chainlink-ccv/cmd/executor"
 	_ "github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm" // evm accessor driver
 	"github.com/smartcontractkit/chainlink-common/keystore"
@@ -15,8 +14,7 @@ func main() {
 	err := bootstrap.Run(
 		"Executor",
 		cmdexecutor.NewFactory(),
-		bootstrap.WithKey(keys.DefaultCSAKeyName, "csa", keystore.Ed25519),   // node identity key for JD communication
-		bootstrap.WithKey("default_evm_key", "signing", keystore.ECDSA_S256), // EVM signing key for OffRamp transaction submission
+		bootstrap.WithKey("default_evm_key", "transmitting", keystore.ECDSA_S256), // EVM signing key for OffRamp transaction submission
 	)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to run executor: %v\n", err)

--- a/cmd/executor/standalone/main.go
+++ b/cmd/executor/standalone/main.go
@@ -7,12 +7,14 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
 	cmdexecutor "github.com/smartcontractkit/chainlink-ccv/cmd/executor"
 	_ "github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm" // evm accessor driver
+	"github.com/smartcontractkit/chainlink-common/keystore"
 )
 
 func main() {
 	err := bootstrap.Run(
 		"Executor",
 		cmdexecutor.NewFactory(),
+		bootstrap.WithKey("default_evm_key", "signing", keystore.ECDSA_S256),
 	)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to run executor: %v\n", err)

--- a/cmd/verifier/committee/main.go
+++ b/cmd/verifier/committee/main.go
@@ -24,9 +24,7 @@ func main() {
 		"EVMCommitteeVerifier",
 		cmd.NewCommitteeVerifierServiceFactory(),
 		bootstrap.WithLogLevel(zapcore.InfoLevel),
-		bootstrap.WithKey(keys.DefaultCSAKeyName, "csa", keystore.Ed25519),                 // node identity key for JD communication
 		bootstrap.WithKey(keys.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256), // ECDSA key for signing verification results
-		bootstrap.WithKey(keys.DefaultEdDSASigningKeyName, "signing", keystore.Ed25519),    // EdDSA key for signing verification results
 	); err != nil {
 		panic(fmt.Sprintf("failed to run EVM committee verifier: %s", err.Error()))
 	}

--- a/cmd/verifier/committee/main.go
+++ b/cmd/verifier/committee/main.go
@@ -8,8 +8,10 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
+	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
 	cmd "github.com/smartcontractkit/chainlink-ccv/cmd/verifier"
 	_ "github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm" // evm accessor driver
+	"github.com/smartcontractkit/chainlink-common/keystore"
 )
 
 func main() {
@@ -22,6 +24,9 @@ func main() {
 		"EVMCommitteeVerifier",
 		cmd.NewCommitteeVerifierServiceFactory(),
 		bootstrap.WithLogLevel(zapcore.InfoLevel),
+		bootstrap.WithKey(keys.DefaultCSAKeyName, "csa", keystore.Ed25519),                 // node identity key for JD communication
+		bootstrap.WithKey(keys.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256), // ECDSA key for signing verification results
+		bootstrap.WithKey(keys.DefaultEdDSASigningKeyName, "signing", keystore.Ed25519),    // EdDSA key for signing verification results
 	); err != nil {
 		panic(fmt.Sprintf("failed to run EVM committee verifier: %s", err.Error()))
 	}

--- a/deployment/adapters/registry.go
+++ b/deployment/adapters/registry.go
@@ -11,11 +11,11 @@ import (
 // ChainAdapters bundles all chain-family-specific adapter implementations.
 // A nil field means the adapter is not supported for that family.
 type ChainAdapters struct {
-	Aggregator              AggregatorConfigAdapter
-	Executor                ExecutorConfigAdapter
-	Verifier                VerifierConfigAdapter
-	Indexer                 IndexerConfigAdapter
-	TokenVerifier           TokenVerifierConfigAdapter
+	Aggregator               AggregatorConfigAdapter
+	Executor                 ExecutorConfigAdapter
+	Verifier                 VerifierConfigAdapter
+	Indexer                  IndexerConfigAdapter
+	TokenVerifier            TokenVerifierConfigAdapter
 	CommitteeVerifierOnchain CommitteeVerifierOnchainAdapter
 }
 


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Removes the hardcoded default key list from initializeKeystore. Services now declare the keys they
  need via WithKey options passed to bootstrap.Run, making key requirements explicit and visible at the
   call site. The bootstrapper has no policy of its own — it only initialises what it is told to.


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

This feature is non-functional refactoring that replaces code paths hit by all existing integration tests. If the environment starts and messages execute, the changes were a success.

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
