### PR TITLE
fix token pool pairs

### DIFF
--- a/build/devenv/common/common.go
+++ b/build/devenv/common/common.go
@@ -65,24 +65,28 @@ type TokenCombination struct {
 	expectedVerifierResults int
 }
 
-// canonicalPairQualifier returns the same qualifier string regardless of which
-// side of a pool pair is treated as "local". The two pool descriptions are
-// sorted alphabetically so that BurnMint↔LockRelease and LockRelease↔BurnMint
-// both produce the same base string.
-func (s TokenCombination) canonicalPairQualifier() string {
-	a := fmt.Sprintf("%s %s %v", s.localPoolType, s.localPoolVersion, s.localPoolCCVQualifiers)
-	b := fmt.Sprintf("%s %s %v", s.remotePoolType, s.remotePoolVersion, s.remotePoolCCVQualifiers)
+func poolDescription(poolType, poolVersion string, ccvQualifiers []string) string {
+	return fmt.Sprintf("%s %s %v", poolType, poolVersion, ccvQualifiers)
+}
+
+func poolPairQualifier(a, b string) string {
 	if a > b {
 		a, b = b, a
 	}
 	return fmt.Sprintf("TEST (%s, %s)", a, b)
 }
 
+func poolInstanceQualifier(poolDesc, counterpartPoolDesc string) string {
+	return fmt.Sprintf("%s::%s", poolPairQualifier(poolDesc, counterpartPoolDesc), poolDesc)
+}
+
 // LocalPoolAddressRef returns the address ref for the local token pool.
 func (s TokenCombination) LocalPoolAddressRef() datastore.AddressRef {
 	qualifier := s.localPoolQualifier
 	if qualifier == "" {
-		qualifier = s.canonicalPairQualifier() + ":local"
+		localPoolDesc := poolDescription(s.localPoolType, s.localPoolVersion, s.localPoolCCVQualifiers)
+		remotePoolDesc := poolDescription(s.remotePoolType, s.remotePoolVersion, s.remotePoolCCVQualifiers)
+		qualifier = poolInstanceQualifier(localPoolDesc, remotePoolDesc)
 	}
 	return datastore.AddressRef{
 		Type:      datastore.ContractType(s.localPoolType),
@@ -95,7 +99,9 @@ func (s TokenCombination) LocalPoolAddressRef() datastore.AddressRef {
 func (s TokenCombination) RemotePoolAddressRef() datastore.AddressRef {
 	qualifier := s.remotePoolQualifier
 	if qualifier == "" {
-		qualifier = s.canonicalPairQualifier() + ":remote"
+		remotePoolDesc := poolDescription(s.remotePoolType, s.remotePoolVersion, s.remotePoolCCVQualifiers)
+		localPoolDesc := poolDescription(s.localPoolType, s.localPoolVersion, s.localPoolCCVQualifiers)
+		qualifier = poolInstanceQualifier(remotePoolDesc, localPoolDesc)
 	}
 	return datastore.AddressRef{
 		Type:      datastore.ContractType(s.remotePoolType),

--- a/build/devenv/common/common.go
+++ b/build/devenv/common/common.go
@@ -65,11 +65,24 @@ type TokenCombination struct {
 	expectedVerifierResults int
 }
 
+// canonicalPairQualifier returns the same qualifier string regardless of which
+// side of a pool pair is treated as "local". The two pool descriptions are
+// sorted alphabetically so that BurnMint↔LockRelease and LockRelease↔BurnMint
+// both produce the same base string.
+func (s TokenCombination) canonicalPairQualifier() string {
+	a := fmt.Sprintf("%s %s %v", s.localPoolType, s.localPoolVersion, s.localPoolCCVQualifiers)
+	b := fmt.Sprintf("%s %s %v", s.remotePoolType, s.remotePoolVersion, s.remotePoolCCVQualifiers)
+	if a > b {
+		a, b = b, a
+	}
+	return fmt.Sprintf("TEST (%s, %s)", a, b)
+}
+
 // LocalPoolAddressRef returns the address ref for the local token pool.
 func (s TokenCombination) LocalPoolAddressRef() datastore.AddressRef {
 	qualifier := s.localPoolQualifier
 	if qualifier == "" {
-		qualifier = fmt.Sprintf("TEST (%s %s %v to %s %s %v)", s.localPoolType, s.localPoolVersion, s.localPoolCCVQualifiers, s.remotePoolType, s.remotePoolVersion, s.remotePoolCCVQualifiers)
+		qualifier = s.canonicalPairQualifier() + ":local"
 	}
 	return datastore.AddressRef{
 		Type:      datastore.ContractType(s.localPoolType),
@@ -82,7 +95,7 @@ func (s TokenCombination) LocalPoolAddressRef() datastore.AddressRef {
 func (s TokenCombination) RemotePoolAddressRef() datastore.AddressRef {
 	qualifier := s.remotePoolQualifier
 	if qualifier == "" {
-		qualifier = fmt.Sprintf("TEST (%s %s %v to %s %s %v)", s.remotePoolType, s.remotePoolVersion, s.remotePoolCCVQualifiers, s.localPoolType, s.localPoolVersion, s.localPoolCCVQualifiers)
+		qualifier = s.canonicalPairQualifier() + ":remote"
 	}
 	return datastore.AddressRef{
 		Type:      datastore.ContractType(s.remotePoolType),

--- a/build/devenv/common/common_test.go
+++ b/build/devenv/common/common_test.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenCombinationAddressRefsUseReciprocalPoolInstanceQualifiers(t *testing.T) {
+	ccvs := []string{DefaultCommitteeVerifierQualifier}
+	forward := newTokenCombination(BurnMintTokenPoolType, "2.0.0", ccvs, LockReleaseTokenPoolType, "2.0.0", ccvs)
+	reverse := newTokenCombination(LockReleaseTokenPoolType, "2.0.0", ccvs, BurnMintTokenPoolType, "2.0.0", ccvs)
+
+	require.Equal(t, forward.RemotePoolAddressRef(), reverse.LocalPoolAddressRef())
+	require.Equal(t, forward.LocalPoolAddressRef(), reverse.RemotePoolAddressRef())
+	require.NotEqual(t, forward.LocalPoolAddressRef().Qualifier, forward.RemotePoolAddressRef().Qualifier)
+	require.NotContains(t, forward.LocalPoolAddressRef().Qualifier, ":local")
+	require.NotContains(t, forward.RemotePoolAddressRef().Qualifier, ":remote")
+	require.Contains(t, forward.LocalPoolAddressRef().Qualifier, "::BurnMintTokenPool")
+	require.Contains(t, forward.RemotePoolAddressRef().Qualifier, "::LockReleaseTokenPool")
+}

--- a/build/devenv/implcommon.go
+++ b/build/devenv/implcommon.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -598,13 +599,24 @@ func tokenTransferRefKey(ref datastore.AddressRef) string {
 	return string(ref.Type) + "+" + v + "+" + ref.Qualifier
 }
 
+// poolPairBatchKey strips the ":local" / ":remote" direction suffix that
+// TokenCombination.LocalPoolAddressRef / RemotePoolAddressRef append to the
+// canonical pair qualifier, returning the shared base so that both sides of a
+// bidirectional pair land in the same ConfigureTokensForTransfers call.
+// Qualifiers without either suffix are returned unchanged.
+func poolPairBatchKey(qualifier string) string {
+	q := strings.TrimSuffix(qualifier, ":local")
+	q = strings.TrimSuffix(q, ":remote")
+	return q
+}
+
 func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) [][]tokenscore.TokenTransferConfig {
 	// Configure each logical token/pool independently across lanes. The upstream
 	// changeset expects one local pool identity per call, while each batch may
 	// still include that pool's configs from multiple chains.
 	byPool := make(map[string][]tokenscore.TokenTransferConfig)
 	for _, cfg := range configs {
-		poolKey := tokenTransferRefKey(cfg.TokenPoolRef)
+		poolKey := poolPairBatchKey(cfg.TokenPoolRef.Qualifier)
 		byPool[poolKey] = append(byPool[poolKey], cfg)
 	}
 

--- a/build/devenv/implcommon.go
+++ b/build/devenv/implcommon.go
@@ -653,43 +653,12 @@ func (k tokenTransferNodeKey) String() string {
 	return fmt.Sprintf("%d/%s", k.chainSelector, k.poolKey)
 }
 
-type tokenTransferLaneKey struct {
-	from tokenTransferNodeKey
-	to   tokenTransferNodeKey
-}
-
-func (k tokenTransferLaneKey) String() string {
-	return k.from.String() + "->" + k.to.String()
-}
-
-func sortedTokenTransferLaneKeys(lanes map[tokenTransferLaneKey]struct{}) []tokenTransferLaneKey {
-	keys := make([]tokenTransferLaneKey, 0, len(lanes))
-	for lane := range lanes {
-		keys = append(keys, lane)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i].String() < keys[j].String()
-	})
-	return keys
-}
-
-func tokenTransferConfigForRemote(cfg tokenscore.TokenTransferConfig, remoteSelector uint64) (tokenscore.TokenTransferConfig, error) {
-	remoteCfg, ok := cfg.RemoteChains[remoteSelector]
-	if !ok {
-		return tokenscore.TokenTransferConfig{}, fmt.Errorf("remote selector %d is missing from token transfer config %s", remoteSelector, tokenTransferConfigNodeKey(cfg))
-	}
-	clone := cfg
-	clone.RemoteChains = map[uint64]tokenscore.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
-		remoteSelector: remoteCfg,
-	}
-	return clone, nil
-}
-
 func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) ([][]tokenscore.TokenTransferConfig, error) {
 	// Group first so unrelated token pairs never get matched together. Within a
-	// group, batches are emitted per reciprocal lane. This keeps the local pool
-	// in each batch aligned with the RemotePool refs that the changeset will
-	// configure on-chain.
+	// group, split only when a ConfigureTokensForTransfers call would contain two
+	// configs for the same selector. Each config keeps its full RemoteChains map:
+	// the EVM token-pool sequence requires every call for an already-active pool
+	// to include all supported remote chains.
 	byPair := make(map[string][]tokenscore.TokenTransferConfig)
 	for _, cfg := range configs {
 		pairKey := canonicalPoolPairKey(cfg.TokenPoolRef)
@@ -704,15 +673,21 @@ func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) ([][]to
 
 	batches := make([][]tokenscore.TokenTransferConfig, 0, len(groupKeys))
 	for _, groupKey := range groupKeys {
-		group := byPair[groupKey]
-		configByNode := make(map[tokenTransferNodeKey]tokenscore.TokenTransferConfig, len(group))
-		lanes := make(map[tokenTransferLaneKey]struct{})
+		group := append([]tokenscore.TokenTransferConfig(nil), byPair[groupKey]...)
+		sort.Slice(group, func(i, j int) bool {
+			if group[i].ChainSelector != group[j].ChainSelector {
+				return group[i].ChainSelector < group[j].ChainSelector
+			}
+			return tokenTransferRefKey(group[i].TokenPoolRef) < tokenTransferRefKey(group[j].TokenPoolRef)
+		})
+
+		configByNode := make(map[tokenTransferNodeKey]struct{}, len(group))
 		for _, cfg := range group {
 			from := tokenTransferConfigNodeKey(cfg)
 			if _, exists := configByNode[from]; exists {
 				return nil, fmt.Errorf("duplicate token transfer config for %s", from)
 			}
-			configByNode[from] = cfg
+			configByNode[from] = struct{}{}
 		}
 		for _, cfg := range group {
 			from := tokenTransferConfigNodeKey(cfg)
@@ -724,38 +699,33 @@ func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) ([][]to
 				if _, exists := configByNode[to]; !exists {
 					return nil, fmt.Errorf("token transfer config %s references remote pool %s, but that pool is not present in the same batch group", from, to)
 				}
-				lanes[tokenTransferLaneKey{from: from, to: to}] = struct{}{}
 			}
 		}
 
-		visited := make(map[tokenTransferLaneKey]bool, len(lanes))
-		for _, lane := range sortedTokenTransferLaneKeys(lanes) {
-			if visited[lane] {
-				continue
-			}
-			reverse := tokenTransferLaneKey{from: lane.to, to: lane.from}
-			if _, exists := lanes[reverse]; !exists {
-				return nil, fmt.Errorf("token transfer lane %s is missing reciprocal lane %s", lane, reverse)
-			}
-			fromCfg, err := tokenTransferConfigForRemote(configByNode[lane.from], lane.to.chainSelector)
-			if err != nil {
-				return nil, err
-			}
-			toCfg, err := tokenTransferConfigForRemote(configByNode[lane.to], lane.from.chainSelector)
-			if err != nil {
-				return nil, err
-			}
-			batch := []tokenscore.TokenTransferConfig{fromCfg, toCfg}
-			sort.Slice(batch, func(i, j int) bool {
-				if batch[i].ChainSelector != batch[j].ChainSelector {
-					return batch[i].ChainSelector < batch[j].ChainSelector
-				}
-				return tokenTransferRefKey(batch[i].TokenPoolRef) < tokenTransferRefKey(batch[j].TokenPoolRef)
-			})
-			batches = append(batches, batch)
-			visited[lane] = true
-			visited[reverse] = true
-		}
+		batches = append(batches, splitTokenTransferBatchBySelector(group)...)
 	}
 	return batches, nil
+}
+
+func splitTokenTransferBatchBySelector(configs []tokenscore.TokenTransferConfig) [][]tokenscore.TokenTransferConfig {
+	batches := make([][]tokenscore.TokenTransferConfig, 0, 1)
+	seenSelectors := make([]map[uint64]bool, 0, 1)
+	for _, cfg := range configs {
+		placed := false
+		for i := range batches {
+			if seenSelectors[i][cfg.ChainSelector] {
+				continue
+			}
+			batches[i] = append(batches[i], cfg)
+			seenSelectors[i][cfg.ChainSelector] = true
+			placed = true
+			break
+		}
+		if placed {
+			continue
+		}
+		batches = append(batches, []tokenscore.TokenTransferConfig{cfg})
+		seenSelectors = append(seenSelectors, map[uint64]bool{cfg.ChainSelector: true})
+	}
+	return batches
 }

--- a/build/devenv/implcommon.go
+++ b/build/devenv/implcommon.go
@@ -576,7 +576,10 @@ func ConfigureAllTokenTransfers(
 		allConfigs = append(allConfigs, cfg)
 	}
 
-	batches := buildTokenTransferBatches(allConfigs)
+	batches, err := buildTokenTransferBatches(allConfigs)
+	if err != nil {
+		return err
+	}
 
 	tokenAdapterRegistry := tokenscore.GetTokenAdapterRegistry()
 	mcmsReaderRegistry := changesetscore.GetRegistry()
@@ -599,40 +602,160 @@ func tokenTransferRefKey(ref datastore.AddressRef) string {
 	return string(ref.Type) + "+" + v + "+" + ref.Qualifier
 }
 
-// poolPairBatchKey strips the ":local" / ":remote" direction suffix that
-// TokenCombination.LocalPoolAddressRef / RemotePoolAddressRef append to the
-// canonical pair qualifier, returning the shared base so that both sides of a
-// bidirectional pair land in the same ConfigureTokensForTransfers call.
-// Qualifiers without either suffix are returned unchanged.
-func poolPairBatchKey(qualifier string) string {
-	q := strings.TrimSuffix(qualifier, ":local")
-	q = strings.TrimSuffix(q, ":remote")
-	return q
+// canonicalPoolPairKey returns a stable batch key for a pool reference.
+//
+// It accepts both the current canonical "BASE (POOL_A, POOL_B)" format and
+// the older directional "BASE (POOL_A to POOL_B)" / ":local" / ":remote" forms.
+// Plain qualifiers without a recognizable pair fall through to tokenTransferRefKey.
+func canonicalPoolPairKey(ref datastore.AddressRef) string {
+	qualifier := strings.TrimSuffix(strings.TrimSuffix(ref.Qualifier, ":local"), ":remote")
+	if pairQualifier, _, ok := strings.Cut(qualifier, "::"); ok {
+		qualifier = pairQualifier
+	}
+	base, rest, ok := strings.Cut(qualifier, " (")
+	if !ok || !strings.HasSuffix(rest, ")") {
+		return tokenTransferRefKey(ref)
+	}
+	inner := strings.TrimSuffix(rest, ")")
+	a, b, ok := strings.Cut(inner, ", ")
+	if !ok {
+		a, b, ok = strings.Cut(inner, " to ")
+		if !ok {
+			return tokenTransferRefKey(ref)
+		}
+	}
+	if a > b {
+		a, b = b, a
+	}
+	return base + "+" + a + "+" + b
 }
 
-func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) [][]tokenscore.TokenTransferConfig {
-	// Configure each logical token/pool independently across lanes. The upstream
-	// changeset expects one local pool identity per call, while each batch may
-	// still include that pool's configs from multiple chains.
-	byPool := make(map[string][]tokenscore.TokenTransferConfig)
+type tokenTransferNodeKey struct {
+	chainSelector uint64
+	poolKey       string
+}
+
+func tokenTransferConfigNodeKey(cfg tokenscore.TokenTransferConfig) tokenTransferNodeKey {
+	return tokenTransferNodeKey{
+		chainSelector: cfg.ChainSelector,
+		poolKey:       tokenTransferRefKey(cfg.TokenPoolRef),
+	}
+}
+
+func tokenTransferRemoteNodeKey(chainSelector uint64, ref datastore.AddressRef) tokenTransferNodeKey {
+	return tokenTransferNodeKey{
+		chainSelector: chainSelector,
+		poolKey:       tokenTransferRefKey(ref),
+	}
+}
+
+func (k tokenTransferNodeKey) String() string {
+	return fmt.Sprintf("%d/%s", k.chainSelector, k.poolKey)
+}
+
+type tokenTransferLaneKey struct {
+	from tokenTransferNodeKey
+	to   tokenTransferNodeKey
+}
+
+func (k tokenTransferLaneKey) String() string {
+	return k.from.String() + "->" + k.to.String()
+}
+
+func sortedTokenTransferLaneKeys(lanes map[tokenTransferLaneKey]struct{}) []tokenTransferLaneKey {
+	keys := make([]tokenTransferLaneKey, 0, len(lanes))
+	for lane := range lanes {
+		keys = append(keys, lane)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+	return keys
+}
+
+func tokenTransferConfigForRemote(cfg tokenscore.TokenTransferConfig, remoteSelector uint64) (tokenscore.TokenTransferConfig, error) {
+	remoteCfg, ok := cfg.RemoteChains[remoteSelector]
+	if !ok {
+		return tokenscore.TokenTransferConfig{}, fmt.Errorf("remote selector %d is missing from token transfer config %s", remoteSelector, tokenTransferConfigNodeKey(cfg))
+	}
+	clone := cfg
+	clone.RemoteChains = map[uint64]tokenscore.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+		remoteSelector: remoteCfg,
+	}
+	return clone, nil
+}
+
+func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) ([][]tokenscore.TokenTransferConfig, error) {
+	// Group first so unrelated token pairs never get matched together. Within a
+	// group, batches are emitted per reciprocal lane. This keeps the local pool
+	// in each batch aligned with the RemotePool refs that the changeset will
+	// configure on-chain.
+	byPair := make(map[string][]tokenscore.TokenTransferConfig)
 	for _, cfg := range configs {
-		poolKey := poolPairBatchKey(cfg.TokenPoolRef.Qualifier)
-		byPool[poolKey] = append(byPool[poolKey], cfg)
+		pairKey := canonicalPoolPairKey(cfg.TokenPoolRef)
+		byPair[pairKey] = append(byPair[pairKey], cfg)
 	}
 
-	groupKeys := make([]string, 0, len(byPool))
-	for groupKey := range byPool {
+	groupKeys := make([]string, 0, len(byPair))
+	for groupKey := range byPair {
 		groupKeys = append(groupKeys, groupKey)
 	}
 	sort.Strings(groupKeys)
 
 	batches := make([][]tokenscore.TokenTransferConfig, 0, len(groupKeys))
 	for _, groupKey := range groupKeys {
-		batch := append([]tokenscore.TokenTransferConfig(nil), byPool[groupKey]...)
-		sort.Slice(batch, func(i, j int) bool {
-			return batch[i].ChainSelector < batch[j].ChainSelector
-		})
-		batches = append(batches, batch)
+		group := byPair[groupKey]
+		configByNode := make(map[tokenTransferNodeKey]tokenscore.TokenTransferConfig, len(group))
+		lanes := make(map[tokenTransferLaneKey]struct{})
+		for _, cfg := range group {
+			from := tokenTransferConfigNodeKey(cfg)
+			if _, exists := configByNode[from]; exists {
+				return nil, fmt.Errorf("duplicate token transfer config for %s", from)
+			}
+			configByNode[from] = cfg
+		}
+		for _, cfg := range group {
+			from := tokenTransferConfigNodeKey(cfg)
+			for remoteSelector, remoteCfg := range cfg.RemoteChains {
+				if remoteCfg.RemotePool == nil {
+					return nil, fmt.Errorf("token transfer config %s has nil remote pool for remote selector %d", from, remoteSelector)
+				}
+				to := tokenTransferRemoteNodeKey(remoteSelector, *remoteCfg.RemotePool)
+				if _, exists := configByNode[to]; !exists {
+					return nil, fmt.Errorf("token transfer config %s references remote pool %s, but that pool is not present in the same batch group", from, to)
+				}
+				lanes[tokenTransferLaneKey{from: from, to: to}] = struct{}{}
+			}
+		}
+
+		visited := make(map[tokenTransferLaneKey]bool, len(lanes))
+		for _, lane := range sortedTokenTransferLaneKeys(lanes) {
+			if visited[lane] {
+				continue
+			}
+			reverse := tokenTransferLaneKey{from: lane.to, to: lane.from}
+			if _, exists := lanes[reverse]; !exists {
+				return nil, fmt.Errorf("token transfer lane %s is missing reciprocal lane %s", lane, reverse)
+			}
+			fromCfg, err := tokenTransferConfigForRemote(configByNode[lane.from], lane.to.chainSelector)
+			if err != nil {
+				return nil, err
+			}
+			toCfg, err := tokenTransferConfigForRemote(configByNode[lane.to], lane.from.chainSelector)
+			if err != nil {
+				return nil, err
+			}
+			batch := []tokenscore.TokenTransferConfig{fromCfg, toCfg}
+			sort.Slice(batch, func(i, j int) bool {
+				if batch[i].ChainSelector != batch[j].ChainSelector {
+					return batch[i].ChainSelector < batch[j].ChainSelector
+				}
+				return tokenTransferRefKey(batch[i].TokenPoolRef) < tokenTransferRefKey(batch[j].TokenPoolRef)
+			})
+			batches = append(batches, batch)
+			visited[lane] = true
+			visited[reverse] = true
+		}
 	}
-	return batches
+	return batches, nil
 }

--- a/build/devenv/implcommon_test.go
+++ b/build/devenv/implcommon_test.go
@@ -16,12 +16,13 @@ func TestBuildTokenTransferBatchesMultipleTokensSameSelectors(t *testing.T) {
 	aBar := testTokenPoolRef(1, "bar")
 	bBar := testTokenPoolRef(2, "bar")
 
-	batches := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+	batches, err := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
 		testTokenTransferConfig(aFoo, bFoo),
 		testTokenTransferConfig(bFoo, aFoo),
 		testTokenTransferConfig(aBar, bBar),
 		testTokenTransferConfig(bBar, aBar),
 	})
+	require.NoError(t, err)
 	require.Len(t, batches, 2)
 
 	for _, batch := range batches {
@@ -40,29 +41,33 @@ func TestBuildTokenTransferBatchesSymmetricTokenAcrossAllLanes(t *testing.T) {
 	pool2 := testTokenPoolRef(2, "burn")
 	pool3 := testTokenPoolRef(3, "burn")
 
-	batches := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+	batches, err := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
 		testTokenTransferConfig(pool1, pool2, pool3),
 		testTokenTransferConfig(pool2, pool1, pool3),
 		testTokenTransferConfig(pool3, pool1, pool2),
 	})
-	require.Len(t, batches, 1)
-	require.Len(t, batches[0], 3)
-	requireNoDuplicateTokenTransferSelectors(t, batches[0])
+	require.NoError(t, err)
+	require.Len(t, batches, 3)
 
-	for _, cfg := range batches[0] {
-		require.Len(t, cfg.RemoteChains, 2)
+	for _, batch := range batches {
+		require.Len(t, batch, 2)
+		requireNoDuplicateTokenTransferSelectors(t, batch)
+		for _, cfg := range batch {
+			require.Len(t, cfg.RemoteChains, 1)
+		}
+		requireReciprocalTokenTransferBatch(t, batch)
 	}
 }
 
-func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByLocalPool(t *testing.T) {
-	burn1 := testTokenPoolRef(1, "burn")
-	burn2 := testTokenPoolRef(2, "burn")
-	burn3 := testTokenPoolRef(3, "burn")
-	lock1 := testTokenPoolRef(1, "lock")
-	lock2 := testTokenPoolRef(2, "lock")
-	lock3 := testTokenPoolRef(3, "lock")
+func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByReciprocalLane(t *testing.T) {
+	burn1 := testTokenPoolRef(1, "TEST (burn, lock)::burn")
+	burn2 := testTokenPoolRef(2, "TEST (burn, lock)::burn")
+	burn3 := testTokenPoolRef(3, "TEST (burn, lock)::burn")
+	lock1 := testTokenPoolRef(1, "TEST (burn, lock)::lock")
+	lock2 := testTokenPoolRef(2, "TEST (burn, lock)::lock")
+	lock3 := testTokenPoolRef(3, "TEST (burn, lock)::lock")
 
-	batches := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+	batches, err := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
 		testTokenTransferConfig(burn1, lock2, lock3),
 		testTokenTransferConfig(burn2, lock1, lock3),
 		testTokenTransferConfig(burn3, lock1, lock2),
@@ -70,49 +75,161 @@ func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByLocalPool(t *testing.T) 
 		testTokenTransferConfig(lock2, burn1, burn3),
 		testTokenTransferConfig(lock3, burn1, burn2),
 	})
-	require.Len(t, batches, 2)
+	require.NoError(t, err)
+	require.Len(t, batches, 6)
 
-	seenQualifiers := make(map[string]bool)
 	for _, batch := range batches {
-		require.Len(t, batch, 3)
+		require.Len(t, batch, 2)
 		requireNoDuplicateTokenTransferSelectors(t, batch)
-
-		qualifier := batch[0].TokenPoolRef.Qualifier
-		seenQualifiers[qualifier] = true
 		for _, cfg := range batch {
-			require.Equal(t, qualifier, cfg.TokenPoolRef.Qualifier)
-			require.Len(t, cfg.RemoteChains, 2)
+			require.Len(t, cfg.RemoteChains, 1)
 		}
+		requireReciprocalTokenTransferBatch(t, batch)
 	}
-	require.Equal(t, map[string]bool{"burn": true, "lock": true}, seenQualifiers)
 }
 
 // TestBuildTokenTransferBatchesCrossTypePools verifies that an EVM
 // BurnMintTokenPool and a Canton LockReleaseTokenPool for the same token pair
-// land in the same batch. Both carry the canonical pair qualifier produced by
-// TokenCombination, differing only in the ":local" / ":remote" suffix.
+// land in the same batch even though their pool types differ.
 func TestBuildTokenTransferBatchesCrossTypePools(t *testing.T) {
 	const pairQualifier = "TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 2.0.0 [default])"
 	evmPool := datastore.AddressRef{
 		ChainSelector: 1,
 		Type:          datastore.ContractType("BurnMintTokenPool"),
 		Version:       semver.MustParse("2.0.0"),
-		Qualifier:     pairQualifier + ":local",
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 2.0.0 [default]",
 	}
 	cantonPool := datastore.AddressRef{
 		ChainSelector: 2,
 		Type:          datastore.ContractType("LockReleaseTokenPool"),
 		Version:       semver.MustParse("2.0.0"),
-		Qualifier:     pairQualifier + ":remote",
+		Qualifier:     pairQualifier + "::LockReleaseTokenPool 2.0.0 [default]",
 	}
 
-	batches := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+	batches, err := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
 		testTokenTransferConfig(evmPool, cantonPool),
 		testTokenTransferConfig(cantonPool, evmPool),
 	})
+	require.NoError(t, err)
 	require.Len(t, batches, 1)
 	require.Len(t, batches[0], 2)
 	requireNoDuplicateTokenTransferSelectors(t, batches[0])
+	requireReciprocalTokenTransferBatch(t, batches[0])
+}
+
+func TestBuildTokenTransferBatchesCrossTypePoolsSupportsDirectionalQualifiers(t *testing.T) {
+	evmPool := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     "TEST (BurnMintTokenPool 2.0.0 [default] to LockReleaseTokenPool 2.0.0 [default])",
+	}
+	cantonPool := datastore.AddressRef{
+		ChainSelector: 2,
+		Type:          datastore.ContractType("LockReleaseTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     "TEST (LockReleaseTokenPool 2.0.0 [default] to BurnMintTokenPool 2.0.0 [default])",
+	}
+
+	batches, err := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+		testTokenTransferConfig(evmPool, cantonPool),
+		testTokenTransferConfig(cantonPool, evmPool),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, batches, 1)
+	require.Len(t, batches[0], 2)
+	requireNoDuplicateTokenTransferSelectors(t, batches[0])
+	requireReciprocalTokenTransferBatch(t, batches[0])
+}
+
+func TestBuildTokenTransferBatchesCrossTypePoolsSplitDuplicateSelectors(t *testing.T) {
+	const pairQualifier = "TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 2.0.0 [default])"
+	burn1 := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 2.0.0 [default]",
+	}
+	lock1 := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("LockReleaseTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::LockReleaseTokenPool 2.0.0 [default]",
+	}
+	burn2 := datastore.AddressRef{
+		ChainSelector: 2,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 2.0.0 [default]",
+	}
+	lock2 := datastore.AddressRef{
+		ChainSelector: 2,
+		Type:          datastore.ContractType("LockReleaseTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::LockReleaseTokenPool 2.0.0 [default]",
+	}
+
+	batches, err := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+		testTokenTransferConfig(burn1, lock2),
+		testTokenTransferConfig(lock1, burn2),
+		testTokenTransferConfig(burn2, lock1),
+		testTokenTransferConfig(lock2, burn1),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, batches, 2)
+	for _, batch := range batches {
+		require.Len(t, batch, 2)
+		requireNoDuplicateTokenTransferSelectors(t, batch)
+		requireReciprocalTokenTransferBatch(t, batch)
+	}
+}
+
+// TestBuildTokenTransferBatchesSameTypeVersionsSplitByLocalVersion verifies that
+// BurnMint 1.6.1 <-> BurnMint 2.0.0 configs stay in separate batches. Both pool
+// versions exist on each chain, and the upstream changeset can only take one
+// config per selector in a call.
+func TestBuildTokenTransferBatchesSameTypeVersionsSplitByLocalVersion(t *testing.T) {
+	const pairQualifier = "TEST (BurnMintTokenPool 1.6.1 [], BurnMintTokenPool 2.0.0 [default])"
+	chain1v161 := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("1.6.1"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 1.6.1 []",
+	}
+	chain2v200 := datastore.AddressRef{
+		ChainSelector: 2,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 2.0.0 [default]",
+	}
+	chain1v200 := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 2.0.0 [default]",
+	}
+	chain2v161 := datastore.AddressRef{
+		ChainSelector: 2,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("1.6.1"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 1.6.1 []",
+	}
+
+	batches, err := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+		testTokenTransferConfig(chain1v161, chain2v200),
+		testTokenTransferConfig(chain2v161, chain1v200),
+		testTokenTransferConfig(chain1v200, chain2v161),
+		testTokenTransferConfig(chain2v200, chain1v161),
+	})
+	require.NoError(t, err)
+	require.Len(t, batches, 2)
+	for _, batch := range batches {
+		require.Len(t, batch, 2)
+		requireNoDuplicateTokenTransferSelectors(t, batch)
+		requireReciprocalTokenTransferBatch(t, batch)
+	}
 }
 
 func testTokenPoolRef(selector uint64, qualifier string) datastore.AddressRef {
@@ -145,5 +262,22 @@ func requireNoDuplicateTokenTransferSelectors(t *testing.T, batch []tokenscore.T
 	for _, cfg := range batch {
 		require.False(t, seen[cfg.ChainSelector], "duplicate selector %d in token transfer batch", cfg.ChainSelector)
 		seen[cfg.ChainSelector] = true
+	}
+}
+
+func requireReciprocalTokenTransferBatch(t *testing.T, batch []tokenscore.TokenTransferConfig) {
+	t.Helper()
+
+	bySelector := make(map[uint64]tokenscore.TokenTransferConfig, len(batch))
+	for _, cfg := range batch {
+		bySelector[cfg.ChainSelector] = cfg
+	}
+	for _, cfg := range batch {
+		for remoteSelector, remoteCfg := range cfg.RemoteChains {
+			require.NotNil(t, remoteCfg.RemotePool)
+			counterpart, ok := bySelector[remoteSelector]
+			require.True(t, ok, "batch is missing remote selector %d", remoteSelector)
+			require.Equal(t, tokenTransferRefKey(counterpart.TokenPoolRef), tokenTransferRefKey(*remoteCfg.RemotePool))
+		}
 	}
 }

--- a/build/devenv/implcommon_test.go
+++ b/build/devenv/implcommon_test.go
@@ -47,19 +47,17 @@ func TestBuildTokenTransferBatchesSymmetricTokenAcrossAllLanes(t *testing.T) {
 		testTokenTransferConfig(pool3, pool1, pool2),
 	})
 	require.NoError(t, err)
-	require.Len(t, batches, 3)
+	require.Len(t, batches, 1)
 
-	for _, batch := range batches {
-		require.Len(t, batch, 2)
-		requireNoDuplicateTokenTransferSelectors(t, batch)
-		for _, cfg := range batch {
-			require.Len(t, cfg.RemoteChains, 1)
-		}
-		requireReciprocalTokenTransferBatch(t, batch)
+	require.Len(t, batches[0], 3)
+	requireNoDuplicateTokenTransferSelectors(t, batches[0])
+	for _, cfg := range batches[0] {
+		require.Len(t, cfg.RemoteChains, 2)
+		requireBatchContainsRemoteSelectors(t, batches[0], cfg)
 	}
 }
 
-func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByReciprocalLane(t *testing.T) {
+func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByLocalPoolInstance(t *testing.T) {
 	burn1 := testTokenPoolRef(1, "TEST (burn, lock)::burn")
 	burn2 := testTokenPoolRef(2, "TEST (burn, lock)::burn")
 	burn3 := testTokenPoolRef(3, "TEST (burn, lock)::burn")
@@ -76,15 +74,17 @@ func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByReciprocalLane(t *testin
 		testTokenTransferConfig(lock3, burn1, burn2),
 	})
 	require.NoError(t, err)
-	require.Len(t, batches, 6)
+	require.Len(t, batches, 2)
 
 	for _, batch := range batches {
-		require.Len(t, batch, 2)
+		require.Len(t, batch, 3)
 		requireNoDuplicateTokenTransferSelectors(t, batch)
+		qualifier := batch[0].TokenPoolRef.Qualifier
 		for _, cfg := range batch {
-			require.Len(t, cfg.RemoteChains, 1)
+			require.Equal(t, qualifier, cfg.TokenPoolRef.Qualifier)
+			require.Len(t, cfg.RemoteChains, 2)
+			requireBatchContainsRemoteSelectors(t, batch, cfg)
 		}
-		requireReciprocalTokenTransferBatch(t, batch)
 	}
 }
 
@@ -182,7 +182,10 @@ func TestBuildTokenTransferBatchesCrossTypePoolsSplitDuplicateSelectors(t *testi
 	for _, batch := range batches {
 		require.Len(t, batch, 2)
 		requireNoDuplicateTokenTransferSelectors(t, batch)
-		requireReciprocalTokenTransferBatch(t, batch)
+		for _, cfg := range batch {
+			require.Len(t, cfg.RemoteChains, 1)
+			requireBatchContainsRemoteSelectors(t, batch, cfg)
+		}
 	}
 }
 
@@ -228,7 +231,10 @@ func TestBuildTokenTransferBatchesSameTypeVersionsSplitByLocalVersion(t *testing
 	for _, batch := range batches {
 		require.Len(t, batch, 2)
 		requireNoDuplicateTokenTransferSelectors(t, batch)
-		requireReciprocalTokenTransferBatch(t, batch)
+		for _, cfg := range batch {
+			require.Len(t, cfg.RemoteChains, 1)
+			requireBatchContainsRemoteSelectors(t, batch, cfg)
+		}
 	}
 }
 
@@ -279,5 +285,18 @@ func requireReciprocalTokenTransferBatch(t *testing.T, batch []tokenscore.TokenT
 			require.True(t, ok, "batch is missing remote selector %d", remoteSelector)
 			require.Equal(t, tokenTransferRefKey(counterpart.TokenPoolRef), tokenTransferRefKey(*remoteCfg.RemotePool))
 		}
+	}
+}
+
+func requireBatchContainsRemoteSelectors(t *testing.T, batch []tokenscore.TokenTransferConfig, cfg tokenscore.TokenTransferConfig) {
+	t.Helper()
+
+	selectors := make(map[uint64]struct{}, len(batch))
+	for _, batchCfg := range batch {
+		selectors[batchCfg.ChainSelector] = struct{}{}
+	}
+	for remoteSelector := range cfg.RemoteChains {
+		_, ok := selectors[remoteSelector]
+		require.True(t, ok, "batch is missing remote selector %d", remoteSelector)
 	}
 }

--- a/build/devenv/implcommon_test.go
+++ b/build/devenv/implcommon_test.go
@@ -87,6 +87,34 @@ func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByLocalPool(t *testing.T) 
 	require.Equal(t, map[string]bool{"burn": true, "lock": true}, seenQualifiers)
 }
 
+// TestBuildTokenTransferBatchesCrossTypePools verifies that an EVM
+// BurnMintTokenPool and a Canton LockReleaseTokenPool for the same token pair
+// land in the same batch. Both carry the canonical pair qualifier produced by
+// TokenCombination, differing only in the ":local" / ":remote" suffix.
+func TestBuildTokenTransferBatchesCrossTypePools(t *testing.T) {
+	const pairQualifier = "TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 2.0.0 [default])"
+	evmPool := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + ":local",
+	}
+	cantonPool := datastore.AddressRef{
+		ChainSelector: 2,
+		Type:          datastore.ContractType("LockReleaseTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + ":remote",
+	}
+
+	batches := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+		testTokenTransferConfig(evmPool, cantonPool),
+		testTokenTransferConfig(cantonPool, evmPool),
+	})
+	require.Len(t, batches, 1)
+	require.Len(t, batches[0], 2)
+	requireNoDuplicateTokenTransferSelectors(t, batches[0])
+}
+
 func testTokenPoolRef(selector uint64, qualifier string) datastore.AddressRef {
 	return datastore.AddressRef{
 		ChainSelector: selector,


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Fixes generic token transfer setup for mixed EVM/Canton environments.

The previous token-pool qualifiers were directional, so the same logical token pair could produce different local pool refs depending on which side built the config. That made batching brittle: reciprocal EVM -> Canton and Canton -> EVM `TokenTransferConfig`s could be split apart even though `ConfigureTokensForTransfers` expects both sides of a remote chain relationship in the same call.

This PR makes token-pool qualifiers reciprocal by separating the logical pair identity from the concrete pool instance, then updates batching to group configs by the canonical pair while preserving each pool’s full `RemoteChains` set. It also adds validation so missing reciprocal pool configs fail earlier with a useful error instead of surfacing as harder-to-debug pool compatibility failures.

Related Canton consumer PR: https://github.com/smartcontractkit/chainlink-canton/pull/440

## Testing

devenv tests

## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
