### PR TITLE
Add message disablement rules support and related services

### DIFF
--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -75,7 +75,7 @@ jobs:
             working-directory: build/devenv/tests/e2e
           - name: TestE2ESmoke_AggregatorMessageDisablementRules
             run_cmd: TestE2ESmoke_Aggregator(MessageDisablementRulesCLI|LaneDisablementRule|ChainDisablementRule)
-            config: env.toml
+            config: env.toml,env-src-auto-mine.toml
             timeout: 10m
             working-directory: build/devenv/tests/e2e
     steps:

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -119,3 +119,10 @@ packages:
       CommitteeBatchWriter:
         configs:
           - dir: ./integration/storageaccess/mocks
+
+  github.com/smartcontractkit/chainlink-ccv/verifier/pkg/vtypes:
+    interfaces:
+      MetricLabeler:
+        configs:
+          - dir: ./verifier/internal/mocks
+            outpkg: mocks

--- a/build/devenv/services/aggregator.template.toml
+++ b/build/devenv/services/aggregator.template.toml
@@ -46,6 +46,7 @@ key_prefix = "ratelimit"
 "/chainlink_ccv.message_discovery.v1.MessageDiscovery/GetMessagesSince" = { limit_per_second = 20 }
 "/chainlink_ccv.verifier.v1.Verifier/GetVerifierResultsForMessage" = { limit_per_second = 100 }
 "/chainlink_ccv.heartbeat.v1.HeartbeatService/SendHeartbeat" = { limit_per_second = 100 }
+"/chainlink_ccv.message_rules.v1.MessageRules/ListMessageRules" = { limit_per_second = 20 }
 
 # Limit shared across all anonymous callers
 [rateLimiting.globalAnonymousLimits]
@@ -56,6 +57,7 @@ key_prefix = "ratelimit"
 [rateLimiting.groupLimits.verifiers]
 "/chainlink_ccv.committee_verifier.v1.CommitteeVerifier/BatchWriteCommitteeVerifierNodeResult" = { limit_per_second = 3 }
 "/chainlink_ccv.heartbeat.v1.HeartbeatService/SendHeartbeat" = { limit_per_second = 100 }
+"/chainlink_ccv.message_rules.v1.MessageRules/ListMessageRules" = { limit_per_second = 20 }
 
 # Higher rate limit group for service tests-1 (honest verifiers should never be rate-limited in tests)
 [rateLimiting.groupLimits.service-tests-1]

--- a/build/devenv/tests/e2e/smoke_aggregator_message_disablement_rules_test.go
+++ b/build/devenv/tests/e2e/smoke_aggregator_message_disablement_rules_test.go
@@ -377,7 +377,7 @@ func newVerifierCommitteeClientForSmoke(t *testing.T, in *ccv.Cfg) *verifiercli.
 	verifierID := in.Verifier[0].Out.VerifierID
 	require.NotEmpty(t, verifierID)
 
-	var members []*verifiercli.Client
+	members := make([]*verifiercli.Client, 1)
 	for _, v := range in.Verifier {
 		if v.Out == nil || v.Out.VerifierID != verifierID {
 			continue

--- a/build/devenv/tests/e2e/smoke_aggregator_message_disablement_rules_test.go
+++ b/build/devenv/tests/e2e/smoke_aggregator_message_disablement_rules_test.go
@@ -377,7 +377,7 @@ func newVerifierCommitteeClientForSmoke(t *testing.T, in *ccv.Cfg) *verifiercli.
 	verifierID := in.Verifier[0].Out.VerifierID
 	require.NotEmpty(t, verifierID)
 
-	members := make([]*verifiercli.Client, 1)
+	members := make([]*verifiercli.Client, 0)
 	for _, v := range in.Verifier {
 		if v.Out == nil || v.Out.VerifierID != verifierID {
 			continue

--- a/build/devenv/tests/e2e/smoke_aggregator_message_disablement_rules_test.go
+++ b/build/devenv/tests/e2e/smoke_aggregator_message_disablement_rules_test.go
@@ -17,15 +17,19 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cciptestinterfaces"
 	devenvcommon "github.com/smartcontractkit/chainlink-ccv/build/devenv/common"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/aggregatorcli"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/logasserter"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/verifiercli"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	verifier "github.com/smartcontractkit/chainlink-ccv/verifier/pkg"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 )
 
 // aggregatorRefreshBuffer is the time to wait after a CLI mutation for the
-// aggregator registry to pick up the DB change. The devenv template sets
-// messageDisablementRules.refreshInterval = "2s", so 5s gives a comfortable margin.
-const aggregatorRefreshBuffer = 5 * time.Second
+// aggregator registry and verifier message-rules poller to pick up the DB
+// change. The devenv template and verifier default poll every 2s, so 10s gives
+// a comfortable margin across both loops.
+const aggregatorRefreshBuffer = 10 * time.Second
 
 func TestE2ESmoke_AggregatorMessageDisablementRulesCLI(t *testing.T) {
 	smokeTestConfig := GetSmokeTestConfig()
@@ -75,13 +79,15 @@ func TestE2ESmoke_AggregatorMessageDisablementRulesCLI(t *testing.T) {
 }
 
 // TestE2ESmoke_AggregatorLaneDisablementRule validates the full user-visible
-// behavior of aggregator message disablement rules across three phases:
+// behavior of aggregator message disablement rules:
 //
-//  1. Unrelated lane — while the lane between chains[0] and chains[1] is
+//  1. Unrelated lane - while the lane between chains[0] and chains[1] is
 //     disabled, chains[0] -> chains[2] continues to be processed normally.
-//  2. Disabled lane — messages on chains[0] -> chains[1] are rejected by the
-//     aggregator with FailedPrecondition and never reach the result store.
-//  3. Recovery — deleting the lane rule restores normal processing.
+//  2. Disabled lane - messages on chains[0] -> chains[1] are dropped by the
+//     verifier and never reach the result store.
+//  3. Replay - deleting the rule alone does not replay a dropped message once
+//     the verifier checkpoint has advanced; rewinding the committee checkpoint
+//     makes the original message process normally.
 func TestE2ESmoke_AggregatorLaneDisablementRule(t *testing.T) {
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
@@ -110,7 +116,16 @@ func TestE2ESmoke_AggregatorLaneDisablementRule(t *testing.T) {
 	blockedSrcSelector := blockedSrc.Details.ChainSelector
 	blockedDestSelector := blockedDest.Details.ChainSelector
 	allowedDestSelector := allowedDest.Details.ChainSelector
-	messageOpts := messageDisablementOptions(t, in, blockedSrcSelector)
+	progressable, ok := blockedSrc.CCIP17.(cciptestinterfaces.ProgressableChain)
+	if !ok {
+		t.Skip("source chain does not implement ProgressableChain; skipping message-disablement replay smoke test")
+	}
+	require.True(t, progressable.SupportManualBlockProgress(ctx),
+		"source chain must support manual block progression with automining enabled; run with env-src-auto-mine.toml")
+	advanceBlocks := func(numBlocks int) {
+		require.NoError(t, progressable.AdvanceBlocks(ctx, numBlocks), "advance %d blocks", numBlocks)
+		time.Sleep(3 * time.Second)
+	}
 
 	receiverOnBlockedDest := mustGetEOAReceiverAddress(t, blockedDest)
 	receiverOnAllowedDest := mustGetEOAReceiverAddress(t, allowedDest)
@@ -131,63 +146,63 @@ func TestE2ESmoke_AggregatorLaneDisablementRule(t *testing.T) {
 
 	time.Sleep(aggregatorRefreshBuffer)
 
+	committee := newVerifierCommitteeClientForSmoke(t, in)
+	committee.ResumeAllBestEffort(ctx)
+	t.Cleanup(func() { committee.ResumeAllBestEffort(ctx) })
+
+	logAssert := logasserter.New(DefaultLokiURL, zerolog.Ctx(ctx).With().Str("component", "log-asserter").Logger())
+	require.NoError(t, logAssert.StartStreaming(ctx, []logasserter.LogStage{
+		logasserter.MessageReachedVerifier(),
+		logasserter.MessageDroppedInVerifier(),
+	}))
+	t.Cleanup(logAssert.StopStreaming)
+
+	messageOpts := committeeV3MessageOptions(t, in, blockedSrcSelector)
+
 	// Phase A: chains[0] -> chains[2] is unrelated to the disabled lane.
-	seqNoAllowed, err := blockedSrc.GetExpectedNextSequenceNumber(ctx, allowedDestSelector)
-	require.NoError(t, err)
-	_, err = blockedSrc.SendMessage(ctx, allowedDestSelector,
+	sentEvtAllowed := sendMessageAndConfirm(t, ctx, blockedSrc, allowedDestSelector,
 		cciptestinterfaces.MessageFields{Receiver: receiverOnAllowedDest},
-		messageOpts,
-		messageDisablementMessageVersion)
-	require.NoError(t, err)
-	sentEvtAllowed, err := blockedSrc.ConfirmSendOnSource(ctx, allowedDestSelector, cciptestinterfaces.MessageEventKey{SeqNum: seqNoAllowed}, defaultSentTimeout)
-	require.NoError(t, err)
+		messageOpts, 3)
+	advanceBlocks(verifier.ConfirmationDepth + 5)
+	requireAggregatorResult(t, ctx, aggregatorClient, sentEvtAllowed.MessageID, "message on unrelated lane should still reach the aggregator")
 
-	allowedCtx, cancelAllowed := context.WithTimeout(ctx, 45*time.Second)
-	defer cancelAllowed()
-	_, err = aggregatorClient.WaitForVerifierResultForMessage(allowedCtx, sentEvtAllowed.MessageID, 500*time.Millisecond)
-	require.NoError(t, err, "message on unrelated lane should still reach the aggregator")
-
-	// Phase B: chains[0] -> chains[1] is rejected by the lane rule.
-	seqNoBlocked, err := blockedSrc.GetExpectedNextSequenceNumber(ctx, blockedDestSelector)
-	require.NoError(t, err)
-	_, err = blockedSrc.SendMessage(ctx, blockedDestSelector,
+	// Phase B: chains[0] -> chains[1] is dropped by the verifier.
+	sentEvtBlocked := sendMessageAndConfirm(t, ctx, blockedSrc, blockedDestSelector,
 		cciptestinterfaces.MessageFields{Receiver: receiverOnBlockedDest},
-		messageOpts,
-		messageDisablementMessageVersion)
-	require.NoError(t, err)
-	sentEvtBlocked, err := blockedSrc.ConfirmSendOnSource(ctx, blockedDestSelector, cciptestinterfaces.MessageEventKey{SeqNum: seqNoBlocked}, defaultSentTimeout)
-	require.NoError(t, err)
+		messageOpts, 3)
+	advanceBlocks(verifier.ConfirmationDepth / 5)
+	reachedCtx, cancelReached := context.WithTimeout(ctx, 60*time.Second)
+	defer cancelReached()
+	_, err = logAssert.WaitForStage(reachedCtx, sentEvtBlocked.MessageID, logasserter.MessageReachedVerifier())
+	require.NoError(t, err, "message should reach verifier pending queue before it is dropped")
+	dropCtx, cancelDrop := context.WithTimeout(ctx, 60*time.Second)
+	defer cancelDrop()
+	_, err = logAssert.WaitForStage(dropCtx, sentEvtBlocked.MessageID, logasserter.MessageDroppedInVerifier())
+	require.NoError(t, err, "message should be dropped in verifier due to message disablement rule")
+	requireNoAggregatorResult(t, ctx, aggregatorClient, sentEvtBlocked.MessageID, "message should not be in aggregator while lane rule exists")
 
-	time.Sleep(20 * time.Second)
-	notProcessedCtx, cancelNotProcessed := context.WithTimeout(ctx, 5*time.Second)
-	defer cancelNotProcessed()
-	_, err = aggregatorClient.GetVerifierResultForMessage(notProcessedCtx, sentEvtBlocked.MessageID)
-	require.Error(t, err, "message should not be in aggregator while lane rule exists")
+	// Move the checkpoint past the dropped message while the rule is active. Removing the
+	// rule alone should not replay it; replay requires an operator checkpoint rewind.
+	advanceBlocks(verifier.ConfirmationDepth*3 + 30)
+	requireNoAggregatorResult(t, ctx, aggregatorClient, sentEvtBlocked.MessageID, "dropped message should not reach aggregator while rule exists")
 
-	// Phase C: deleting the rule restores the lane.
 	_, err = rulesClient.Delete(cliCtx, ruleID)
 	require.NoError(t, err, "CLI delete lane rule should succeed")
 	time.Sleep(aggregatorRefreshBuffer)
+	advanceBlocks(verifier.ConfirmationDepth + 5)
+	requireNoAggregatorResult(t, ctx, aggregatorClient, sentEvtBlocked.MessageID, "dropped message should not reappear after rule deletion alone")
 
-	seqNoRecovery, err := blockedSrc.GetExpectedNextSequenceNumber(ctx, blockedDestSelector)
-	require.NoError(t, err)
-	_, err = blockedSrc.SendMessage(ctx, blockedDestSelector,
-		cciptestinterfaces.MessageFields{Receiver: receiverOnBlockedDest},
-		messageOpts,
-		messageDisablementMessageVersion)
-	require.NoError(t, err)
-	sentEvtRecovery, err := blockedSrc.ConfirmSendOnSource(ctx, blockedDestSelector, cciptestinterfaces.MessageEventKey{SeqNum: seqNoRecovery}, defaultSentTimeout)
-	require.NoError(t, err)
+	require.NoError(t, committee.RewindFinalizedHeight(ctx,
+		verifiercli.FormatChainSelector(blockedSrcSelector), verifiercli.FormatBlockHeight(0)),
+		"rewind committee finalized height")
 
-	recoveryCtx, cancelRecovery := context.WithTimeout(ctx, 45*time.Second)
-	defer cancelRecovery()
-	_, err = aggregatorClient.WaitForVerifierResultForMessage(recoveryCtx, sentEvtRecovery.MessageID, 500*time.Millisecond)
-	require.NoError(t, err, "message should reach the aggregator after lane rule is deleted")
+	advanceBlocks(verifier.ConfirmationDepth*2 + 10)
+	requireAggregatorResult(t, ctx, aggregatorClient, sentEvtBlocked.MessageID, "dropped message should be reprocessed after checkpoint rewind")
 }
 
 // TestE2ESmoke_AggregatorChainDisablementRule validates that a Chain rule
-// blocks any message touching the configured selector while unrelated chains
-// keep flowing.
+// drops any message touching the configured selector while unrelated chains
+// keep flowing, and that dropped messages require a checkpoint rewind to replay.
 func TestE2ESmoke_AggregatorChainDisablementRule(t *testing.T) {
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
@@ -213,10 +228,19 @@ func TestE2ESmoke_AggregatorChainDisablementRule(t *testing.T) {
 	src := chains[0]
 	blockedDest := chains[1]
 	allowedDest := chains[2]
-	srcSelector := src.Details.ChainSelector
 	blockedDestSelector := blockedDest.Details.ChainSelector
 	allowedDestSelector := allowedDest.Details.ChainSelector
-	messageOpts := messageDisablementOptions(t, in, srcSelector)
+	srcSelector := src.Details.ChainSelector
+	progressable, ok := src.CCIP17.(cciptestinterfaces.ProgressableChain)
+	if !ok {
+		t.Skip("source chain does not implement ProgressableChain; skipping message-disablement replay smoke test")
+	}
+	require.True(t, progressable.SupportManualBlockProgress(ctx),
+		"source chain must support manual block progression with automining enabled; run with env-src-auto-mine.toml")
+	advanceBlocks := func(numBlocks int) {
+		require.NoError(t, progressable.AdvanceBlocks(ctx, numBlocks), "advance %d blocks", numBlocks)
+		time.Sleep(3 * time.Second)
+	}
 
 	ac := aggregatorcli.NewClient(in.Aggregator[0].Out.AggregatorContainerName)
 	rulesClient := ac.MessageDisablementRules()
@@ -234,29 +258,57 @@ func TestE2ESmoke_AggregatorChainDisablementRule(t *testing.T) {
 
 	time.Sleep(aggregatorRefreshBuffer)
 
+	committee := newVerifierCommitteeClientForSmoke(t, in)
+	committee.ResumeAllBestEffort(ctx)
+	t.Cleanup(func() { committee.ResumeAllBestEffort(ctx) })
+
+	logAssert := logasserter.New(DefaultLokiURL, zerolog.Ctx(ctx).With().Str("component", "log-asserter").Logger())
+	require.NoError(t, logAssert.StartStreaming(ctx, []logasserter.LogStage{
+		logasserter.MessageReachedVerifier(),
+		logasserter.MessageDroppedInVerifier(),
+	}))
+	t.Cleanup(logAssert.StopStreaming)
+
+	messageOpts := committeeV3MessageOptions(t, in, srcSelector)
+
 	allowedSent := sendMessageAndConfirm(t, ctx, src, allowedDestSelector,
 		cciptestinterfaces.MessageFields{Receiver: mustGetEOAReceiverAddress(t, allowedDest)},
-		messageOpts)
+		messageOpts, 3)
+	advanceBlocks(verifier.ConfirmationDepth + 5)
 	requireAggregatorResult(t, ctx, aggregatorClient, allowedSent.MessageID, "message on unrelated chain should still reach the aggregator")
 
 	blockedSent := sendMessageAndConfirm(t, ctx, src, blockedDestSelector,
 		cciptestinterfaces.MessageFields{Receiver: mustGetEOAReceiverAddress(t, blockedDest)},
-		messageOpts)
+		messageOpts, 3)
+	advanceBlocks(verifier.ConfirmationDepth / 5)
+	reachedCtx, cancelReached := context.WithTimeout(ctx, 60*time.Second)
+	defer cancelReached()
+	_, err = logAssert.WaitForStage(reachedCtx, blockedSent.MessageID, logasserter.MessageReachedVerifier())
+	require.NoError(t, err, "message should reach verifier pending queue before it is dropped")
+	dropCtx, cancelDrop := context.WithTimeout(ctx, 60*time.Second)
+	defer cancelDrop()
+	_, err = logAssert.WaitForStage(dropCtx, blockedSent.MessageID, logasserter.MessageDroppedInVerifier())
+	require.NoError(t, err, "message should be dropped in verifier due to message disablement rule")
 	requireNoAggregatorResult(t, ctx, aggregatorClient, blockedSent.MessageID, "message touching disabled chain should not be in aggregator")
+
+	advanceBlocks(verifier.ConfirmationDepth*3 + 30)
+	requireNoAggregatorResult(t, ctx, aggregatorClient, blockedSent.MessageID, "dropped message should not reach aggregator while rule exists")
 
 	_, err = rulesClient.Delete(cliCtx, ruleID)
 	require.NoError(t, err, "CLI delete chain rule should succeed")
 	time.Sleep(aggregatorRefreshBuffer)
+	advanceBlocks(verifier.ConfirmationDepth + 5)
+	requireNoAggregatorResult(t, ctx, aggregatorClient, blockedSent.MessageID, "dropped message should not reappear after rule deletion alone")
 
-	recoverySent := sendMessageAndConfirm(t, ctx, src, blockedDestSelector,
-		cciptestinterfaces.MessageFields{Receiver: mustGetEOAReceiverAddress(t, blockedDest)},
-		messageOpts)
-	requireAggregatorResult(t, ctx, aggregatorClient, recoverySent.MessageID, "message should reach the aggregator after chain rule is deleted")
+	require.NoError(t, committee.RewindFinalizedHeight(ctx,
+		verifiercli.FormatChainSelector(srcSelector), verifiercli.FormatBlockHeight(0)),
+		"rewind committee finalized height")
+
+	advanceBlocks(verifier.ConfirmationDepth*2 + 10)
+	requireAggregatorResult(t, ctx, aggregatorClient, blockedSent.MessageID, "dropped message should be reprocessed after checkpoint rewind")
 }
 
-const messageDisablementMessageVersion uint8 = 3
-
-func messageDisablementOptions(t *testing.T, in *ccv.Cfg, srcSelector uint64) cciptestinterfaces.MessageOptions {
+func committeeV3MessageOptions(t *testing.T, in *ccv.Cfg, srcSelector uint64) cciptestinterfaces.MessageOptions {
 	t.Helper()
 
 	executorAddr := getContractAddress(t, in, srcSelector,
@@ -284,13 +336,14 @@ func sendMessageAndConfirm(
 	src cciptestinterfaces.CCIP17,
 	destSelector uint64,
 	fields cciptestinterfaces.MessageFields,
-	opts cciptestinterfaces.MessageOptions,
+	extraArgs cciptestinterfaces.ExtraArgsDataProvider,
+	messageVersion uint8,
 ) cciptestinterfaces.MessageSentEvent {
 	t.Helper()
 
 	seqNo, err := src.GetExpectedNextSequenceNumber(ctx, destSelector)
 	require.NoError(t, err)
-	_, err = src.SendMessage(ctx, destSelector, fields, opts, messageDisablementMessageVersion)
+	_, err = src.SendMessage(ctx, destSelector, fields, extraArgs, messageVersion)
 	require.NoError(t, err)
 	sentEvt, err := src.ConfirmSendOnSource(ctx, destSelector, cciptestinterfaces.MessageEventKey{SeqNum: seqNo}, defaultSentTimeout)
 	require.NoError(t, err)
@@ -314,4 +367,26 @@ func requireNoAggregatorResult(t *testing.T, ctx context.Context, aggregatorClie
 	defer cancel()
 	_, err := aggregatorClient.GetVerifierResultForMessage(notProcessedCtx, messageID)
 	require.Error(t, err, msg)
+}
+
+func newVerifierCommitteeClientForSmoke(t *testing.T, in *ccv.Cfg) *verifiercli.CommitteeClient {
+	t.Helper()
+
+	require.GreaterOrEqual(t, len(in.Verifier), 1)
+	require.NotNil(t, in.Verifier[0].Out)
+	verifierID := in.Verifier[0].Out.VerifierID
+	require.NotEmpty(t, verifierID)
+
+	var members []*verifiercli.Client
+	for _, v := range in.Verifier {
+		if v.Out == nil || v.Out.VerifierID != verifierID {
+			continue
+		}
+		require.NotEmpty(t, v.Out.ContainerName, "verifier container name must be set")
+		members = append(members, verifiercli.NewClient(v.Out.ContainerName))
+	}
+
+	committee, err := verifiercli.NewCommitteeClient(verifierID, members...)
+	require.NoError(t, err)
+	return committee
 }

--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/heartbeatclient"
+	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/messagerules"
 	"github.com/smartcontractkit/chainlink-ccv/integration/storageaccess"
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
@@ -243,6 +244,30 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		heartbeat.NewHeartbeatMonitoringAdapter(verifierMonitoring),
 	)
 
+	messageRulesClient, err := messagerules.NewGRPCClient(
+		config.AggregatorAddress,
+		lggr,
+		hmacConfig,
+		config.InsecureAggregatorConnection,
+		config.AggregatorMaxRecvMsgSizeBytes,
+	)
+	if err != nil {
+		lggr.Errorw("Failed to create message rules gRPC client", "error", err)
+		return fmt.Errorf("failed to create message rules client: %w", err)
+	}
+
+	messageRulesPoller, err := messagerules.NewPollerService(
+		messageRulesClient,
+		config.MessageDisablementRulesPollInterval,
+		config.MessageDisablementRulesClientTimeout,
+		logger.With(lggr, "component", "MessageRulesPoller"),
+		verifierMonitoring.Metrics(),
+	)
+	if err != nil {
+		lggr.Errorw("Failed to create message rules poller", "error", err)
+		return fmt.Errorf("failed to create message rules poller: %w", err)
+	}
+
 	messageTracker := monitoring.NewMessageLatencyTracker(
 		lggr,
 		config.VerifierID,
@@ -259,6 +284,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		verifierMonitoring,
 		chainStatusManager,
 		observedHeartbeatClient,
+		messageRulesPoller,
 		chainStatusDB,
 	)
 	if err != nil {

--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -256,10 +256,19 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		return fmt.Errorf("failed to create message rules client: %w", err)
 	}
 
+	messageRulesPollInterval, err := config.MessageDisablementRulesPollIntervalDuration()
+	if err != nil {
+		return fmt.Errorf("message disablement rules poll interval: %w", err)
+	}
+	messageRulesClientTimeout, err := config.MessageDisablementRulesClientTimeoutDuration()
+	if err != nil {
+		return fmt.Errorf("message disablement rules client timeout: %w", err)
+	}
+
 	messageRulesPoller, err := messagerules.NewPollerService(
 		messageRulesClient,
-		config.MessageDisablementRulesPollInterval,
-		config.MessageDisablementRulesClientTimeout,
+		messageRulesPollInterval,
+		messageRulesClientTimeout,
 		logger.With(lggr, "component", "MessageRulesPoller"),
 		verifierMonitoring.Metrics(),
 	)

--- a/cmd/verifier/token/main.go
+++ b/cmd/verifier/token/main.go
@@ -300,6 +300,7 @@ func createCCTPCoordinator(
 		verifierMonitoring,
 		chainStatusManager,
 		heartbeatclient.NewNoopHeartbeatClient(),
+		nil,
 		db,
 	)
 	if err != nil {
@@ -354,6 +355,7 @@ func createLombardCoordinator(
 		verifierMonitoring,
 		chainStatusManager,
 		heartbeatclient.NewNoopHeartbeatClient(),
+		nil,
 		db,
 	)
 	if err != nil {

--- a/common/message_rules_checker.go
+++ b/common/message_rules_checker.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+// AllowAllMessagesChecker implements MessageRulesChecker by never disabling a message.
+// Use when message-disablement rules from the aggregator are not wired (e.g. tests, token verifier stub).
+type AllowAllMessagesChecker struct{}
+
+func (AllowAllMessagesChecker) IsMessageDisabled(context.Context, protocol.Message) (bool, error) {
+	return false, nil
+}

--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/ccv/chains/evm/gobindings/generated/latest/onramp"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/heartbeatclient"
+	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/messagerules"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/sourcereader"
 	"github.com/smartcontractkit/chainlink-ccv/integration/storageaccess"
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
@@ -201,6 +202,30 @@ func NewVerificationCoordinator(
 		heartbeat.NewHeartbeatMonitoringAdapter(verifierMonitoring),
 	)
 
+	messageRulesClient, err := messagerules.NewGRPCClient(
+		cfg.AggregatorAddress,
+		lggr,
+		aggregatorSecret,
+		cfg.InsecureAggregatorConnection,
+		cfg.AggregatorMaxRecvMsgSizeBytes,
+	)
+	if err != nil {
+		lggr.Errorw("Failed to create message rules gRPC client", "error", err)
+		return nil, fmt.Errorf("failed to create message rules client: %w", err)
+	}
+
+	messageRulesPoller, err := messagerules.NewPollerService(
+		messageRulesClient,
+		cfg.MessageDisablementRulesPollInterval,
+		cfg.MessageDisablementRulesClientTimeout,
+		logger.With(lggr, "component", "MessageRulesPoller"),
+		verifierMonitoring.Metrics(),
+	)
+	if err != nil {
+		lggr.Errorw("Failed to create message rules poller", "error", err)
+		return nil, fmt.Errorf("failed to create message rules poller: %w", err)
+	}
+
 	messageTracker := monitoring.NewMessageLatencyTracker(
 		lggr,
 		coordinatorConfig.VerifierID,
@@ -217,6 +242,7 @@ func NewVerificationCoordinator(
 		verifierMonitoring,
 		chainStatusManager,
 		observedHeartbeatClient,
+		messageRulesPoller,
 		ds,
 	)
 	if err != nil {

--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -214,10 +214,19 @@ func NewVerificationCoordinator(
 		return nil, fmt.Errorf("failed to create message rules client: %w", err)
 	}
 
+	messageRulesPollInterval, err := cfg.MessageDisablementRulesPollIntervalDuration()
+	if err != nil {
+		return nil, fmt.Errorf("message disablement rules poll interval: %w", err)
+	}
+	messageRulesClientTimeout, err := cfg.MessageDisablementRulesClientTimeoutDuration()
+	if err != nil {
+		return nil, fmt.Errorf("message disablement rules client timeout: %w", err)
+	}
+
 	messageRulesPoller, err := messagerules.NewPollerService(
 		messageRulesClient,
-		cfg.MessageDisablementRulesPollInterval,
-		cfg.MessageDisablementRulesClientTimeout,
+		messageRulesPollInterval,
+		messageRulesClientTimeout,
 		logger.With(lggr, "component", "MessageRulesPoller"),
 		verifierMonitoring.Metrics(),
 	)

--- a/verifier/internal/mocks/mock_MetricLabeler.go
+++ b/verifier/internal/mocks/mock_MetricLabeler.go
@@ -837,6 +837,40 @@ func (_c *MockMetricLabeler_SetLocalChainGlobalCursed_Call) RunAndReturn(run fun
 	return _c
 }
 
+// SetMessageDisablementRulesRefreshFailure provides a mock function with given fields: ctx, failed
+func (_m *MockMetricLabeler) SetMessageDisablementRulesRefreshFailure(ctx context.Context, failed int64) {
+	_m.Called(ctx, failed)
+}
+
+// MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetMessageDisablementRulesRefreshFailure'
+type MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call struct {
+	*mock.Call
+}
+
+// SetMessageDisablementRulesRefreshFailure is a helper method to define mock.On call
+//   - ctx context.Context
+//   - failed int64
+func (_e *MockMetricLabeler_Expecter) SetMessageDisablementRulesRefreshFailure(ctx interface{}, failed interface{}) *MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call {
+	return &MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call{Call: _e.mock.On("SetMessageDisablementRulesRefreshFailure", ctx, failed)}
+}
+
+func (_c *MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call) Run(run func(ctx context.Context, failed int64)) *MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call) Return() *MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call) RunAndReturn(run func(context.Context, int64)) *MockMetricLabeler_SetMessageDisablementRulesRefreshFailure_Call {
+	_c.Run(run)
+	return _c
+}
+
 // SetRemoteChainCursed provides a mock function with given fields: ctx, localSelector, remoteSelector, cursed
 func (_m *MockMetricLabeler) SetRemoteChainCursed(ctx context.Context, localSelector protocol.ChainSelector, remoteSelector protocol.ChainSelector, cursed bool) {
 	_m.Called(ctx, localSelector, remoteSelector, cursed)

--- a/verifier/pkg/commit/config.go
+++ b/verifier/pkg/commit/config.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
@@ -27,10 +28,15 @@ type Config struct {
 	// If 0 or not set, defaults to 4MB.
 	AggregatorMaxRecvMsgSizeBytes int `toml:"aggregator_max_recv_msg_size_bytes"`
 
-	// MessageDisablementRulesPollInterval is how often to refresh message disablement rules from the aggregator. Zero uses the integration package default.
-	MessageDisablementRulesPollInterval time.Duration `toml:"message_disablement_rules_poll_interval"`
-	// MessageDisablementRulesClientTimeout is the timeout for each ListMessageRules RPC. Zero uses the integration package default.
-	MessageDisablementRulesClientTimeout time.Duration `toml:"message_disablement_rules_client_timeout"`
+	// MessageDisablementRulesPollInterval and MessageDisablementRulesClientTimeout are Go duration strings
+	// (e.g. "2s", "500ms"). Empty means use the integration package default for that setting.
+	//
+	// They are stored as strings (not time.Duration) because the Chainlink node unmarshals
+	// committeeVerifierConfig with github.com/pelletier/go-toml, which does not decode TOML
+	// duration strings into time.Duration. Standalone / devenv decoding uses github.com/BurntSushi/toml,
+	// which does support time.Duration; using string keeps both paths and changeset marshaling compatible.
+	MessageDisablementRulesPollInterval  string `toml:"message_disablement_rules_poll_interval"`
+	MessageDisablementRulesClientTimeout string `toml:"message_disablement_rules_client_timeout"`
 
 	SignerAddress string `toml:"signer_address"`
 
@@ -48,6 +54,28 @@ type Config struct {
 
 	// CommitteeConfig that is needed by the SourceReader and the application.
 	chainaccess.CommitteeConfig
+}
+
+func parseOptionalDurationString(value, fieldName string) (time.Duration, error) {
+	s := strings.TrimSpace(value)
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", fieldName, value, err)
+	}
+	return d, nil
+}
+
+// MessageDisablementRulesPollIntervalDuration returns the configured poll interval, or zero to use the integration default.
+func (c *Config) MessageDisablementRulesPollIntervalDuration() (time.Duration, error) {
+	return parseOptionalDurationString(c.MessageDisablementRulesPollInterval, "message_disablement_rules_poll_interval")
+}
+
+// MessageDisablementRulesClientTimeoutDuration returns the configured RPC timeout, or zero to use the integration default.
+func (c *Config) MessageDisablementRulesClientTimeoutDuration() (time.Duration, error) {
+	return parseOptionalDurationString(c.MessageDisablementRulesClientTimeout, "message_disablement_rules_client_timeout")
 }
 
 func (c *Config) Validate() error {
@@ -71,6 +99,13 @@ func (c *Config) Validate() error {
 		if _, ok := c.RMNRemoteAddresses[k]; !ok {
 			return fmt.Errorf("invalid verifier configuration, chain selector in onramp (%s) not in RMN Remote addresses", k)
 		}
+	}
+
+	if _, err := c.MessageDisablementRulesPollIntervalDuration(); err != nil {
+		return err
+	}
+	if _, err := c.MessageDisablementRulesClientTimeoutDuration(); err != nil {
+		return err
 	}
 
 	return nil

--- a/verifier/pkg/commit/config.go
+++ b/verifier/pkg/commit/config.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 	verifier "github.com/smartcontractkit/chainlink-ccv/verifier/pkg/vtypes"
@@ -25,6 +26,11 @@ type Config struct {
 	// Should match or be less than the aggregator's server maxSendMsgSizeBytes setting.
 	// If 0 or not set, defaults to 4MB.
 	AggregatorMaxRecvMsgSizeBytes int `toml:"aggregator_max_recv_msg_size_bytes"`
+
+	// MessageDisablementRulesPollInterval is how often to refresh message disablement rules from the aggregator. Zero uses the integration package default.
+	MessageDisablementRulesPollInterval time.Duration `toml:"message_disablement_rules_poll_interval"`
+	// MessageDisablementRulesClientTimeout is the timeout for each ListMessageRules RPC. Zero uses the integration package default.
+	MessageDisablementRulesClientTimeout time.Duration `toml:"message_disablement_rules_client_timeout"`
 
 	SignerAddress string `toml:"signer_address"`
 

--- a/verifier/pkg/commit/config_test.go
+++ b/verifier/pkg/commit/config_test.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,12 +60,38 @@ func TestConfig_Validate_Success(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "message disablement duration strings",
+			config: Config{
+				MessageDisablementRulesPollInterval:  "2s",
+				MessageDisablementRulesClientTimeout: "5s",
+				CommitteeVerifierAddresses: map[string]string{
+					"1": "0xCommittee1",
+				},
+				CommitteeConfig: chainaccess.CommitteeConfig{
+					OnRampAddresses: map[string]string{
+						"1": "0xOnRamp1",
+					},
+					RMNRemoteAddresses: map[string]string{
+						"1": "0xRMNRemote1",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.config.Validate()
 			require.NoError(t, err)
+			if tt.name == "message disablement duration strings" {
+				poll, err := tt.config.MessageDisablementRulesPollIntervalDuration()
+				require.NoError(t, err)
+				assert.Equal(t, 2*time.Second, poll)
+				timeout, err := tt.config.MessageDisablementRulesClientTimeoutDuration()
+				require.NoError(t, err)
+				assert.Equal(t, 5*time.Second, timeout)
+			}
 		})
 	}
 }
@@ -166,6 +193,24 @@ func TestConfig_Validate_Errors(t *testing.T) {
 				},
 			},
 			errSubstr: "not in RMN Remote addresses",
+		},
+		{
+			name: "invalid message_disablement_rules_poll_interval",
+			config: Config{
+				MessageDisablementRulesPollInterval: "not-a-duration",
+				CommitteeVerifierAddresses: map[string]string{
+					"1": "0xCommittee1",
+				},
+				CommitteeConfig: chainaccess.CommitteeConfig{
+					OnRampAddresses: map[string]string{
+						"1": "0xOnRamp1",
+					},
+					RMNRemoteAddresses: map[string]string{
+						"1": "0xRMNRemote1",
+					},
+				},
+			},
+			errSubstr: "invalid message_disablement_rules_poll_interval",
 		},
 	}
 

--- a/verifier/pkg/coordinator.go
+++ b/verifier/pkg/coordinator.go
@@ -56,6 +56,8 @@ type Coordinator struct {
 	resultQueueObserver services.Service
 
 	monitoring commonmetrics.ServiceMetrics
+
+	messageRulesSvc common.MessageRulesCheckerService
 }
 
 func NewCoordinator(
@@ -68,6 +70,7 @@ func NewCoordinator(
 	monitoring Monitoring,
 	chainStatusManager protocol.ChainStatusManager,
 	heartbeatClient heartbeatclient.HeartbeatSender,
+	messageRulesSvc common.MessageRulesCheckerService,
 	ds sqlutil.DataSource,
 ) (*Coordinator, error) {
 	if ds == nil {
@@ -75,7 +78,7 @@ func NewCoordinator(
 	}
 	return NewCoordinatorWithDetector(
 		lggr, verifier, sourceReaders, storage, config,
-		messageTracker, monitoring, chainStatusManager, nil, heartbeatClient, ds,
+		messageTracker, monitoring, chainStatusManager, nil, heartbeatClient, messageRulesSvc, ds,
 	)
 }
 
@@ -90,6 +93,7 @@ func NewCoordinatorWithDetector(
 	chainStatusManager protocol.ChainStatusManager,
 	detector common.CurseCheckerService,
 	heartbeatClient heartbeatclient.HeartbeatSender,
+	messageRulesSvc common.MessageRulesCheckerService,
 	ds sqlutil.DataSource,
 ) (*Coordinator, error) {
 	if ds == nil {
@@ -99,7 +103,12 @@ func NewCoordinatorWithDetector(
 		return nil, errors.New("verifier is required")
 	}
 	lggr = logger.With(lggr, "verifierID", config.VerifierID)
-	vc := &Coordinator{lggr: lggr, verifierID: config.VerifierID, monitoring: monitoring}
+	vc := &Coordinator{
+		lggr:            lggr,
+		verifierID:      config.VerifierID,
+		monitoring:      monitoring,
+		messageRulesSvc: messageRulesSvc,
+	}
 	vc.initFn = func(ctx context.Context) error {
 		enabledSourceReaders, err := filterOnlyEnabledSourceReaders(ctx, lggr, config, sourceReaders, chainStatusManager)
 		if err != nil {
@@ -113,8 +122,14 @@ func NewCoordinatorWithDetector(
 			return fmt.Errorf("failed to create curse detector: %w", err)
 		}
 		vc.curseDetector = curseDetector
+
+		messageRulesChecker := common.MessageRulesChecker(common.AllowAllMessagesChecker{})
+		if vc.messageRulesSvc != nil {
+			messageRulesChecker = vc.messageRulesSvc
+		}
+
 		processors, err := createDurableProcessors(
-			lggr, ds, config, verifier, monitoring, enabledSourceReaders, chainStatusManager, vc.curseDetector, messageTracker, storage,
+			lggr, ds, config, verifier, monitoring, enabledSourceReaders, chainStatusManager, vc.curseDetector, messageTracker, storage, messageRulesChecker,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create durable processors: %w", err)
@@ -168,6 +183,7 @@ func createDurableProcessors(
 	curseDetector common.CurseCheckerService,
 	messageTracker MessageLatencyTracker,
 	storage protocol.CCVNodeDataWriter,
+	messageRulesChecker common.MessageRulesChecker,
 ) (*durableProcessors, error) {
 	taskQueue, err := jobqueue.NewPostgresJobQueue[VerificationTask](
 		ds,
@@ -220,7 +236,7 @@ func createDurableProcessors(
 	}
 
 	sourceReadersDB, err := createSourceReadersDB(
-		lggr, config, chainStatusManager, curseDetector, monitoring, enabledSourceReaders, taskQueueObserver,
+		lggr, config, chainStatusManager, curseDetector, monitoring, enabledSourceReaders, taskQueueObserver, messageRulesChecker,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DB source reader services: %w", err)
@@ -256,6 +272,12 @@ func (vc *Coordinator) Start(ctx context.Context) error {
 		if vc.initFn != nil {
 			if err := vc.initFn(ctx); err != nil {
 				return err
+			}
+		}
+
+		if vc.messageRulesSvc != nil {
+			if err := vc.messageRulesSvc.Start(ctx); err != nil {
+				return fmt.Errorf("failed to start message rules service: %w", err)
 			}
 		}
 
@@ -318,6 +340,7 @@ func createSourceReadersDB(
 	monitoring Monitoring,
 	enabledSourceReaders map[protocol.ChainSelector]chainaccess.SourceReader,
 	taskQueue jobqueue.JobQueue[VerificationTask],
+	messageRulesChecker common.MessageRulesChecker,
 ) (map[protocol.ChainSelector]*sourcereader.Service, error) {
 	sourceReaderServices := make(map[protocol.ChainSelector]*sourcereader.Service)
 	for chainSelector, sourceReader := range enabledSourceReaders {
@@ -327,7 +350,7 @@ func createSourceReadersDB(
 		srs, err := sourcereader.NewService(
 			sourceReader, chainSelector, chainStatusManager,
 			logger.With(lggr, "component", "SourceReaderDB", "chainID", chainSelector),
-			sourceCfg, curseDetector, filter, monitoring.Metrics(), taskQueue,
+			sourceCfg, curseDetector, filter, monitoring.Metrics(), taskQueue, messageRulesChecker,
 		)
 		if err != nil {
 			lggr.Errorw("failed to create Service for chain, skipping this chain", "chainSelector", chainSelector, "error", err)
@@ -398,6 +421,12 @@ func (vc *Coordinator) Close() error {
 			}
 		}
 
+		if vc.messageRulesSvc != nil {
+			if err := vc.messageRulesSvc.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to stop message rules service: %w", err))
+			}
+		}
+
 		if vc.taskVerifierProcessor != nil {
 			if err := vc.taskVerifierProcessor.Close(); err != nil {
 				errs = append(errs, fmt.Errorf("failed to stop verifier processor: %w", err))
@@ -464,6 +493,11 @@ func (vc *Coordinator) Name() string {
 func (vc *Coordinator) HealthReport() map[string]error {
 	report := make(map[string]error)
 	report[vc.Name()] = vc.Ready()
+	if vc.messageRulesSvc != nil {
+		if hr, ok := vc.messageRulesSvc.(protocol.HealthReporter); ok {
+			maps.Copy(report, hr.HealthReport())
+		}
+	}
 	if vc.taskVerifierProcessor != nil {
 		maps.Copy(report, vc.taskVerifierProcessor.HealthReport())
 	}

--- a/verifier/pkg/coordinator_cctp_test.go
+++ b/verifier/pkg/coordinator_cctp_test.go
@@ -496,6 +496,7 @@ func createCCTPCoordinator(
 		noopMonitoring,
 		ts.chainStatusManager,
 		heartbeatclient.NewNoopHeartbeatClient(),
+		nil,
 		ts.db,
 	)
 }

--- a/verifier/pkg/coordinator_curse_test.go
+++ b/verifier/pkg/coordinator_curse_test.go
@@ -136,6 +136,7 @@ func setupCurseTest(t *testing.T, sourceChain, destChain protocol.ChainSelector,
 		setup.chainStatusManager,
 		setup.mockCurseChecker,
 		heartbeatclient.NewNoopHeartbeatClient(),
+		nil,
 		sqlxDB,
 	)
 	require.NoError(t, err)

--- a/verifier/pkg/coordinator_lombard_test.go
+++ b/verifier/pkg/coordinator_lombard_test.go
@@ -321,6 +321,7 @@ func createLombardCoordinatorWithRetryConfig(
 		noopMonitoring,
 		ts.chainStatusManager,
 		heartbeatclient.NewNoopHeartbeatClient(),
+		nil,
 		ts.db,
 	)
 }

--- a/verifier/pkg/coordinator_test.go
+++ b/verifier/pkg/coordinator_test.go
@@ -164,6 +164,7 @@ func createVerificationCoordinator(
 		noopMonitoring,
 		ts.chainStatusManager,
 		heartbeatclient.NewNoopHeartbeatClient(),
+		nil,
 		ts.db,
 	)
 }

--- a/verifier/pkg/helpers_test.go
+++ b/verifier/pkg/helpers_test.go
@@ -140,6 +140,9 @@ func (m *noopMetricLabeler) SetRemoteChainCursed(ctx context.Context, localSelec
 
 func (m *noopMetricLabeler) SetLocalChainGlobalCursed(ctx context.Context, localSelector protocol.ChainSelector, globalCurse bool) {
 }
+
+func (m *noopMetricLabeler) SetMessageDisablementRulesRefreshFailure(context.Context, int64) {}
+
 func (m *noopMetricLabeler) IncrementHeartbeatsSent(ctx context.Context)                           {}
 func (m *noopMetricLabeler) IncrementHeartbeatsFailed(ctx context.Context)                         {}
 func (m *noopMetricLabeler) RecordHeartbeatDuration(ctx context.Context, duration time.Duration)   {}
@@ -436,7 +439,7 @@ func createDurableProcessorsWithPollInterval(
 	}
 
 	sourceReadersDB, err := createSourceReadersDB(
-		lggr, config, chainStatusManager, curseDetector, monitoring, enabledSourceReaders, taskQueue,
+		lggr, config, chainStatusManager, curseDetector, monitoring, enabledSourceReaders, taskQueue, common.AllowAllMessagesChecker{},
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create DB source reader services: %w", err)

--- a/verifier/pkg/monitoring/metrics.go
+++ b/verifier/pkg/monitoring/metrics.go
@@ -57,6 +57,8 @@ type VerifierMetrics struct {
 	remoteChainCursed              metric.Int64Gauge
 	localChainGlobalCursed         metric.Int64Gauge
 
+	messageDisablementRulesRefreshFailure metric.Int64Gauge
+
 	// Reorg/Finality  Tracking
 	reorgTrackedSeqNumsGauge metric.Int64Gauge
 
@@ -260,6 +262,15 @@ func InitMetrics() (*VerifierMetrics, error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register remote chain cursed gauge: %w", err)
+	}
+
+	vm.messageDisablementRulesRefreshFailure, err = beholder.GetMeter().Int64Gauge(
+		"verifier_message_disablement_rules_refresh_failure",
+		metric.WithDescription("Whether the latest message disablement rules refresh failed (1) or succeeded (0)"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register message disablement rules refresh failure gauge: %w", err)
 	}
 
 	// Reorg Tracking
@@ -542,6 +553,11 @@ func (v *VerifierMetricLabeler) SetLocalChainGlobalCursed(ctx context.Context, l
 		cursedInt = 1
 	}
 	v.vm.localChainGlobalCursed.Record(ctx, cursedInt, metric.WithAttributes(otelLabels...))
+}
+
+func (v *VerifierMetricLabeler) SetMessageDisablementRulesRefreshFailure(ctx context.Context, failed int64) {
+	otelLabels := beholder.OtelAttributes(v.Labels).AsStringAttributes()
+	v.vm.messageDisablementRulesRefreshFailure.Record(ctx, failed, metric.WithAttributes(otelLabels...))
 }
 
 func (v *VerifierMetricLabeler) IncrementActiveRequestsCounter(ctx context.Context) {

--- a/verifier/pkg/monitoring/monitoring.go
+++ b/verifier/pkg/monitoring/monitoring.go
@@ -169,6 +169,9 @@ func (f *FakeVerifierMetricLabeler) SetRemoteChainCursed(ctx context.Context, lo
 func (f *FakeVerifierMetricLabeler) SetLocalChainGlobalCursed(ctx context.Context, localSelector protocol.ChainSelector, globalCurse bool) {
 }
 
+func (f *FakeVerifierMetricLabeler) SetMessageDisablementRulesRefreshFailure(context.Context, int64) {
+}
+
 func (f *FakeVerifierMetricLabeler) IncrementActiveRequestsCounter(context.Context) {}
 
 func (f *FakeVerifierMetricLabeler) IncrementHTTPRequestCounter(context.Context) {}

--- a/verifier/pkg/sourcereader/service.go
+++ b/verifier/pkg/sourcereader/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	sourceReader    chainaccess.SourceReader
 	chainSelector   protocol.ChainSelector
 	curseDetector   common.CurseCheckerService
+	messageRules    common.MessageRulesChecker
 	finalityChecker protocol.FinalityViolationChecker
 	pollInterval    time.Duration
 	pollTimeout     time.Duration
@@ -78,6 +79,7 @@ func NewService(
 	filter chainaccess.MessageFilter,
 	metrics verifier.MetricLabeler,
 	taskQueue jobqueue.JobQueue[verifier.VerificationTask],
+	messageRules common.MessageRulesChecker,
 ) (*Service, error) {
 	if sourceReader == nil {
 		return nil, fmt.Errorf("sourceReader cannot be nil")
@@ -96,6 +98,9 @@ func NewService(
 	}
 	if taskQueue == nil {
 		return nil, fmt.Errorf("taskQueue cannot be nil")
+	}
+	if messageRules == nil {
+		return nil, fmt.Errorf("messageRules cannot be nil")
 	}
 
 	var finalityChecker protocol.FinalityViolationChecker
@@ -137,6 +142,7 @@ func NewService(
 		chainSelector:      chainSelector,
 		chainStatusManager: chainStatusManager,
 		curseDetector:      curseDetector,
+		messageRules:       messageRules,
 		finalityChecker:    finalityChecker,
 		pollInterval:       interval,
 		pollTimeout:        pollTimeout,
@@ -515,7 +521,7 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 	advanceCheckpointTo := func() uint64 {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		hasCurseUnknown := false
+		hasBlockingUnknown := false
 
 		if r.disabled.Load() {
 			return 0
@@ -540,12 +546,31 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 						"sourceChain", task.Message.SourceChainSelector,
 						"destChain", task.Message.DestChainSelector,
 						"error", curseErr)
-					hasCurseUnknown = true
+					hasBlockingUnknown = true
 					// In this particular case we can't make a decision, so we'll just skip the task
 					// Curse err should be transient so the next poll is likely to have the information
 					continue
 				}
 				r.logger.Warnw("Dropping task - lane is cursed",
+					"messageID", msgID,
+					"sourceChain", task.Message.SourceChainSelector,
+					"destChain", task.Message.DestChainSelector)
+				toBeDeleted = append(toBeDeleted, msgID)
+				continue
+			}
+
+			disabled, disablementErr := r.messageRules.IsMessageDisabled(ctx, task.Message)
+			if disablementErr != nil {
+				r.logger.Warnw("Blocking message - message rules state unknown",
+					"messageID", msgID,
+					"sourceChain", task.Message.SourceChainSelector,
+					"destChain", task.Message.DestChainSelector,
+					"error", disablementErr)
+				hasBlockingUnknown = true
+				continue
+			}
+			if disabled {
+				r.logger.Warnw("Dropping task - message matched a disablement rule",
 					"messageID", msgID,
 					"sourceChain", task.Message.SourceChainSelector,
 					"destChain", task.Message.DestChainSelector)
@@ -561,7 +586,7 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 			}
 		}
 
-		// Delete cursed tasks immediately (these are being dropped, not queued)
+		// Delete dropped tasks immediately (these are not queued)
 		for _, msgID := range toBeDeleted {
 			delete(r.pendingTasks, msgID)
 		}
@@ -575,9 +600,9 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 			safeCheckpoint = lp.Uint64()
 		}
 
-		if hasCurseUnknown {
-			// When curse state is unknown we need to keep the checkpoint unchanged to avoid skipping messages
-			r.logger.Warnw("Curse state unknown, keeping checkpoint unchanged to avoid skipped messages")
+		if hasBlockingUnknown {
+			// When drop/block rules are unknown we need to keep the checkpoint unchanged to avoid skipping messages.
+			r.logger.Warnw("Curse or message rules state unknown, keeping checkpoint unchanged to avoid skipped messages")
 			safeCheckpoint = 0
 		}
 

--- a/verifier/pkg/sourcereader/service_test.go
+++ b/verifier/pkg/sourcereader/service_test.go
@@ -84,6 +84,7 @@ func newTestSRS(
 		&noopFilter{},
 		&testutil.NoopMetricLabeler{},
 		queue,
+		common.AllowAllMessagesChecker{},
 	)
 	require.NoError(t, err)
 
@@ -787,6 +788,7 @@ func TestSRS_DisableFinalityChecker(t *testing.T) {
 		&noopFilter{},
 		&testutil.NoopMetricLabeler{},
 		&fakeTaskQueue{},
+		common.AllowAllMessagesChecker{},
 	)
 	require.NoError(t, err)
 

--- a/verifier/pkg/vtypes/interfaces.go
+++ b/verifier/pkg/vtypes/interfaces.go
@@ -58,6 +58,7 @@ type FinalityCheckerMetrics interface {
 type MetricLabeler interface {
 	FinalityCheckerMetrics
 	common.CurseCheckerMetrics
+	common.MessageRulesCheckerMetrics
 
 	// With returns a new metrics labeler with the given key-value pairs.
 	With(keyValues ...string) MetricLabeler

--- a/verifier/testutil/metric_labeler.go
+++ b/verifier/testutil/metric_labeler.go
@@ -42,6 +42,9 @@ func (n *NoopMetricLabeler) SetRemoteChainCursed(_ context.Context, _, _ protoco
 
 func (n *NoopMetricLabeler) SetLocalChainGlobalCursed(_ context.Context, _ protocol.ChainSelector, _ bool) {
 }
+
+func (n *NoopMetricLabeler) SetMessageDisablementRulesRefreshFailure(_ context.Context, _ int64) {}
+
 func (n *NoopMetricLabeler) IncrementActiveRequestsCounter(_ context.Context) {}
 func (n *NoopMetricLabeler) IncrementHTTPRequestCounter(_ context.Context)    {}
 func (n *NoopMetricLabeler) DecrementActiveRequestsCounter(_ context.Context) {}


### PR DESCRIPTION
The main changes include the addition of a message rules poller to the verifier, enhanced end-to-end tests to verify correct behavior when messages are disabled and replayed, and the introduction of a default "allow all" message checker for cases where message rules are not wired. Additionally, rate limiting for the new message rules endpoint is configured, and several helper utilities are added to support these changes.

**Verifier Service Enhancements:**

* Added a message rules poller to the verifier service, enabling it to periodically fetch and enforce message disablement rules from the aggregator. This includes wiring up a new gRPC client and poller service in `servicefactory.go`. [[1]](diffhunk://#diff-4fd296d61b90e3828962a4933be9b6918639f3e086a50f0e302fd7c0c25fa115R19) [[2]](diffhunk://#diff-4fd296d61b90e3828962a4933be9b6918639f3e086a50f0e302fd7c0c25fa115R247-R270) [[3]](diffhunk://#diff-4fd296d61b90e3828962a4933be9b6918639f3e086a50f0e302fd7c0c25fa115R287)
* Introduced a default `AllowAllMessagesChecker` in `common/message_rules_checker.go` to ensure verifiers that do not wire message rules (e.g., token verifier stubs or tests) do not disable any messages.
* Updated token verifier coordinator constructors to accept the message rules poller, passing `nil` when not used. [[1]](diffhunk://#diff-a5822e40f9379b510c84b2c6506c2d29db366127af97f815ec7f9eaced6fefe0R303) [[2]](diffhunk://#diff-a5822e40f9379b510c84b2c6506c2d29db366127af97f815ec7f9eaced6fefe0R358)

**End-to-End Testing Improvements:**

* Extended E2E tests for aggregator message and chain disablement rules to verify that messages are dropped by the verifier (not just rejected by the aggregator), and that replay is only possible after a committee checkpoint rewind. This includes new log assertions, block advancement logic, and committee client helpers. [[1]](diffhunk://#diff-85b7ebdadb3a236968e5db16a85fe79871d23a93453e408f8770ab9d28546424R20-R32) [[2]](diffhunk://#diff-85b7ebdadb3a236968e5db16a85fe79871d23a93453e408f8770ab9d28546424L78-R90) [[3]](diffhunk://#diff-85b7ebdadb3a236968e5db16a85fe79871d23a93453e408f8770ab9d28546424L113-R128) [[4]](diffhunk://#diff-85b7ebdadb3a236968e5db16a85fe79871d23a93453e408f8770ab9d28546424R149-R205) [[5]](diffhunk://#diff-85b7ebdadb3a236968e5db16a85fe79871d23a93453e408f8770ab9d28546424L216-R243) [[6]](diffhunk://#diff-85b7ebdadb3a236968e5db16a85fe79871d23a93453e408f8770ab9d28546424R261-R311) [[7]](diffhunk://#diff-85b7ebdadb3a236968e5db16a85fe79871d23a93453e408f8770ab9d28546424L287-R346) [[8]](diffhunk://#diff-85b7ebdadb3a236968e5db16a85fe79871d23a93453e408f8770ab9d28546424R371-R392)

**Rate Limiting and Mocking:**

* Added rate limit entries for the new `MessageRules/ListMessageRules` endpoint in the aggregator service configuration. [[1]](diffhunk://#diff-e60b5025833f18cfd6a63fac0d0b0699f6c393ceeda964c9e8dea15b2dae23d9R49) [[2]](diffhunk://#diff-e60b5025833f18cfd6a63fac0d0b0699f6c393ceeda964c9e8dea15b2dae23d9R60)
* Added mock generation for the `MetricLabeler` interface in the verifier package to support testing. (.mockery.yaml)

These changes collectively ensure that message disablement rules are enforced at the verifier level, provide robust testing for rule enforcement and replay scenarios, and maintain service reliability through proper rate limiting and testability enhancements.