### PR TITLE
Justfile: fix lint recipe

### DIFF
--- a/.github/actions/lint-test-component/action.yaml
+++ b/.github/actions/lint-test-component/action.yaml
@@ -57,7 +57,9 @@ runs:
           chainlink-ccv-gotools-${{ runner.os }}-
 
     - name: Install just
-      uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v2.0.0
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      with:
+        just-version: '1.40.0'
 
     - name: Install golangci-lint
       shell: bash

--- a/.github/workflows/build-push-main.yaml
+++ b/.github/workflows/build-push-main.yaml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
         with:
           just-version: '1.40.0'
 

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Install gomods
         run: go install github.com/jmank88/gomods@v${{ steps.tool-versions.outputs.gomods_version }}

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ inputs.git-ref }}
 
       - name: Install Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
         with:
           just-version: '1.40.0'
 

--- a/.github/workflows/release-rc-publish.yaml
+++ b/.github/workflows/release-rc-publish.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Authenticate to AWS ECR (primary)
         uses: ./.github/actions/aws-ecr-auth

--- a/.github/workflows/repo-hygiene.yaml
+++ b/.github/workflows/repo-hygiene.yaml
@@ -37,7 +37,9 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install just
-        uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v2.0.0
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Install go-tools
         run: just install-go-tools

--- a/.github/workflows/test-coverage-report.yaml
+++ b/.github/workflows/test-coverage-report.yaml
@@ -36,7 +36,9 @@ jobs:
           restore-keys: |
             chainlink-ccv-gotools-${{ runner.os }}-
       - name: Install just
-        uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v2.0.0
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
       - name: Install go-tools
         run: just install-go-tools
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -42,7 +42,9 @@ jobs:
             chainlink-ccv-gotools-${{ runner.os }}-
 
       - name: Install just
-        uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v2.0.0
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Install go-tools
         run: just install-go-tools

--- a/.github/workflows/test-nightly-performance-chaos.yaml
+++ b/.github/workflows/test-nightly-performance-chaos.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Install Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Authenticate to AWS ECR
         uses: ./.github/actions/aws-ecr-auth

--- a/.github/workflows/test-performance-on-demand.yaml
+++ b/.github/workflows/test-performance-on-demand.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Install Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Authenticate to AWS ECR
         uses: ./.github/actions/aws-ecr-auth

--- a/.github/workflows/test-services.yaml
+++ b/.github/workflows/test-services.yaml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Install Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Authenticate to AWS ECR
         uses: ./.github/actions/aws-ecr-auth

--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Install Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Authenticate to AWS ECR
         uses: ./.github/actions/aws-ecr-auth

--- a/.github/workflows/test-testnets-integration.yaml
+++ b/.github/workflows/test-testnets-integration.yaml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Authenticate to AWS ECR
         uses: ./.github/actions/aws-ecr-auth

--- a/Justfile
+++ b/Justfile
@@ -47,9 +47,10 @@ tidy: ensure-go
 fmt: ensure-golangci-lint
     find . -type f -name go.mod -execdir golangci-lint fmt \;
 
-# Run golangci-lint
+# Run golangci-lint (positional args: fix?, timeout?). Pass `true` or `fix` as the first arg to add
+# golangci's --fix; other tokens (e.g. mistyped `--timeout`) must not enable --fix.
 lint fix="" timeout="10m": ensure-golangci-lint
-    gomods -c 'golangci-lint run --config {{justfile_directory()}}/.golangci.yaml {{ if fix != "" { "--fix" } else { "" } }} --timeout {{timeout}}'
+    gomods -c 'golangci-lint run --config {{justfile_directory()}}/.golangci.yaml {{ if fix == "true" { "--fix" } else if fix == "fix" { "--fix" } else { "" } }} --timeout {{timeout}}'
 
 shellcheck:
     @command -v shellcheck >/dev/null 2>&1 || { \


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

The lint recipe was always running `--fix` in CI because Just has
positional arguments and not named flags. To make the command less error
prone, only add `--fix` if the positional argument is either "true" or
"fix".

The Just version was also inconsistently being set in the CI jobs, so
use 1.40.0 to be consistent.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

All CI should continue to pass normally, despite pinning the Justfile version to 1.40.0 there.

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
