### PR TITLE
bootstrap: move key name constants to canonical packages

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -127,9 +127,9 @@ func NewBootstrapper(
 	// Deprecated: we should remove these once all apps and integrations define required keys.
 	if len(b.keys) == 0 {
 		b.keys = []keyToInit{
-			{keys.DefaultCSAKeyName, "csa", keystore.Ed25519},
-			{keys.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256},
-			{keys.DefaultEdDSASigningKeyName, "signing", keystore.Ed25519},
+			{DefaultCSAKeyName, "csa", keystore.Ed25519},
+			{defaultECDSASigningKeyName, "signing", keystore.ECDSA_S256},
+			{defaultEdDSASigningKeyName, "signing", keystore.Ed25519},
 		}
 	}
 
@@ -149,7 +149,7 @@ func NewBootstrapper(
 			}
 		}
 		if !hasCSA {
-			b.keys = append([]keyToInit{{keys.DefaultCSAKeyName, "csa", keystore.Ed25519}}, b.keys...)
+			b.keys = append([]keyToInit{{DefaultCSAKeyName, "csa", keystore.Ed25519}}, b.keys...)
 		}
 	}
 
@@ -352,9 +352,8 @@ type keyToInit struct {
 }
 
 // WithKey declares a key that the bootstrapper must ensure exists, creating it if absent.
-// When no WithKey options are provided, the bootstrapper applies a default set of three keys:
-// keys.DefaultCSAKeyName (Ed25519), keys.DefaultECDSASigningKeyName (ECDSA_S256), and
-// keys.DefaultEdDSASigningKeyName (Ed25519). Passing one or more WithKey options suppresses
+// When no WithKey options are provided, the bootstrapper applies a deprecated default set of
+// three keys (CSA, ECDSA signing, EdDSA signing). Passing one or more WithKey options suppresses
 // those defaults entirely; the caller is responsible for declaring every key it requires.
 func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 	return func(b *Bootstrapper) error {
@@ -370,7 +369,7 @@ func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 // WithJD tells the bootstrapper to load config from JD and start the JD lifecycle manager.
 // This is the default option if no AppConfig is provided.
 // JD mode requires a keystore and a CSA key for node authentication. The bootstrapper
-// automatically provisions keys.DefaultCSAKeyName unless a key with purpose "csa" is
+// automatically provisions bootstrap.DefaultCSAKeyName unless a key with purpose "csa" is
 // already declared via WithKey.
 func WithJD() Option {
 	return func(b *Bootstrapper) error {

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -17,7 +17,6 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap/db"
-	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
 	"github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -152,9 +151,9 @@ func TestNewBootstrapper_WithKey_Defaults(t *testing.T) {
 
 	// No WithKey options → the three original defaults must be applied.
 	require.Len(t, b.keys, 3)
-	require.Equal(t, keys.DefaultCSAKeyName, b.keys[0].name)
-	require.Equal(t, keys.DefaultECDSASigningKeyName, b.keys[1].name)
-	require.Equal(t, keys.DefaultEdDSASigningKeyName, b.keys[2].name)
+	require.Equal(t, DefaultCSAKeyName, b.keys[0].name)
+	require.Equal(t, defaultECDSASigningKeyName, b.keys[1].name)
+	require.Equal(t, defaultEdDSASigningKeyName, b.keys[2].name)
 }
 
 func TestNewBootstrapper_WithKey_Explicit(t *testing.T) {

--- a/bootstrap/keynames.go
+++ b/bootstrap/keynames.go
@@ -1,0 +1,12 @@
+package bootstrap
+
+// DefaultCSAKeyName is the keystore key name for the JD CSA authentication key.
+// It is exported so that external tools (e.g. devenv) can look up the key by name.
+const DefaultCSAKeyName = "bootstrap_default_csa_key"
+
+// Deprecated key names retained only for the backwards-compat initialization block.
+// Remove once all callers declare their required keys explicitly via WithKey.
+const (
+	defaultECDSASigningKeyName = "bootstrap_default_ecdsa_signing_key"
+	defaultEdDSASigningKeyName = "bootstrap_default_eddsa_signing_key"
+)

--- a/bootstrap/keys/ensure.go
+++ b/bootstrap/keys/ensure.go
@@ -11,13 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
-// Default key names used by the bootstrapper.
-const (
-	DefaultECDSASigningKeyName = "bootstrap_default_ecdsa_signing_key"
-	DefaultEdDSASigningKeyName = "bootstrap_default_eddsa_signing_key"
-	DefaultCSAKeyName          = "bootstrap_default_csa_key"
-)
-
 // EnsureKey creates keyName in the keystore if it does not already exist.
 func EnsureKey(
 	ctx context.Context,

--- a/build/devenv/services/bootstrap.go
+++ b/build/devenv/services/bootstrap.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
-	bskeys "github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
+	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/commit"
 	"github.com/smartcontractkit/chainlink-common/keystore"
 )
 
@@ -102,13 +102,13 @@ type BootstrapKeys struct {
 // GetExecutorBootstrapKeys fetches only the CSA key from the bootstrap server.
 // Executors only need the CSA key for JD registration.
 func GetExecutorBootstrapKeys(bootstrapURL string) (BootstrapKeys, error) {
-	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName})
+	return fetchBootstrapKeys(bootstrapURL, []string{bootstrap.DefaultCSAKeyName})
 }
 
 // GetBootstrapKeys fetches the CSA and ECDSA keys from the bootstrap server.
 // Verifiers need both for JD registration and committee signer registration.
 func GetBootstrapKeys(bootstrapURL string) (BootstrapKeys, error) {
-	return fetchBootstrapKeys(bootstrapURL, []string{bskeys.DefaultCSAKeyName, bskeys.DefaultECDSASigningKeyName})
+	return fetchBootstrapKeys(bootstrapURL, []string{bootstrap.DefaultCSAKeyName, commit.DefaultECDSASigningKeyName})
 }
 
 func fetchBootstrapKeys(bootstrapURL string, keyNames []string) (BootstrapKeys, error) {
@@ -155,10 +155,10 @@ func fetchBootstrapKeys(bootstrapURL string, keyNames []string) (BootstrapKeys, 
 	}
 
 	result := BootstrapKeys{
-		CSAPublicKey: hex.EncodeToString(keyMap[bskeys.DefaultCSAKeyName].KeyInfo.PublicKey),
+		CSAPublicKey: hex.EncodeToString(keyMap[bootstrap.DefaultCSAKeyName].KeyInfo.PublicKey),
 	}
 
-	if ecdsaKeyResp, ok := keyMap[bskeys.DefaultECDSASigningKeyName]; ok {
+	if ecdsaKeyResp, ok := keyMap[commit.DefaultECDSASigningKeyName]; ok {
 		ecdsaPublicKey, err := crypto.UnmarshalPubkey(ecdsaKeyResp.KeyInfo.PublicKey)
 		if err != nil {
 			return BootstrapKeys{}, fmt.Errorf("failed to unmarshal ECDSA public key: %w", err)

--- a/build/devenv/services/executor/base_test.go
+++ b/build/devenv/services/executor/base_test.go
@@ -1,0 +1,65 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services"
+)
+
+func TestApplyDefaults(t *testing.T) {
+	t.Run("DB name defaults to ContainerName-db", func(t *testing.T) {
+		in := &Input{ContainerName: "my-executor"}
+		ApplyDefaults(in)
+		require.NotNil(t, in.DB)
+		assert.Equal(t, "my-executor-db", in.DB.Name)
+	})
+
+	t.Run("multiple executors get distinct DB names", func(t *testing.T) {
+		in1 := &Input{ContainerName: "executor-1"}
+		in2 := &Input{ContainerName: "executor-2"}
+		ApplyDefaults(in1)
+		ApplyDefaults(in2)
+		assert.NotEqual(t, in1.DB.Name, in2.DB.Name)
+	})
+
+	t.Run("explicit DB name is preserved", func(t *testing.T) {
+		in := &Input{
+			ContainerName: "my-executor",
+			DB:            &DBInput{Name: "custom-db", Image: DefaultExecutorDBImage},
+		}
+		ApplyDefaults(in)
+		assert.Equal(t, "custom-db", in.DB.Name)
+	})
+
+	t.Run("image defaults applied", func(t *testing.T) {
+		in := &Input{ContainerName: "e"}
+		ApplyDefaults(in)
+		assert.Equal(t, DefaultExecutorImage, in.Image)
+		assert.Equal(t, DefaultExecutorDBImage, in.DB.Image)
+	})
+
+	t.Run("chain family defaults to EVM", func(t *testing.T) {
+		in := &Input{ContainerName: "e"}
+		ApplyDefaults(in)
+		assert.Equal(t, chainsel.FamilyEVM, in.ChainFamily)
+	})
+
+	t.Run("mode defaults to Standalone", func(t *testing.T) {
+		in := &Input{ContainerName: "e"}
+		ApplyDefaults(in)
+		assert.Equal(t, services.Standalone, in.Mode)
+	})
+}
+
+func TestNew_NilJDInfra(t *testing.T) {
+	in := &Input{ContainerName: "e"}
+	ApplyDefaults(in)
+	_, err := New(in, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JD infrastructure")
+}

--- a/changelog/2026-04-29_bootstrap_withkey.md
+++ b/changelog/2026-04-29_bootstrap_withkey.md
@@ -16,10 +16,13 @@ Pass one option per required key. Each key is created on first run if absent.
 bootstrap.Run(
     "MyService",
     myFactory,
-    bootstrap.WithKey(keys.DefaultCSAKeyName, "csa", keystore.Ed25519),
-    bootstrap.WithKey("my_signing_key",       "signing", keystore.ECDSA_S256),
+    bootstrap.WithKey(commit.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256),
 )
 ```
+
+The **CSA key is provisioned automatically** in JD mode — callers do not need to declare it.
+The bootstrapper injects `bootstrap.DefaultCSAKeyName` (Ed25519) unless the caller has already
+declared a key with purpose `"csa"` via `WithKey`.
 
 Services that pass **no** `WithKey` options continue to receive the original default set
 (CSA + ECDSA + EdDSA), so existing binaries that have not been updated are unaffected.
@@ -74,3 +77,35 @@ keys, err := services.GetExecutorBootstrapKeys(bootstrapURL)
 // For verifiers (CSA + ECDSA):
 keys, err := services.GetBootstrapKeys(bootstrapURL)
 ```
+
+---
+
+## Breaking change: key name constants moved to canonical packages
+
+The constants previously exported from `bootstrap/keys` are now private. Each key name is
+exported from the package that owns the key.
+
+| Constant | Old location | New location |
+|----------|-------------|--------------|
+| `DefaultCSAKeyName` | `bootstrap/keys` | `bootstrap` |
+| `DefaultECDSASigningKeyName` | `bootstrap/keys` | `verifier/pkg/commit` |
+
+Update import sites:
+
+```go
+// Before
+import bskeys "github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
+bootstrap.WithKey(bskeys.DefaultCSAKeyName,          "csa",     keystore.Ed25519)
+bootstrap.WithKey(bskeys.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256)
+
+// After
+import (
+    "github.com/smartcontractkit/chainlink-ccv/bootstrap"
+    "github.com/smartcontractkit/chainlink-ccv/verifier/pkg/commit"
+)
+// CSA key is auto-provisioned; only declare signing keys explicitly:
+bootstrap.WithKey(commit.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256)
+```
+
+`bootstrap/keys` retains its utility functions (`EnsureKey`, `NewCSASigner`, `NewPGStorage`,
+`DecodeEd25519PublicKey`) — only the constants are no longer exported.

--- a/cmd/verifier/committee/main.go
+++ b/cmd/verifier/committee/main.go
@@ -8,9 +8,9 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
-	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
 	cmd "github.com/smartcontractkit/chainlink-ccv/cmd/verifier"
 	_ "github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm" // evm accessor driver
+	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/commit"
 	"github.com/smartcontractkit/chainlink-common/keystore"
 )
 
@@ -24,7 +24,7 @@ func main() {
 		"EVMCommitteeVerifier",
 		cmd.NewCommitteeVerifierServiceFactory(),
 		bootstrap.WithLogLevel(zapcore.InfoLevel),
-		bootstrap.WithKey(keys.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256), // ECDSA key for signing verification results
+		bootstrap.WithKey(commit.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256), // ECDSA key for signing verification results
 	); err != nil {
 		panic(fmt.Sprintf("failed to run EVM committee verifier: %s", err.Error()))
 	}

--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
-	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/heartbeatclient"
 	"github.com/smartcontractkit/chainlink-ccv/integration/storageaccess"
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
@@ -190,7 +189,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		HeartbeatInterval:   10 * time.Second, // Send heartbeat to aggregator every 10s
 	}
 
-	signer, _, signerAddress, err := commit.NewSignerFromKeystore(ctx, deps.Keystore, keys.DefaultECDSASigningKeyName)
+	signer, _, signerAddress, err := commit.NewSignerFromKeystore(ctx, deps.Keystore, commit.DefaultECDSASigningKeyName)
 	if err != nil {
 		lggr.Errorw("Failed to create signer", "error", err)
 		return fmt.Errorf("failed to create signer: %w", err)

--- a/verifier/pkg/commit/config.go
+++ b/verifier/pkg/commit/config.go
@@ -7,6 +7,9 @@ import (
 	verifier "github.com/smartcontractkit/chainlink-ccv/verifier/pkg/vtypes"
 )
 
+// DefaultECDSASigningKeyName is the keystore key name for the ECDSA key used to sign verification results.
+const DefaultECDSASigningKeyName = "bootstrap_default_ecdsa_signing_key"
+
 type Config struct {
 	VerifierID        string `toml:"verifier_id"`
 	AggregatorAddress string `toml:"aggregator_address"`


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
  Moves the key name constants out of bootstrap/keys (where they didn't belong) into the packages that own them:

  - DefaultCSAKeyName → bootstrap (it's the bootstrapper's JD auth key)
  - DefaultECDSASigningKeyName → verifier/pkg/commit (it's the verifier's signing key)


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing
Non functional changes. Regression testing covered by existing unit and integration tests.

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
