### PR TITLE
build/devenv: rm Curse/Uncurse methods, use fastcurse API

### DIFF
--- a/build/devenv/cciptestinterfaces/interface.go
+++ b/build/devenv/cciptestinterfaces/interface.go
@@ -154,10 +154,6 @@ type Chain interface {
 	GetMaxDataBytes(ctx context.Context, remoteChainSelector uint64) (uint32, error)
 	// ManuallyExecuteMessage manually executes a message on this chain and returns an error if the execution fails.
 	ManuallyExecuteMessage(ctx context.Context, message protocol.Message, gasLimit uint64, ccvs []protocol.UnknownAddress, verifierResults [][]byte) (ExecutionStateChangedEvent, error)
-	// Curse curses a list of chains on this chain.
-	Curse(ctx context.Context, subjects [][16]byte) error
-	// Uncurse uncurses a list of chains on this chain.
-	Uncurse(ctx context.Context, subjects [][16]byte) error
 	// ChainSelector gets the selector for this chain.
 	ChainSelector() uint64
 	// NativeBalance returns the native token balance of the given address on this chain.

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -539,7 +539,6 @@ func buildEnvironmentTopology(in *Cfg, e *deployment.Environment) *ccvdeployment
 func generateExecutorJobSpecs(
 	e *deployment.Environment,
 	in *Cfg,
-	selectors []uint64,
 	topology *ccvdeployment.EnvironmentTopology,
 	ds datastore.MutableDataStore,
 ) (map[string]bootstrap.JobSpec, error) {
@@ -617,7 +616,6 @@ func generateExecutorJobSpecs(
 func generateVerifierJobSpecs(
 	e *deployment.Environment,
 	in *Cfg,
-	selectors []uint64,
 	topology *ccvdeployment.EnvironmentTopology,
 	sharedTLSCerts *services.TLSCertPaths,
 	ds datastore.MutableDataStore,
@@ -1350,7 +1348,7 @@ func NewEnvironment() (in *Cfg, err error) {
 	// START: Launch executors //
 	/////////////////////////////
 
-	executorJobSpecs, err := generateExecutorJobSpecs(e, in, selectors, topology, ds)
+	executorJobSpecs, err := generateExecutorJobSpecs(e, in, topology, ds)
 	if err != nil {
 		return nil, err
 	}
@@ -1381,7 +1379,7 @@ func NewEnvironment() (in *Cfg, err error) {
 	// START: Launch verifiers //
 	/////////////////////////////
 
-	verifierJobSpecs, err := generateVerifierJobSpecs(e, in, selectors, topology, sharedTLSCerts, ds)
+	verifierJobSpecs, err := generateVerifierJobSpecs(e, in, topology, sharedTLSCerts, ds)
 	if err != nil {
 		return nil, err
 	}

--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -32,7 +32,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
 
 	adapters_1_6_1 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/adapters"
-	rmn_remote_binding "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
@@ -1750,114 +1749,6 @@ func (m *CCIP17EVM) ManuallyExecuteMessage(
 		Msg("Execution transaction mined")
 
 	return event, nil
-}
-
-// ============================================================================
-// RMN Curse Operations
-// ============================================================================
-
-// getRMNRemoteAddress returns the RMN Remote contract address for a given chain.
-func (m *CCIP17EVM) getRMNRemoteAddress() (common.Address, error) {
-	rmnRemoteRef, err := m.e.DataStore.Addresses().Get(
-		datastore.NewAddressRefKey(
-			m.chainDetails.ChainSelector,
-			datastore.ContractType(rmn_remote.ContractType),
-			rmn_remote.Version,
-			"",
-		),
-	)
-	if err != nil {
-		return common.Address{}, fmt.Errorf("failed to get RMN Remote address for chain %d: %w", m.chainDetails.ChainSelector, err)
-	}
-	return common.HexToAddress(rmnRemoteRef.Address), nil
-}
-
-func (m *CCIP17EVM) getRMNRemote() (*rmn_remote_binding.RMNRemote, error) {
-	rmnRemoteAddr, err := m.getRMNRemoteAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	rmnRemote, err := rmn_remote_binding.NewRMNRemote(rmnRemoteAddr, m.ethClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create RMN Remote contract binding: %w", err)
-	}
-	return rmnRemote, nil
-}
-
-// Curse applies curses to the RMN Remote contract on a given chain.
-// The subjects parameter contains the curse subjects (either chain selectors or global curse).
-func (m *CCIP17EVM) Curse(ctx context.Context, subjects [][16]byte) error {
-	rmnRemote, err := m.getRMNRemote()
-	if err != nil {
-		return err
-	}
-
-	// Get deployer key for transaction signing
-	txOpts := m.e.BlockChains.EVMChains()[m.chainDetails.ChainSelector].DeployerKey
-	if txOpts == nil {
-		return fmt.Errorf("deployer key not found for chain %d", m.chainDetails.ChainSelector)
-	}
-
-	// Call Curse method
-	tx, err := rmnRemote.Curse0(txOpts, subjects)
-	if err != nil {
-		return fmt.Errorf("failed to call Curse on RMN Remote: %w", err)
-	}
-
-	// Wait for transaction receipt
-	receipt, err := bind.WaitMined(ctx, m.ethClient, tx.Hash())
-	if err != nil {
-		return fmt.Errorf("failed to wait for curse transaction: %w", err)
-	}
-	if receipt.Status != types.ReceiptStatusSuccessful {
-		return fmt.Errorf("curse transaction failed")
-	}
-
-	m.logger.Info().
-		Uint64("chain", m.chainDetails.ChainSelector).
-		Str("tx", tx.Hash().Hex()).
-		Int("numSubjects", len(subjects)).
-		Msg("Cursed subjects on chain")
-
-	return nil
-}
-
-// Uncurse removes curses from the RMN Remote contract on a given chain.
-// The subjects parameter contains the curse subjects to remove (either chain selectors or global curse).
-func (m *CCIP17EVM) Uncurse(ctx context.Context, subjects [][16]byte) error {
-	rmnRemote, err := m.getRMNRemote()
-	if err != nil {
-		return err
-	}
-
-	// Get deployer key for transaction signing
-	txOpts := m.e.BlockChains.EVMChains()[m.chainDetails.ChainSelector].DeployerKey
-	if txOpts == nil {
-		return fmt.Errorf("deployer key not found for chain %d", m.chainDetails.ChainSelector)
-	}
-
-	tx, err := rmnRemote.Uncurse0(txOpts, subjects)
-	if err != nil {
-		return fmt.Errorf("failed to call Uncurse on RMN Remote: %w", err)
-	}
-
-	// Wait for transaction receipt
-	receipt, err := bind.WaitMined(ctx, m.ethClient, tx.Hash())
-	if err != nil {
-		return fmt.Errorf("failed to wait for uncurse transaction: %w", err)
-	}
-	if receipt.Status != types.ReceiptStatusSuccessful {
-		return fmt.Errorf("uncurse transaction failed")
-	}
-
-	m.logger.Info().
-		Uint64("chain", m.chainDetails.ChainSelector).
-		Str("tx", tx.Hash().Hex()).
-		Int("numSubjects", len(subjects)).
-		Msg("Applied uncurse on chain")
-
-	return nil
 }
 
 func (m *CCIP17EVM) GetRoundRobinUser() func() *bind.TransactOpts {

--- a/build/devenv/lib.go
+++ b/build/devenv/lib.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/registry"
 	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/client"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 type ChainImpl struct {
@@ -26,6 +27,7 @@ type Lib struct {
 	cfg            *Cfg
 	l              *zerolog.Logger
 	familiesToLoad []string
+	cldfEnv        *deployment.Environment
 }
 
 // NewLib creates a new Lib object given a logger and envOutFile.
@@ -39,11 +41,18 @@ func NewLib(logger *zerolog.Logger, envOutFile string, familiesToLoad ...string)
 		return nil, fmt.Errorf("failed to load environment output: %w", err)
 	}
 
+	// Load CLDF env
+	_, env, err := NewCLDFOperationsEnvironment(cfg.Blockchains, cfg.CLDF.DataStore)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CLDF operations environment: %w", err)
+	}
+
 	lib := &Lib{
 		envOutFile:     envOutFile,
 		cfg:            cfg,
 		l:              logger,
 		familiesToLoad: familiesToLoad,
+		cldfEnv:        env,
 	}
 
 	if err := lib.verify(); err != nil {
@@ -83,7 +92,18 @@ func (l *Lib) verify() error {
 	if l.l == nil {
 		return fmt.Errorf("logger is nil")
 	}
+	if l.cldfEnv == nil {
+		return fmt.Errorf("CLDF environment is nil")
+	}
 	return nil
+}
+
+// CLDFEnvironment returns the CLDF environment.
+func (l *Lib) CLDFEnvironment() (*deployment.Environment, error) {
+	if err := l.verify(); err != nil {
+		return nil, fmt.Errorf("failed to initialize CLDF environment: %w", err)
+	}
+	return l.cldfEnv, nil
 }
 
 func (l *Lib) DataStore() (datastore.DataStore, error) {
@@ -134,11 +154,6 @@ func (l *Lib) Chains(ctx context.Context) ([]ChainImpl, error) {
 		return nil, fmt.Errorf("invalid library object: %w", err)
 	}
 
-	_, env, err := NewCLDFOperationsEnvironment(l.cfg.Blockchains, l.cfg.CLDF.DataStore)
-	if err != nil {
-		return nil, fmt.Errorf("creating CLDF operations environment: %w", err)
-	}
-
 	// Track which selectors were handled from the cfg so we can append registry-only entries afterwards.
 	chainImplRegistry := registry.GetGlobalChainImplRegistry()
 	seen := make(map[uint64]struct{})
@@ -165,7 +180,7 @@ func (l *Lib) Chains(ctx context.Context) ([]ChainImpl, error) {
 		if err != nil {
 			return nil, fmt.Errorf("getting implementation factory for chain ID %s selector %d family %s: %w", bc.ChainID, details.ChainSelector, bc.Out.Family, err)
 		}
-		impl, err := fac.New(ctx, l.cfg, *l.l, env, bc)
+		impl, err := fac.New(ctx, l.cfg, *l.l, l.cldfEnv, bc)
 		if err != nil {
 			return nil, fmt.Errorf("creating implementation for chain ID %s selector %d family %s: %w", bc.ChainID, details.ChainSelector, bc.Out.Family, err)
 		}

--- a/build/devenv/tests/e2e/finality_reorg_curse_test.go
+++ b/build/devenv/tests/e2e/finality_reorg_curse_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 )
 
@@ -173,7 +174,7 @@ func TestE2EReorg(t *testing.T) {
 
 	// Helper function to verify a message exists in aggregator (with polling)
 	verifyMessageExists := func(messageID [32]byte, description string) {
-		waitCtx, waitCancel := context.WithTimeout(ctx, 30*time.Second)
+		waitCtx, waitCancel := context.WithTimeout(ctx, 60*time.Second)
 		defer waitCancel()
 		result, err := defaultAggregatorClient.WaitForVerifierResultForMessage(waitCtx, messageID, 500*time.Millisecond)
 		require.NoError(t, err, "%s should be found after finality", description)
@@ -780,8 +781,12 @@ func TestE2EReorg(t *testing.T) {
 }
 
 func curseSelector(t *testing.T, env *deployment.Environment, adapter fastcurse.CurseAdapter, chainSelector, subjectChainSelector uint64, globalCurse bool) {
+	// re-set the bundle so it doesn't cache previous curses.
+	bundle := operations.NewBundle(env.GetContext, env.Logger, operations.NewMemoryReporter())
+	env.OperationsBundle = bundle
+
 	curseCS := fastcurse.CurseChangeset(fastcurse.GetCurseRegistry(), changesets.GetRegistry())
-	output, err := curseCS.Apply(*env, fastcurse.RMNCurseConfig{
+	_, err := curseCS.Apply(*env, fastcurse.RMNCurseConfig{
 		CurseActions: []fastcurse.CurseActionInput{
 			{
 				ChainSelector:        chainSelector,
@@ -792,7 +797,6 @@ func curseSelector(t *testing.T, env *deployment.Environment, adapter fastcurse.
 		},
 	})
 	require.NoError(t, err)
-	require.Greater(t, len(output.Reports), 0)
 
 	// Verify the curse is applied
 	if subjectChainSelector != 0 {
@@ -805,11 +809,19 @@ func curseSelector(t *testing.T, env *deployment.Environment, adapter fastcurse.
 		require.NoError(t, err)
 		require.True(t, isCursed, "global curse should be active on chain")
 	}
+
+	// Wait for the verifier to detect the curse.
+	// The verifier is hardcoded to poll every 2 seconds, wait for 3 seconds to be sure.
+	time.Sleep(3 * time.Second)
 }
 
 func uncurseSelector(t *testing.T, env *deployment.Environment, adapter fastcurse.CurseAdapter, chainSelector, subjectChainSelector uint64, globalCurse bool) {
+	// re-set the bundle so it doesn't cache previous uncurses.
+	bundle := operations.NewBundle(env.GetContext, env.Logger, operations.NewMemoryReporter())
+	env.OperationsBundle = bundle
+
 	uncurseCS := fastcurse.UncurseChangeset(fastcurse.GetCurseRegistry(), changesets.GetRegistry())
-	output, err := uncurseCS.Apply(*env, fastcurse.RMNCurseConfig{
+	_, err := uncurseCS.Apply(*env, fastcurse.RMNCurseConfig{
 		CurseActions: []fastcurse.CurseActionInput{
 			{
 				ChainSelector:        chainSelector,
@@ -820,7 +832,6 @@ func uncurseSelector(t *testing.T, env *deployment.Environment, adapter fastcurs
 		},
 	})
 	require.NoError(t, err)
-	require.Greater(t, len(output.Reports), 0)
 
 	// Verify the curse is lifted
 	if subjectChainSelector != 0 {
@@ -833,4 +844,8 @@ func uncurseSelector(t *testing.T, env *deployment.Environment, adapter fastcurs
 		require.NoError(t, err)
 		require.False(t, isCursed, "global curse should not be active on chain")
 	}
+
+	// Wait for the verifier to detect the uncurse.
+	// The verifier is hardcoded to poll every 2 seconds, wait for 3 seconds to be sure.
+	time.Sleep(3 * time.Second)
 }

--- a/build/devenv/tests/e2e/finality_reorg_curse_test.go
+++ b/build/devenv/tests/e2e/finality_reorg_curse_test.go
@@ -87,6 +87,11 @@ func TestE2EReorg(t *testing.T) {
 	destImpl := chains[1]
 	dest2Impl := chains[2]
 
+	curseAdapter, ok := fastcurse.GetCurseRegistry().GetCurseAdapter(chain_selectors.FamilyEVM, semver.MustParse("1.6.0"))
+	require.True(t, ok)
+	require.NotNil(t, curseAdapter)
+	require.NoError(t, curseAdapter.Initialize(*cldfEnv, srcImpl.ChainSelector()))
+
 	srcSelector := srcImpl.Details.ChainSelector
 	destSelector := destImpl.Details.ChainSelector
 	destSelector2 := dest2Impl.Details.ChainSelector
@@ -161,19 +166,19 @@ func TestE2EReorg(t *testing.T) {
 	// Helper to log a sent message event
 	logSentMessage := func(event cciptestinterfaces.MessageSentEvent, description string) {
 		l.Info().
-			Str("messageID", fmt.Sprintf("%x", event.MessageID)).
+			Str("messageID", fmt.Sprintf("%x", event.MessageID[:])).
 			Int("seqNumber", int(event.Message.SequenceNumber)).
 			Msgf("📨 %s", description)
 	}
 
 	// Helper function to verify a message exists in aggregator (with polling)
 	verifyMessageExists := func(messageID [32]byte, description string) {
-		waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+		waitCtx, waitCancel := context.WithTimeout(ctx, 30*time.Second)
 		defer waitCancel()
 		result, err := defaultAggregatorClient.WaitForVerifierResultForMessage(waitCtx, messageID, 500*time.Millisecond)
 		require.NoError(t, err, "%s should be found after finality", description)
 		l.Info().
-			Str("messageID", fmt.Sprintf("%x", messageID)).
+			Str("messageID", fmt.Sprintf("%x", messageID[:])).
 			Str("verifierResult", fmt.Sprintf("%x", result)).
 			Msgf("✅ %s verified in aggregator after finality", description)
 	}
@@ -267,7 +272,7 @@ func TestE2EReorg(t *testing.T) {
 
 		l.Info().Msg("Applying lane curse between chain0 and chain1 (before message gets picked up by verifier)")
 		// normally it's bidirectional, for the sake of the test we only curse one direction
-		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
+		curseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector, false)
 
 		l.Info().Msg("🔍 Asserting message reached verifier but was dropped due to curse")
 		assertCtx, assertCancel := context.WithTimeout(ctx, 100*time.Second)
@@ -276,7 +281,7 @@ func TestE2EReorg(t *testing.T) {
 		_, err = logAssert.WaitForStage(assertCtx, msg1ID, logasserter.MessageDroppedInVerifier())
 		require.NoError(t, err, "message should be dropped in verifier due to curse")
 		l.Info().
-			Str("messageID", fmt.Sprintf("%x", msg1ID)).
+			Str("messageID", fmt.Sprintf("%x", msg1ID[:])).
 			Msg("✅ Confirmed message was dropped in verifier after curse")
 
 		// Verify the message is NOT in the aggregator (it was dropped, not processed)
@@ -297,7 +302,7 @@ func TestE2EReorg(t *testing.T) {
 
 		// Uncurse the lane
 		l.Info().Msg("🔓 Uncursing the cursed lane")
-		uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
+		uncurseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector, false)
 
 		// Send a message again on the previously cursed lane to verify it works now
 		event3, err := srcImpl.SendMessage(ctx, destSelector, newMessageFields(receiver, "message 2 after uncurse"), defaultMessageOptions, defaultMessageVersion)
@@ -342,7 +347,7 @@ func TestE2EReorg(t *testing.T) {
 		advanceBlocks(verifier.ConfirmationDepth / 5)
 
 		l.Info().Msg("🌐 Applying GLOBAL curse to source chain (affects ALL lanes from this chain)")
-		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), 0, true)
+		curseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), 0, true)
 
 		l.Info().Msg("🔍 Asserting BOTH messages are dropped due to global curse")
 		assertCtx, assertCancel := context.WithTimeout(ctx, 100*time.Second)
@@ -352,14 +357,14 @@ func TestE2EReorg(t *testing.T) {
 		_, err = logAssert.WaitForStage(assertCtx, msg1ID, logasserter.MessageDroppedInVerifier())
 		require.NoError(t, err, "message to chain1 should be dropped due to global curse")
 		l.Info().
-			Str("messageID", fmt.Sprintf("%x", msg1ID)).
+			Str("messageID", fmt.Sprintf("%x", msg1ID[:])).
 			Msg("✅ Confirmed message to chain1 was dropped due to global curse")
 
 		// Verify message to chain2 is dropped
 		_, err = logAssert.WaitForStage(assertCtx, msg2ID, logasserter.MessageDroppedInVerifier())
 		require.NoError(t, err, "message to chain2 should be dropped due to global curse")
 		l.Info().
-			Str("messageID", fmt.Sprintf("%x", msg2ID)).
+			Str("messageID", fmt.Sprintf("%x", msg2ID[:])).
 			Msg("✅ Confirmed message to chain2 was dropped due to global curse")
 
 		// Verify BOTH messages are NOT in the aggregator
@@ -368,7 +373,7 @@ func TestE2EReorg(t *testing.T) {
 
 		// Uncurse the chain
 		l.Info().Msg("🔓 Removing global curse from source chain")
-		uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), 0, true)
+		uncurseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), 0, true)
 
 		// Send new messages after uncurse to verify both lanes work
 		l.Info().Msg("📨 Sending messages after global uncurse to verify lanes work")
@@ -390,9 +395,9 @@ func TestE2EReorg(t *testing.T) {
 	})
 
 	t.Run("lane curse blocks one lane while peer lane keeps verifying traffic", func(t *testing.T) {
-		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
+		curseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector, false)
 		t.Cleanup(func() {
-			uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
+			uncurseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector, false)
 		})
 
 		_, err := srcImpl.SendMessage(ctx, destSelector, newMessageFields(receiver, "blocked lane msg"), defaultMessageOptions, defaultMessageVersion)
@@ -415,9 +420,9 @@ func TestE2EReorg(t *testing.T) {
 	})
 
 	t.Run("curse on dest2 lane does not block dest1 lane", func(t *testing.T) {
-		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector2, false)
+		curseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector2, false)
 		t.Cleanup(func() {
-			uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector2, false)
+			uncurseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector2, false)
 		})
 
 		_, err = srcImpl.SendMessage(ctx, destSelector2, newMessageFields(receiver2, "blocked dest2 msg"), defaultMessageOptions, defaultMessageVersion)
@@ -474,9 +479,9 @@ func TestE2EReorg(t *testing.T) {
 		_, err = logAssert.WaitForStage(reachedCtx, droppedMsgID, logasserter.MessageReachedVerifier())
 		require.NoError(t, err, "message should reach verifier pending queue before curse is applied")
 
-		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
+		curseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector, false)
 		t.Cleanup(func() {
-			uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
+			uncurseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector, false)
 		})
 
 		dropCtx, dropCancel := context.WithTimeout(ctx, 60*time.Second)
@@ -491,7 +496,7 @@ func TestE2EReorg(t *testing.T) {
 		advanceBlocks(verifier.ConfirmationDepth*3 + 30)
 		verifyMessageNotExists(droppedMsgID, "Dropped message should not reach aggregator while cursed")
 
-		uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
+		uncurseSelector(t, cldfEnv, curseAdapter, srcImpl.ChainSelector(), destSelector, false)
 
 		// With the checkpoint past the message block, uncursing on-chain alone must not replay it.
 		advanceBlocks(verifier.ConfirmationDepth + 5)
@@ -774,7 +779,7 @@ func TestE2EReorg(t *testing.T) {
 	})
 }
 
-func curseSelector(t *testing.T, env *deployment.Environment, chainSelector, subjectChainSelector uint64, globalCurse bool) {
+func curseSelector(t *testing.T, env *deployment.Environment, adapter fastcurse.CurseAdapter, chainSelector, subjectChainSelector uint64, globalCurse bool) {
 	curseCS := fastcurse.CurseChangeset(fastcurse.GetCurseRegistry(), changesets.GetRegistry())
 	output, err := curseCS.Apply(*env, fastcurse.RMNCurseConfig{
 		CurseActions: []fastcurse.CurseActionInput{
@@ -788,9 +793,21 @@ func curseSelector(t *testing.T, env *deployment.Environment, chainSelector, sub
 	})
 	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
+
+	// Verify the curse is applied
+	if subjectChainSelector != 0 {
+		isCursed, err := adapter.IsSubjectCursedOnChain(*env, chainSelector, fastcurse.GenericSelectorToSubject(subjectChainSelector))
+		require.NoError(t, err)
+		require.True(t, isCursed, "subject should be cursed on chain")
+	}
+	if globalCurse {
+		isCursed, err := adapter.IsSubjectCursedOnChain(*env, chainSelector, fastcurse.GlobalCurseSubject())
+		require.NoError(t, err)
+		require.True(t, isCursed, "global curse should be active on chain")
+	}
 }
 
-func uncurseSelector(t *testing.T, env *deployment.Environment, chainSelector, subjectChainSelector uint64, globalCurse bool) {
+func uncurseSelector(t *testing.T, env *deployment.Environment, adapter fastcurse.CurseAdapter, chainSelector, subjectChainSelector uint64, globalCurse bool) {
 	uncurseCS := fastcurse.UncurseChangeset(fastcurse.GetCurseRegistry(), changesets.GetRegistry())
 	output, err := uncurseCS.Apply(*env, fastcurse.RMNCurseConfig{
 		CurseActions: []fastcurse.CurseActionInput{
@@ -804,4 +821,16 @@ func uncurseSelector(t *testing.T, env *deployment.Environment, chainSelector, s
 	})
 	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
+
+	// Verify the curse is lifted
+	if subjectChainSelector != 0 {
+		isCursed, err := adapter.IsSubjectCursedOnChain(*env, chainSelector, fastcurse.GenericSelectorToSubject(subjectChainSelector))
+		require.NoError(t, err)
+		require.False(t, isCursed, "subject should not be cursed on chain")
+	}
+	if globalCurse {
+		isCursed, err := adapter.IsSubjectCursedOnChain(*env, chainSelector, fastcurse.GlobalCurseSubject())
+		require.NoError(t, err)
+		require.False(t, isCursed, "global curse should not be active on chain")
+	}
 }

--- a/build/devenv/tests/e2e/finality_reorg_curse_test.go
+++ b/build/devenv/tests/e2e/finality_reorg_curse_test.go
@@ -2,21 +2,24 @@ package e2e
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/adapters" // register the EVM 1.6.0 curse adapter
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/proxy"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/versioned_verifier_resolver"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/fastcurse"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	ccv "github.com/smartcontractkit/chainlink-ccv/build/devenv"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cciptestinterfaces"
 	devenvcommon "github.com/smartcontractkit/chainlink-ccv/build/devenv/common"
@@ -27,6 +30,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/chainstatus"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 )
 
@@ -40,6 +44,9 @@ func TestE2EReorg(t *testing.T) {
 	smokeTestConfig := GetSmokeTestConfig()
 	lib, err := ccv.NewLib(l, smokeTestConfig, chain_selectors.FamilyEVM)
 	require.NoError(t, err)
+	cldfEnv, err := lib.CLDFEnvironment()
+	require.NoError(t, err)
+	require.NotNil(t, cldfEnv)
 
 	// TODO: put LoadOutput behind the lib.
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
@@ -177,20 +184,6 @@ func TestE2EReorg(t *testing.T) {
 		require.Error(t, err, "%s should not be found in aggregator", description)
 	}
 
-	//// chainSelectorToSubject converts a chain selector to a bytes16 curse subject.
-	chainSelectorToSubject := func(chainSel uint64) [16]byte {
-		var result [16]byte
-		// Convert the uint64 to bytes and place it in the last 8 bytes of the array
-		binary.BigEndian.PutUint64(result[8:], chainSel)
-		return result
-	}
-
-	// globalCurseSubject returns the global curse constant from RMN specification.
-	// If this subject is present in cursed subjects, all lanes involving this chain are cursed.
-	globalCurseSubject := func() [16]byte {
-		return [16]byte{0: 0x01, 15: 0x01}
-	}
-
 	t.Run("simple reorg with message ordering", func(t *testing.T) {
 		// 1/5 Blocks
 		advanceBlocks(verifier.ConfirmationDepth / 5)
@@ -274,8 +267,7 @@ func TestE2EReorg(t *testing.T) {
 
 		l.Info().Msg("Applying lane curse between chain0 and chain1 (before message gets picked up by verifier)")
 		// normally it's bidirectional, for the sake of the test we only curse one direction
-		err = srcImpl.Curse(ctx, [][16]byte{chainSelectorToSubject(destSelector)})
-		require.NoError(t, err)
+		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
 
 		l.Info().Msg("🔍 Asserting message reached verifier but was dropped due to curse")
 		assertCtx, assertCancel := context.WithTimeout(ctx, 100*time.Second)
@@ -305,8 +297,7 @@ func TestE2EReorg(t *testing.T) {
 
 		// Uncurse the lane
 		l.Info().Msg("🔓 Uncursing the cursed lane")
-		err = srcImpl.Uncurse(ctx, [][16]byte{chainSelectorToSubject(destSelector)})
-		require.NoError(t, err)
+		uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
 
 		// Send a message again on the previously cursed lane to verify it works now
 		event3, err := srcImpl.SendMessage(ctx, destSelector, newMessageFields(receiver, "message 2 after uncurse"), defaultMessageOptions, defaultMessageVersion)
@@ -351,8 +342,7 @@ func TestE2EReorg(t *testing.T) {
 		advanceBlocks(verifier.ConfirmationDepth / 5)
 
 		l.Info().Msg("🌐 Applying GLOBAL curse to source chain (affects ALL lanes from this chain)")
-		err = srcImpl.Curse(ctx, [][16]byte{globalCurseSubject()})
-		require.NoError(t, err)
+		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), 0, true)
 
 		l.Info().Msg("🔍 Asserting BOTH messages are dropped due to global curse")
 		assertCtx, assertCancel := context.WithTimeout(ctx, 100*time.Second)
@@ -378,8 +368,7 @@ func TestE2EReorg(t *testing.T) {
 
 		// Uncurse the chain
 		l.Info().Msg("🔓 Removing global curse from source chain")
-		err = srcImpl.Uncurse(ctx, [][16]byte{globalCurseSubject()})
-		require.NoError(t, err)
+		uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), 0, true)
 
 		// Send new messages after uncurse to verify both lanes work
 		l.Info().Msg("📨 Sending messages after global uncurse to verify lanes work")
@@ -401,13 +390,12 @@ func TestE2EReorg(t *testing.T) {
 	})
 
 	t.Run("lane curse blocks one lane while peer lane keeps verifying traffic", func(t *testing.T) {
-		err := srcImpl.Curse(ctx, [][16]byte{chainSelectorToSubject(destSelector)})
-		require.NoError(t, err)
+		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
 		t.Cleanup(func() {
-			_ = srcImpl.Uncurse(ctx, [][16]byte{chainSelectorToSubject(destSelector)})
+			uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
 		})
 
-		_, err = srcImpl.SendMessage(ctx, destSelector, newMessageFields(receiver, "blocked lane msg"), defaultMessageOptions, defaultMessageVersion)
+		_, err := srcImpl.SendMessage(ctx, destSelector, newMessageFields(receiver, "blocked lane msg"), defaultMessageOptions, defaultMessageVersion)
 		require.Error(t, err, "send to cursed lane (chain0 -> chain1) should fail")
 
 		uncursedMsgIDs := make([][32]byte, 0, 3)
@@ -427,10 +415,9 @@ func TestE2EReorg(t *testing.T) {
 	})
 
 	t.Run("curse on dest2 lane does not block dest1 lane", func(t *testing.T) {
-		err := srcImpl.Curse(ctx, [][16]byte{chainSelectorToSubject(destSelector2)})
-		require.NoError(t, err)
+		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector2, false)
 		t.Cleanup(func() {
-			_ = srcImpl.Uncurse(ctx, [][16]byte{chainSelectorToSubject(destSelector2)})
+			uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector2, false)
 		})
 
 		_, err = srcImpl.SendMessage(ctx, destSelector2, newMessageFields(receiver2, "blocked dest2 msg"), defaultMessageOptions, defaultMessageVersion)
@@ -487,9 +474,9 @@ func TestE2EReorg(t *testing.T) {
 		_, err = logAssert.WaitForStage(reachedCtx, droppedMsgID, logasserter.MessageReachedVerifier())
 		require.NoError(t, err, "message should reach verifier pending queue before curse is applied")
 
-		require.NoError(t, srcImpl.Curse(ctx, [][16]byte{chainSelectorToSubject(destSelector)}))
+		curseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
 		t.Cleanup(func() {
-			_ = srcImpl.Uncurse(ctx, [][16]byte{chainSelectorToSubject(destSelector)})
+			uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
 		})
 
 		dropCtx, dropCancel := context.WithTimeout(ctx, 60*time.Second)
@@ -504,7 +491,7 @@ func TestE2EReorg(t *testing.T) {
 		advanceBlocks(verifier.ConfirmationDepth*3 + 30)
 		verifyMessageNotExists(droppedMsgID, "Dropped message should not reach aggregator while cursed")
 
-		require.NoError(t, srcImpl.Uncurse(ctx, [][16]byte{chainSelectorToSubject(destSelector)}))
+		uncurseSelector(t, cldfEnv, srcImpl.ChainSelector(), destSelector, false)
 
 		// With the checkpoint past the message block, uncursing on-chain alone must not replay it.
 		advanceBlocks(verifier.ConfirmationDepth + 5)
@@ -785,4 +772,36 @@ func TestE2EReorg(t *testing.T) {
 
 		l.Info().Msg("✅ Source chain re-enabled in database after being disabled from finality violation")
 	})
+}
+
+func curseSelector(t *testing.T, env *deployment.Environment, chainSelector, subjectChainSelector uint64, globalCurse bool) {
+	curseCS := fastcurse.CurseChangeset(fastcurse.GetCurseRegistry(), changesets.GetRegistry())
+	output, err := curseCS.Apply(*env, fastcurse.RMNCurseConfig{
+		CurseActions: []fastcurse.CurseActionInput{
+			{
+				ChainSelector:        chainSelector,
+				SubjectChainSelector: subjectChainSelector,
+				Version:              semver.MustParse("1.6.0"),
+				IsGlobalCurse:        globalCurse,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(output.Reports), 0)
+}
+
+func uncurseSelector(t *testing.T, env *deployment.Environment, chainSelector, subjectChainSelector uint64, globalCurse bool) {
+	uncurseCS := fastcurse.UncurseChangeset(fastcurse.GetCurseRegistry(), changesets.GetRegistry())
+	output, err := uncurseCS.Apply(*env, fastcurse.RMNCurseConfig{
+		CurseActions: []fastcurse.CurseActionInput{
+			{
+				ChainSelector:        chainSelector,
+				SubjectChainSelector: subjectChainSelector,
+				Version:              semver.MustParse("1.6.0"),
+				IsGlobalCurse:        globalCurse,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(output.Reports), 0)
 }

--- a/changelog/2026-05-05_remove_chain_curse_api.md
+++ b/changelog/2026-05-05_remove_chain_curse_api.md
@@ -1,0 +1,76 @@
+# Remove `cciptestinterfaces.Chain` curse API; use `fastcurse` + shared CLDF env
+
+## Executive Summary
+
+- Removes `Curse`/`Uncurse` from the `build/devenv/cciptestinterfaces.Chain` interface and drops the CCIP17 EVM implementation of those methods.
+- Consolidates curse operations in devenv tests around `chainlink-ccip/deployment/fastcurse` changesets, instead of direct RMN Remote contract calls.
+- Updates `build/devenv.Lib` to construct and retain a CLDF `deployment.Environment` once, and exposes it via `(*Lib).CLDFEnvironment()`.
+- Introduces a **breaking change** for any downstream code that previously invoked `Chain.Curse` / `Chain.Uncurse`.
+
+## AI Adapter Index
+
+| Symbol | Kind | Search | Location | Section |
+|---|---|---|---|---|
+| `cciptestinterfaces.Chain.Curse` | removed | `\.Curse\(` | `build/devenv/cciptestinterfaces/interface.go:136` | [#chain-curse-removed](#chain-curse-removed) |
+| `cciptestinterfaces.Chain.Uncurse` | removed | `\.Uncurse\(` | `build/devenv/cciptestinterfaces/interface.go:136` | [#chain-uncurse-removed](#chain-uncurse-removed) |
+| `ccv.Lib.CLDFEnvironment` | added | `CLDFEnvironment\(` | `build/devenv/lib.go:101` | [#lib-cldfenvironment-added](#lib-cldfenvironment-added) |
+| `generateExecutorJobSpecs` | signature-changed | `generateExecutorJobSpecs\(` | `build/devenv/environment.go:539` | [#generateexecutorjobspecs-signature](#generateexecutorjobspecs-signature) |
+| `generateVerifierJobSpecs` | signature-changed | `generateVerifierJobSpecs\(` | `build/devenv/environment.go:616` | [#generateverifierjobspecs-signature](#generateverifierjobspecs-signature) |
+| `e2e.curseSelector` | added | `curseSelector\(` | `build/devenv/tests/e2e/finality_reorg_curse_test.go:777` | [#e2e-curse-helpers](#e2e-curse-helpers) |
+| `e2e.uncurseSelector` | added | `uncurseSelector\(` | `build/devenv/tests/e2e/finality_reorg_curse_test.go:793` | [#e2e-curse-helpers](#e2e-curse-helpers) |
+
+## Breaking Changes
+
+### Chain curse API removed
+
+- **What changed:** `cciptestinterfaces.Chain` no longer includes `Curse(ctx, subjects)` / `Uncurse(ctx, subjects)`.
+- **Before:** Consumers could call `impl.Curse(ctx, subjects)` / `impl.Uncurse(ctx, subjects)` on a chain implementation.
+- **After:** Consumers must perform curse/uncurse via CCIP “fastcurse” changesets (see migration below) and an available CLDF `deployment.Environment`.
+- **Why:** Centralizes curse operations behind changesets + adapter registry (and avoids embedding RMN Remote contract binding logic in the devenv chain impl).
+- **Who is affected:** Any downstream repo code that calls `.Curse(` or `.Uncurse(` on objects implementing `cciptestinterfaces.Chain`.
+
+## Migration Guide
+
+1. Stop calling `cciptestinterfaces.Chain.Curse` / `.Uncurse`.
+   - Find call sites by grepping for `\.Curse\(` and `\.Uncurse\(`.
+2. Obtain a CLDF environment (`*deployment.Environment`).
+   - If you already use `ccv.NewLib`, prefer `(*ccv.Lib).CLDFEnvironment()` (`build/devenv/lib.go:101`).
+   - Otherwise construct one via `NewCLDFOperationsEnvironment(...)` (same function `NewLib` uses at `build/devenv/lib.go:44`).
+3. Apply curses via `fastcurse` changesets.
+   - Use the pattern implemented in `build/devenv/tests/e2e/finality_reorg_curse_test.go:777`.
+
+### Example migration (test-style)
+
+```go
+// Before (no longer compiles)
+err := srcImpl.Curse(ctx, subjects)
+require.NoError(t, err)
+
+// After
+cldfEnv, err := lib.CLDFEnvironment()
+require.NoError(t, err)
+
+curseCS := fastcurse.CurseChangeset(fastcurse.GetCurseRegistry(), changesets.GetRegistry())
+_, err = curseCS.Apply(*cldfEnv, fastcurse.RMNCurseConfig{
+	CurseActions: []fastcurse.CurseActionInput{
+		{
+			ChainSelector:        srcImpl.ChainSelector(),
+			SubjectChainSelector: destSelector, // 0 if global curse
+			Version:              semver.MustParse("1.6.0"),
+			IsGlobalCurse:        false, // true for global curse
+		},
+	},
+})
+require.NoError(t, err)
+```
+
+## New Features / Additions
+
+- **`(*ccv.Lib).CLDFEnvironment()`** — returns the CLDF `*deployment.Environment` created during `ccv.NewLib(...)` initialization. See `build/devenv/lib.go:101`.
+  - Usage: lets tests/tools reuse the same CLDF environment without rebuilding it inside `Chains()` or other call paths.
+
+## Compatibility & Requirements *(optional)*
+
+- Curse/uncurse operations now rely on the `chainlink-ccip` curse adapter registry. The e2e test ensures this is registered via a blank import:
+  - `build/devenv/tests/e2e/finality_reorg_curse_test.go:17`
+


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

This PR removes the `Curse` and `Uncurse` methods from the `cciptestinterfaces.Chain` interface because it duplicates the already existing adapter in the chain-agnostic deployment API.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

Updated the curse E2E tests to use the `fastcurse` API.


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
