### PR TITLE
fix sv jobSpec

### DIFF
--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -314,13 +314,16 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 
 	verifierMonitoring.RecordServiceStarted(ctx)
 
-	// Setup HTTP server for health checks and status
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	// Dedicated mux per Start(): JD job replacement calls Start again after Stop. Using
+	// http.HandleFunc would register on DefaultServeMux, which is never cleared — second
+	// Start panics with conflicting pattern "/".
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		lggr.Infow("CCV Verifier is running!\n")
 		lggr.Infow("Verifier ID: %s\n", coordinatorConfig.VerifierID)
 	})
 
-	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		for serviceName, err := range coordinator.HealthReport() {
 			if err != nil {
 				w.WriteHeader(http.StatusServiceUnavailable)
@@ -332,7 +335,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		lggr.Infow("Healthy\n")
 	})
 
-	http.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
 		stats := aggregatorWriter.GetStats()
 		lggr.Infow("Storage Statistics:\n")
 		for key, value := range stats {
@@ -342,7 +345,12 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 
 	// Start HTTP server
 	// TODO: listen port should be configurable.
-	server := &http.Server{Addr: ":8100", ReadTimeout: 10 * time.Second, WriteTimeout: 10 * time.Second}
+	server := &http.Server{
+		Addr:         ":8100",
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
 	go func() {
 		lggr.Infow("🌐 HTTP server starting", "port", "8100")
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

When the Job Distributor sends a replacement job proposal to the standalone committee verifier (second `StartJob` in the same process after `StopJob`), the process can panic and exit.  example below;

```text
: "chainlink-canton-committee-verifier"}
panic: pattern "/" (registered at /go/pkg/mod/github.com/smartcontractkit/chainlink-ccv@v0.0.0-20260414185437-e41e205c8bfa/verifier/cmd/servicefactory.go:347) conflicts with pattern "/" (registered at /go/pkg/mod/github.com/smartcontractkit/chainlink-ccv@v0.0.0-20260414185437-e41e205c8bfa/verifier/cmd/servicefactory.go:347):
        / matches the same requests as /

goroutine 145 [running]:
net/http.(*ServeMux).register(...)
        /usr/local/go/src/net/http/server.go:2911
net/http.HandleFunc({0x1dde020?, 0x1e0b378?}, 0xc000378770?)
        /usr/local/go/src/net/http/server.go:2905 +0x85
github.com/smartcontractkit/chainlink-ccv/verifier/cmd.(*factory[...]).Start(0x1e0f0c0, {0x1e0b378, 0xc000378770}, {{0x0, 0x0}, {0xc001006c41, 0x24}, 0x1, {0xc001006c1a, 0x14}, ...}, ...)
        /go/pkg/mod/github.com/smartcontractkit/chainlink-ccv@v0.0.0-20260414185437-e41e205c8bfa/verifier/cmd/servicefactory.go:347 +0x2c98
github.com/smartcontractkit/chainlink-ccv/bootstrap.(*runner).StartJob(0xc000574ae0, {0x1e0b378, 0xc000378770}, {0xc000eef800, 0x591})
        /go/pkg/mod/github.com/smartcontractkit/chainlink-ccv@v0.0.0-20260414185437-e41e205c8bfa/bootstrap/bootstrap.go:67 +0x16e
github.com/smartcontractkit/chainlink-ccv/common/jd/lifecycle.(*Manager).handleProposal(0xc0005545b0, 0xc0003fec40)
        /go/pkg/mod/github.com/smartcontractkit/chainlink-ccv@v0.0.0-20260414185437-e41e205c8bfa/common/jd/lifecycle/manager.go:246 +0x3f1
github.com/smartcontractkit/chainlink-ccv/common/jd/lifecycle.(*Manager).eventLoop(0xc0005545b0)
        /go/pkg/mod/github.com/smartcontractkit/chainlink-ccv@v0.0.0-20260414185437-e41e205c8bfa/common/jd/lifecycle/manager.go:196 +0x28e
github.com/smartcontractkit/chainlink-ccv/bootstrap.(*Bootstrapper).startWithJDLifecycle.(*Manager).Start.func1.2()
        /go/pkg/mod/github.com/smartcontractkit/chainlink-ccv@v0.0.0-20260414185437-e41e205c8bfa/common/jd/lifecycle/manager.go:179 +0x17
sync.(*WaitGroup).Go.func1()
        /usr/local/go/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 1
        /usr/local/go/src/sync/waitgroup.go:237 +0x73
sish@MB-GK0096RV2L chainlink-ccv-deploy % 
```

Downstream impact 

- Container restarts; `job_store` may stay on the old revision if the crash happens before `SaveJob` completes.
- Logs may show shutdown of the first job, then startup of the new job, then panic — not always as a structured `level=error` line.

Root cause

`http.HandleFunc` registers handlers on the package-global default `ServeMux` (`http.DefaultServeMux`). That mux is never cleared when an `http.Server` is shut down.

1. First `Start()` registers `/`, `/health`, `/stats` on `DefaultServeMux` and serves them with `http.Server{Addr: ":8100"}` (default handler is that mux).
2. JD replacement → `StopJob` → server shutdown — registrations remain.
3. Second `Start()` calls `http.HandleFunc("/", ...)` again → duplicate pattern `/` → **panic**.

Fix: 
Use a **new `http.ServeMux` per `Start()`** and pass it explicitly:

```go
mux := http.NewServeMux()
mux.HandleFunc("/", ...)
mux.HandleFunc("/health", ...)
mux.HandleFunc("/stats", ...)
server := &http.Server{
    Addr:    ":8100",
    Handler: mux,
    // ...
}

