### PR TITLE
Fix ApplyVerifierConfig: committee chain selectors span multiple signer families error

### DIFF
--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -667,7 +667,7 @@ func generateVerifierJobSpecs(
 				CommitteeQualifier:       committeeName,
 				DefaultExecutorQualifier: devenvcommon.DefaultExecutorQualifier,
 				NOPs:                     ccvchangesets.NOPInputsFromTopology(topology),
-				Committee:                ccvchangesets.CommitteeInputFromTopology(committee),
+				Committee:                ccvchangesets.CommitteeInputFromTopologyPerFamily(committee, family),
 				PyroscopeURL:             topology.PyroscopeURL,
 				Monitoring:               topology.Monitoring,
 				TargetNOPs:               verNOPAliases,

--- a/deployment/changesets/topology_inputs.go
+++ b/deployment/changesets/topology_inputs.go
@@ -4,6 +4,8 @@ import (
 	"slices"
 	"strconv"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	ccvdeployment "github.com/smartcontractkit/chainlink-ccv/deployment"
 	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
 )
@@ -59,6 +61,25 @@ func CommitteeInputFromTopology(committee ccvdeployment.CommitteeConfig) Committ
 		Aggregators:  aggregators,
 		ChainConfigs: chainConfigs,
 	}
+}
+
+// CommitteeInputFromTopologyPerFamily is like [CommitteeInputFromTopology] but keeps only
+// source-chain configs whose selector maps to chainFamily (e.g. chainsel.FamilyEVM,
+// chainsel.FamilySolana). Callers that invoke [ApplyVerifierConfig] once per verifier
+// chain family must pass a committee sliced this way so signer-family checks see a
+// single family per invocation.
+func CommitteeInputFromTopologyPerFamily(committee ccvdeployment.CommitteeConfig, chainFamily string) CommitteeInput {
+	out := CommitteeInputFromTopology(committee)
+	filtered := make(map[uint64]CommitteeChainMembership, len(out.ChainConfigs))
+	for sel, membership := range out.ChainConfigs {
+		family, err := chainsel.GetSelectorFamily(sel)
+		if err != nil || family != chainFamily {
+			continue
+		}
+		filtered[sel] = membership
+	}
+	out.ChainConfigs = filtered
+	return out
 }
 
 // ExecutorPoolInputFromTopology converts a topology ExecutorPoolConfig into the

--- a/deployment/changesets/topology_inputs.go
+++ b/deployment/changesets/topology_inputs.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
-
 	ccvdeployment "github.com/smartcontractkit/chainlink-ccv/deployment"
 	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
 )
@@ -29,12 +28,10 @@ func NOPInputsFromTopology(topology *ccvdeployment.EnvironmentTopology) []NOPInp
 	return out
 }
 
-// CommitteeInputFromTopology converts a topology CommitteeConfig into the
-// imperative ApplyVerifierConfig committee input. The onchain-only fields
-// (threshold, fee aggregator, allowlist admin) are intentionally not carried
-// — those are written by the onchain changesets, not by the offchain
-// verifier-config publisher.
-func CommitteeInputFromTopology(committee ccvdeployment.CommitteeConfig) CommitteeInput {
+// CommitteeInputFromTopologyPerFamily converts a topology CommitteeConfig into the imperative changeset CommitteeInput,
+// filtering the chain configs to only include those matching the given chain family. Callers that invoke [ApplyVerifierConfig] once per verifier
+// chain family must pass a committee sliced this way so signer-family checks see a single family per invocation.
+func CommitteeInputFromTopologyPerFamily(committee ccvdeployment.CommitteeConfig, chainFamily string) CommitteeInput {
 	aggregators := make([]AggregatorRef, len(committee.Aggregators))
 	for i, agg := range committee.Aggregators {
 		aggregators[i] = AggregatorRef{
@@ -51,6 +48,13 @@ func CommitteeInputFromTopology(committee ccvdeployment.CommitteeConfig) Committ
 			// Topology validation rejects non-uint64 keys; defensive skip.
 			continue
 		}
+
+		family, err := chainsel.GetSelectorFamily(sel)
+		if err != nil || family != chainFamily {
+			// Skip chain configs that don't match the requested family.
+			continue
+		}
+
 		chainConfigs[sel] = CommitteeChainMembership{
 			NOPAliases: shared.ConvertStringToNopAliases(chainCfg.NOPAliases),
 		}
@@ -61,25 +65,6 @@ func CommitteeInputFromTopology(committee ccvdeployment.CommitteeConfig) Committ
 		Aggregators:  aggregators,
 		ChainConfigs: chainConfigs,
 	}
-}
-
-// CommitteeInputFromTopologyPerFamily is like [CommitteeInputFromTopology] but keeps only
-// source-chain configs whose selector maps to chainFamily (e.g. chainsel.FamilyEVM,
-// chainsel.FamilySolana). Callers that invoke [ApplyVerifierConfig] once per verifier
-// chain family must pass a committee sliced this way so signer-family checks see a
-// single family per invocation.
-func CommitteeInputFromTopologyPerFamily(committee ccvdeployment.CommitteeConfig, chainFamily string) CommitteeInput {
-	out := CommitteeInputFromTopology(committee)
-	filtered := make(map[uint64]CommitteeChainMembership, len(out.ChainConfigs))
-	for sel, membership := range out.ChainConfigs {
-		family, err := chainsel.GetSelectorFamily(sel)
-		if err != nil || family != chainFamily {
-			continue
-		}
-		filtered[sel] = membership
-	}
-	out.ChainConfigs = filtered
-	return out
 }
 
 // ExecutorPoolInputFromTopology converts a topology ExecutorPoolConfig into the

--- a/deployment/changesets/topology_inputs_test.go
+++ b/deployment/changesets/topology_inputs_test.go
@@ -1,0 +1,32 @@
+package changesets
+
+import (
+	"strconv"
+	"testing"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	ccvdeployment "github.com/smartcontractkit/chainlink-ccv/deployment"
+)
+
+func TestCommitteeInputFromTopologyPerFamily_filtersChainConfigs(t *testing.T) {
+	t.Parallel()
+	committee := ccvdeployment.CommitteeConfig{
+		Qualifier: "default",
+		ChainConfigs: map[string]ccvdeployment.ChainCommitteeConfig{
+			strconv.FormatUint(chainsel.SOLANA_DEVNET.Selector, 10):     {NOPAliases: []string{"nop1"}},
+			strconv.FormatUint(chainsel.ETHEREUM_MAINNET.Selector, 10): {NOPAliases: []string{"nop2"}},
+		},
+	}
+
+	sol := CommitteeInputFromTopologyPerFamily(committee, chainsel.FamilySolana)
+	require.Len(t, sol.ChainConfigs, 1)
+	_, ok := sol.ChainConfigs[chainsel.SOLANA_DEVNET.Selector]
+	require.True(t, ok)
+
+	evm := CommitteeInputFromTopologyPerFamily(committee, chainsel.FamilyEVM)
+	require.Len(t, evm.ChainConfigs, 1)
+	_, ok = evm.ChainConfigs[chainsel.ETHEREUM_MAINNET.Selector]
+	require.True(t, ok)
+}

--- a/deployment/changesets/topology_inputs_test.go
+++ b/deployment/changesets/topology_inputs_test.go
@@ -4,8 +4,9 @@ import (
 	"strconv"
 	"testing"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	ccvdeployment "github.com/smartcontractkit/chainlink-ccv/deployment"
 )

--- a/deployment/changesets/topology_inputs_test.go
+++ b/deployment/changesets/topology_inputs_test.go
@@ -15,7 +15,7 @@ func TestCommitteeInputFromTopologyPerFamily_filtersChainConfigs(t *testing.T) {
 	committee := ccvdeployment.CommitteeConfig{
 		Qualifier: "default",
 		ChainConfigs: map[string]ccvdeployment.ChainCommitteeConfig{
-			strconv.FormatUint(chainsel.SOLANA_DEVNET.Selector, 10):     {NOPAliases: []string{"nop1"}},
+			strconv.FormatUint(chainsel.SOLANA_DEVNET.Selector, 10):    {NOPAliases: []string{"nop1"}},
 			strconv.FormatUint(chainsel.ETHEREUM_MAINNET.Selector, 10): {NOPAliases: []string{"nop2"}},
 		},
 	}


### PR DESCRIPTION
The recent [change](https://github.com/smartcontractkit/chainlink-ccv/pull/1079/changes#diff-3e22a5f4008455439bb221656190b272a8d201057251702ff5bfc4c91bb865a5R669) introduces a bug in devenv:

`Error: failed to generate verifier configs for committee default: failed to determine signer address family: committee chain selectors span multiple signer families: "evm" and "solana"`


This PR fix it by isolating ApplyVerifierConfig committee input for each chain families.