### PR TITLE
CODEOWNERS: add ccip-1-7-offchain to build/devenv

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 * @smartcontractkit/ccip-1-7-offchain
-build/devenv @smartcontractkit/ccip-platform
+build/devenv @smartcontractkit/ccip-platform @smartcontractkit/ccip-1-7-offchain
 deployment @smartcontractkit/ccip-platform
+bootstrap @smartcontractkit/ccip-platform @smartcontractkit/ccip-1-7-offchain


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

The ccip-platform team is quite small right now so it becomes a problem
especially if some folks are not available in many time zones. So, until
the ccip-platform group is larger, add back ccip-1-7-offchain to
build/devenv.

Add ccip-platform as a codeowner of bootstrap as well, since this group
was the primary author.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

N/A

<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
