### PR TITLE
Use 'just lint' for consistent CI and developer workflows.

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -53,7 +53,7 @@ jobs:
           install-only: true
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
 
       - name: Install gomods
         run: go install github.com/jmank88/gomods@v${{ steps.tool-versions.outputs.gomods_version }}

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -42,42 +42,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          source "${GITHUB_WORKSPACE}/tool-versions.env" 
-
-          # Make it a step output
+          source "${GITHUB_WORKSPACE}/tool-versions.env"
           echo "golangci_lint_version=$VERSION_GOLANGCI_LINT" >> "$GITHUB_OUTPUT"
+          echo "gomods_version=$VERSION_GOMODS" >> "$GITHUB_OUTPUT"
 
-      - name: Check golangci-lint for root
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47 #v9.0.0
         with:
           version: "v${{ steps.tool-versions.outputs.golangci_lint_version }}"
-          working-directory: ./
-          args: --config .golangci.yaml ./...
+          install-only: true
 
-      - name: Check golangci-lint for build/devenv
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8
-        with:
-          version: "v${{ steps.tool-versions.outputs.golangci_lint_version }}"
-          working-directory: build/devenv/
-          args: --config ../../.golangci.yaml ./...
+      - name: Install just
+        uses: extractions/setup-just@v3
 
-      - name: Check golangci-lint for build/devenv/fakes
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8
-        with:
-          version: "v${{ steps.tool-versions.outputs.golangci_lint_version }}"
-          working-directory: build/devenv/fakes/
-          args: --config ../../../.golangci.yaml ./...
-      
-      - name: Check golangci-lint for deployment
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8
-        with:
-          version: "v${{ steps.tool-versions.outputs.golangci_lint_version }}"
-          working-directory: deployment/
-          args: --config ../.golangci.yaml ./...
-      
-      - name: Check golangci-lint for indexer oapigen
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8
-        with:
-          version: "v${{ steps.tool-versions.outputs.golangci_lint_version }}"
-          working-directory: indexer/cmd/oapigen/
-          args: --config ../../../.golangci.yaml ./...
+      - name: Install gomods
+        run: go install github.com/jmank88/gomods@v${{ steps.tool-versions.outputs.gomods_version }}
+
+      - name: Lint
+        run: just lint

--- a/indexer/cmd/oapigen/generator.go
+++ b/indexer/cmd/oapigen/generator.go
@@ -21,99 +21,104 @@ func main() {
 		os.Exit(2)
 	}
 
-	outPath := os.Args[1]
-	out, err := getOutputFile(outPath)
-	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "failed to open output file:", err)
-		os.Exit(1)
-	}
-	defer func() { _ = out.Close() }()
+	if true {
+		os.Exit(0)
+	} else {
 
-	// Create a new stdlib HTTP router.
-	mux := http.NewServeMux()
-
-	// Create a Huma v2 API on top of the router.
-	cfg := huma.DefaultConfig("Indexer API", "1.0.0")
-	api := humago.New(mux, cfg)
-
-	// Huma will use this to override its built in error type.
-	huma.NewError = func(status int, msg string, errs ...error) huma.StatusError {
-		return v1.ErrorResponse{
-			Status:  status,
-			Message: msg,
+		outPath := os.Args[1]
+		out, err := getOutputFile(outPath)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "failed to open output file:", err)
+			os.Exit(1)
 		}
-	}
-	grp := huma.NewGroup(api, "/v1")
+		defer func() { _ = out.Close() }()
 
-	// Register root-level health and readiness endpoints (explicit type args)
-	huma.Register(api, huma.Operation{
-		OperationID: "health",
-		Method:      http.MethodGet,
-		Path:        "/health",
-		Description: "Liveness probe that returns a plain 200.",
-	}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
-		return nil, nil
-	})
+		// Create a new stdlib HTTP router.
+		mux := http.NewServeMux()
 
-	huma.Register(api, huma.Operation{
-		OperationID: "ready",
-		Method:      http.MethodGet,
-		Path:        "/ready",
-		Description: "Readiness probe that returns 200 if the service has storage access.",
-	}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
-		return nil, nil
-	})
+		// Create a Huma v2 API on top of the router.
+		cfg := huma.DefaultConfig("Indexer API", "1.0.0")
+		api := humago.New(mux, cfg)
 
-	// Register v1 endpoints
-	huma.Register(grp, huma.Operation{
-		OperationID: "verifier-results",
-		Method:      http.MethodGet,
-		Path:        "/verifierresults",
-		Description: "Get verifier results",
-	}, func(ctx context.Context, input *v1.VerifierResultsInput) (*v1.VerifierResultsResponse, error) {
-		return nil, nil
-	})
-
-	huma.Register(grp, huma.Operation{
-		OperationID: "verifier-results-by-message-id",
-		Method:      http.MethodGet,
-		Path:        "/verifierresults/{messageID}",
-		Description: "Get message by ID",
-	}, func(ctx context.Context, input *v1.VerifierResultsByMessageIDInput) (*v1.VerifierResultsByMessageIDResponse, error) {
-		return nil, nil
-	})
-
-	huma.Register(grp, huma.Operation{
-		OperationID: "messages",
-		Method:      http.MethodGet,
-		Path:        "/messages",
-		Description: "Get messages",
-	}, func(ctx context.Context, input *v1.MessagesInput) (*v1.MessagesResponse, error) {
-		return nil, nil
-	})
-
-	oapi := api.OpenAPI()
-
-	// Remove $schema properties from all schemas (it was only in ErrorResponse)
-	if oapi.Components != nil {
-		for _, schema := range oapi.Components.Schemas.Map() {
-			delete(schema.Properties, "$schema")
+		// Huma will use this to override its built in error type.
+		huma.NewError = func(status int, msg string, errs ...error) huma.StatusError {
+			return v1.ErrorResponse{
+				Status:  status,
+				Message: msg,
+			}
 		}
-	}
+		grp := huma.NewGroup(api, "/v1")
 
-	// yml, err := api.OpenAPI().Downgrade()
-	yml, err := api.OpenAPI().DowngradeYAML()
-	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "failed to generate openapi yaml:", err)
-		os.Exit(1)
-	}
+		// Register root-level health and readiness endpoints (explicit type args)
+		huma.Register(api, huma.Operation{
+			OperationID: "health",
+			Method:      http.MethodGet,
+			Path:        "/health",
+			Description: "Liveness probe that returns a plain 200.",
+		}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+			return nil, nil
+		})
 
-	if _, err := out.Write(yml); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "failed to write file:", err)
-		os.Exit(1)
-	}
+		huma.Register(api, huma.Operation{
+			OperationID: "ready",
+			Method:      http.MethodGet,
+			Path:        "/ready",
+			Description: "Readiness probe that returns 200 if the service has storage access.",
+		}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+			return nil, nil
+		})
 
-	_, _ = fmt.Fprintf(os.Stderr, "wrote OpenAPI YAML to %s\n", outPath)
+		// Register v1 endpoints
+		huma.Register(grp, huma.Operation{
+			OperationID: "verifier-results",
+			Method:      http.MethodGet,
+			Path:        "/verifierresults",
+			Description: "Get verifier results",
+		}, func(ctx context.Context, input *v1.VerifierResultsInput) (*v1.VerifierResultsResponse, error) {
+			return nil, nil
+		})
+
+		huma.Register(grp, huma.Operation{
+			OperationID: "verifier-results-by-message-id",
+			Method:      http.MethodGet,
+			Path:        "/verifierresults/{messageID}",
+			Description: "Get message by ID",
+		}, func(ctx context.Context, input *v1.VerifierResultsByMessageIDInput) (*v1.VerifierResultsByMessageIDResponse, error) {
+			return nil, nil
+		})
+
+		huma.Register(grp, huma.Operation{
+			OperationID: "messages",
+			Method:      http.MethodGet,
+			Path:        "/messages",
+			Description: "Get messages",
+		}, func(ctx context.Context, input *v1.MessagesInput) (*v1.MessagesResponse, error) {
+			return nil, nil
+		})
+
+		oapi := api.OpenAPI()
+
+		// Remove $schema properties from all schemas (it was only in ErrorResponse)
+		if oapi.Components != nil {
+			for _, schema := range oapi.Components.Schemas.Map() {
+				delete(schema.Properties, "$schema")
+			}
+		}
+
+		// yml, err := api.OpenAPI().Downgrade()
+		yml, err := api.OpenAPI().DowngradeYAML()
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "failed to generate openapi yaml:", err)
+			os.Exit(1)
+		}
+
+		if _, err := out.Write(yml); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "failed to write file:", err)
+			os.Exit(1)
+		}
+
+		_, _ = fmt.Fprintf(os.Stderr, "wrote OpenAPI YAML to %s\n", outPath)
+	}
 }
 
 func getOutputFile(path string) (*os.File, error) {

--- a/indexer/cmd/oapigen/generator.go
+++ b/indexer/cmd/oapigen/generator.go
@@ -21,104 +21,99 @@ func main() {
 		os.Exit(2)
 	}
 
-	if true {
-		os.Exit(0)
-	} else {
-
-		outPath := os.Args[1]
-		out, err := getOutputFile(outPath)
-		if err != nil {
-			_, _ = fmt.Fprintln(os.Stderr, "failed to open output file:", err)
-			os.Exit(1)
-		}
-		defer func() { _ = out.Close() }()
-
-		// Create a new stdlib HTTP router.
-		mux := http.NewServeMux()
-
-		// Create a Huma v2 API on top of the router.
-		cfg := huma.DefaultConfig("Indexer API", "1.0.0")
-		api := humago.New(mux, cfg)
-
-		// Huma will use this to override its built in error type.
-		huma.NewError = func(status int, msg string, errs ...error) huma.StatusError {
-			return v1.ErrorResponse{
-				Status:  status,
-				Message: msg,
-			}
-		}
-		grp := huma.NewGroup(api, "/v1")
-
-		// Register root-level health and readiness endpoints (explicit type args)
-		huma.Register(api, huma.Operation{
-			OperationID: "health",
-			Method:      http.MethodGet,
-			Path:        "/health",
-			Description: "Liveness probe that returns a plain 200.",
-		}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
-			return nil, nil
-		})
-
-		huma.Register(api, huma.Operation{
-			OperationID: "ready",
-			Method:      http.MethodGet,
-			Path:        "/ready",
-			Description: "Readiness probe that returns 200 if the service has storage access.",
-		}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
-			return nil, nil
-		})
-
-		// Register v1 endpoints
-		huma.Register(grp, huma.Operation{
-			OperationID: "verifier-results",
-			Method:      http.MethodGet,
-			Path:        "/verifierresults",
-			Description: "Get verifier results",
-		}, func(ctx context.Context, input *v1.VerifierResultsInput) (*v1.VerifierResultsResponse, error) {
-			return nil, nil
-		})
-
-		huma.Register(grp, huma.Operation{
-			OperationID: "verifier-results-by-message-id",
-			Method:      http.MethodGet,
-			Path:        "/verifierresults/{messageID}",
-			Description: "Get message by ID",
-		}, func(ctx context.Context, input *v1.VerifierResultsByMessageIDInput) (*v1.VerifierResultsByMessageIDResponse, error) {
-			return nil, nil
-		})
-
-		huma.Register(grp, huma.Operation{
-			OperationID: "messages",
-			Method:      http.MethodGet,
-			Path:        "/messages",
-			Description: "Get messages",
-		}, func(ctx context.Context, input *v1.MessagesInput) (*v1.MessagesResponse, error) {
-			return nil, nil
-		})
-
-		oapi := api.OpenAPI()
-
-		// Remove $schema properties from all schemas (it was only in ErrorResponse)
-		if oapi.Components != nil {
-			for _, schema := range oapi.Components.Schemas.Map() {
-				delete(schema.Properties, "$schema")
-			}
-		}
-
-		// yml, err := api.OpenAPI().Downgrade()
-		yml, err := api.OpenAPI().DowngradeYAML()
-		if err != nil {
-			_, _ = fmt.Fprintln(os.Stderr, "failed to generate openapi yaml:", err)
-			os.Exit(1)
-		}
-
-		if _, err := out.Write(yml); err != nil {
-			_, _ = fmt.Fprintln(os.Stderr, "failed to write file:", err)
-			os.Exit(1)
-		}
-
-		_, _ = fmt.Fprintf(os.Stderr, "wrote OpenAPI YAML to %s\n", outPath)
+	outPath := os.Args[1]
+	out, err := getOutputFile(outPath)
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "failed to open output file:", err)
+		os.Exit(1)
 	}
+	defer func() { _ = out.Close() }()
+
+	// Create a new stdlib HTTP router.
+	mux := http.NewServeMux()
+
+	// Create a Huma v2 API on top of the router.
+	cfg := huma.DefaultConfig("Indexer API", "1.0.0")
+	api := humago.New(mux, cfg)
+
+	// Huma will use this to override its built in error type.
+	huma.NewError = func(status int, msg string, errs ...error) huma.StatusError {
+		return v1.ErrorResponse{
+			Status:  status,
+			Message: msg,
+		}
+	}
+	grp := huma.NewGroup(api, "/v1")
+
+	// Register root-level health and readiness endpoints (explicit type args)
+	huma.Register(api, huma.Operation{
+		OperationID: "health",
+		Method:      http.MethodGet,
+		Path:        "/health",
+		Description: "Liveness probe that returns a plain 200.",
+	}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "ready",
+		Method:      http.MethodGet,
+		Path:        "/ready",
+		Description: "Readiness probe that returns 200 if the service has storage access.",
+	}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	// Register v1 endpoints
+	huma.Register(grp, huma.Operation{
+		OperationID: "verifier-results",
+		Method:      http.MethodGet,
+		Path:        "/verifierresults",
+		Description: "Get verifier results",
+	}, func(ctx context.Context, input *v1.VerifierResultsInput) (*v1.VerifierResultsResponse, error) {
+		return nil, nil
+	})
+
+	huma.Register(grp, huma.Operation{
+		OperationID: "verifier-results-by-message-id",
+		Method:      http.MethodGet,
+		Path:        "/verifierresults/{messageID}",
+		Description: "Get message by ID",
+	}, func(ctx context.Context, input *v1.VerifierResultsByMessageIDInput) (*v1.VerifierResultsByMessageIDResponse, error) {
+		return nil, nil
+	})
+
+	huma.Register(grp, huma.Operation{
+		OperationID: "messages",
+		Method:      http.MethodGet,
+		Path:        "/messages",
+		Description: "Get messages",
+	}, func(ctx context.Context, input *v1.MessagesInput) (*v1.MessagesResponse, error) {
+		return nil, nil
+	})
+
+	oapi := api.OpenAPI()
+
+	// Remove $schema properties from all schemas (it was only in ErrorResponse)
+	if oapi.Components != nil {
+		for _, schema := range oapi.Components.Schemas.Map() {
+			delete(schema.Properties, "$schema")
+		}
+	}
+
+	// yml, err := api.OpenAPI().Downgrade()
+	yml, err := api.OpenAPI().DowngradeYAML()
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "failed to generate openapi yaml:", err)
+		os.Exit(1)
+	}
+
+	if _, err := out.Write(yml); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "failed to write file:", err)
+		os.Exit(1)
+	}
+
+	_, _ = fmt.Fprintf(os.Stderr, "wrote OpenAPI YAML to %s\n", outPath)
 }
 
 func getOutputFile(path string) (*os.File, error) {


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
Update the golangci-lint.yaml workflow to use 'just lint' in order to make CI consistent with the developer command.

Note: this approach breaks the inline lint reporting. I think thats fine because it's easy to run the linter on this repo.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing
Temporarily introduced a lint error in a nested module to make sure it is detected:
* golangci-lint correctly fails due to a lint error on the `oapigen` module: [DETAILS](https://github.com/smartcontractkit/chainlink-ccv/actions/runs/25435384348/job/74611859117).

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
