### PR TITLE
indexer: Use cache in Dockerfile.dev

### DIFF
--- a/indexer/Dockerfile.dev
+++ b/indexer/Dockerfile.dev
@@ -10,7 +10,9 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
 
 # Then copy the rest of the source
 COPY . .
-RUN CGO_ENABLED=0 go build -o /bin/indexer-replay ./indexer/cmd/replay/main.go
+RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
+    --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
+    CGO_ENABLED=0 go build -o /bin/indexer-replay ./indexer/cmd/replay/main.go
 WORKDIR /app/indexer
 ENV DEVELOPMENT_LOG_PROFILE=true
 CMD ["air", "-c", "air.toml"]


### PR DESCRIPTION
Noticed on CI, indexer re-downloads dependencies otherwise:

```
#13 [stage-0 7/8] RUN CGO_ENABLED=0 go build -o /bin/indexer-replay ./indexer/cmd/replay/main.go
#13 0.150 go: downloading github.com/olekukonko/tablewriter v0.0.5
#13 0.150 go: downloading github.com/jmoiron/sqlx v1.4.0
#13 0.159 go: downloading github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629
#13 0.161 go: downloading github.com/urfave/cli v1.22.14
#13 0.161 go: downloading go.uber.org/zap v1.27.1
#13 0.168 go: downloading github.com/failsafe-go/failsafe-go v0.9.0
#13 0.406 go: downloading google.golang.org/grpc v1.81.0
#13 0.408 go: downloading github.com/grafana/pyroscope-go v1.2.8
#13 0.721 go: downloading go.opentelemetry.io/otel v1.43.0
#13 0.722 go: downloading go.opentelemetry.io/otel/metric v1.43.0
#13 0.722 go: downloading go.opentelemetry.io/otel/sdk/metric v1.43.0
#13 0.722 go: downloading github.com/BurntSushi/toml v1.5.0
#13 0.778 go: downloading go.opentelemetry.io/otel/sdk v1.43.0
#13 0.785 go: downloading github.com/smartcontractkit/chainlink-protos/chainlink-ccv/verifier v0.0.0-20251211142334-5c3421fe2c8d
#13 0.785 go: downloading github.com/lib/pq v1.11.1
#13 0.786 go: downloading github.com/pressly/goose/v3 v3.26.0
#13 0.789 go: downloading github.com/google/uuid v1.6.0
#13 0.816 go: downloading google.golang.org/protobuf v1.36.11
#13 0.824 go: downloading github.com/ethereum/go-ethereum v1.17.2
#13 0.864 go: downloading github.com/smartcontractkit/chain-selectors v1.0.98
#13 0.915 go: downloading golang.org/x/crypto v0.49.0
#13 0.936 go: downloading github.com/mattn/go-runewidth v0.0.16
#13 0.975 go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.7
#13 1.010 go: downloading go.uber.org/multierr v1.11.0
#13 1.044 go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9
#13 1.080 go: downloading github.com/smartcontractkit/chainlink-protos/chainlink-ccv/committee-verifier v0.0.0-20251211142334-5c3421fe2c8d
#13 1.105 go: downloading github.com/smartcontractkit/chainlink-protos/chainlink-ccv/message-discovery v0.0.0-20251211142334-5c3421fe2c8d
#13 1.112 go: downloading github.com/grafana/pyroscope-go/godeltaprof v0.1.9
#13 1.112 go: downloading github.com/smartcontractkit/libocr v0.0.0-20260304194147-a03701e2c02e
#13 1.114 go: downloading go.opentelemetry.io/otel/trace v1.43.0
#13 1.115 go: downloading github.com/XSAM/otelsql v0.37.0
#13 1.123 go: downloading github.com/jackc/pgx/v4 v4.18.3
#13 1.163 go: downloading github.com/prometheus/client_golang v1.23.2
#13 1.170 go: downloading github.com/scylladb/go-reflectx v1.0.1
#13 1.193 go: downloading github.com/go-playground/validator/v10 v10.30.1
#13 1.194 go: downloading github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10
#13 1.199 go: downloading go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
#13 1.229 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
#13 1.234 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
#13 1.244 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
#13 1.244 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
#13 1.277 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
#13 1.277 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
#13 1.277 go: downloading go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.19.0
#13 1.294 go: downloading go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.43.0
#13 1.294 go: downloading go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0
#13 1.306 go: downloading go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
#13 1.312 go: downloading go.opentelemetry.io/otel/log v0.19.0
#13 1.336 go: downloading go.opentelemetry.io/otel/sdk/log v0.19.0
#13 1.344 go: downloading golang.org/x/net v0.52.0
#13 1.348 go: downloading github.com/sethvargo/go-retry v0.3.0
#13 1.349 go: downloading github.com/mr-tron/base58 v1.2.0
#13 1.350 go: downloading gopkg.in/yaml.v3 v3.0.1
#13 1.355 go: downloading github.com/rivo/uniseg v0.4.7
#13 1.381 go: downloading github.com/russross/blackfriday/v2 v2.1.0
#13 1.381 go: downloading github.com/bits-and-blooms/bitset v1.24.0
#13 1.382 go: downloading golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa
#13 1.412 go: downloading golang.org/x/sys v0.42.0
#13 1.429 go: downloading github.com/klauspost/compress v1.18.5
#13 1.431 go: downloading github.com/jackc/pgconn v1.14.3
#13 1.467 go: downloading github.com/jackc/pgio v1.0.0
#13 1.467 go: downloading github.com/jackc/pgproto3/v2 v2.3.3
#13 1.499 go: downloading github.com/jackc/pgtype v1.14.4
#13 1.506 go: downloading github.com/go-logr/logr v1.4.3
#13 1.542 go: downloading github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.16.2
#13 1.572 go: downloading github.com/cloudevents/sdk-go/v2 v2.16.2
#13 1.574 go: downloading github.com/beorn7/perks v1.0.1
#13 1.583 go: downloading github.com/cespare/xxhash/v2 v2.3.0
#13 1.609 go: downloading github.com/prometheus/client_model v0.6.2
#13 1.616 go: downloading github.com/prometheus/common v0.66.1
#13 1.653 go: downloading github.com/prometheus/procfs v0.16.1
#13 1.665 go: downloading github.com/gabriel-vasile/mimetype v1.4.13
#13 1.685 go: downloading github.com/go-playground/universal-translator v0.18.1
#13 1.689 go: downloading github.com/leodido/go-urn v1.4.0
#13 1.690 go: downloading golang.org/x/text v0.35.0
#13 1.731 go: downloading go.opentelemetry.io/proto/otlp v1.10.0
#13 1.783 go: downloading github.com/mfridman/interpolate v0.0.2
#13 1.785 go: downloading golang.org/x/sync v0.20.0
#13 1.793 go: downloading github.com/influxdata/tdigest v0.0.1
#13 1.806 go: downloading github.com/hashicorp/golang-lru/v2 v2.0.7
#13 1.810 go: downloading github.com/smartcontractkit/chainlink-protos/chainlink-ccv/heartbeat v0.0.0-20260115142640-f6b99095c12e
#13 1.816 go: downloading github.com/go-logr/stdr v1.2.2
#13 1.822 go: downloading go.opentelemetry.io/auto/sdk v1.2.1
#13 1.837 go: downloading github.com/jackc/chunkreader/v2 v2.0.1
#13 1.839 go: downloading github.com/jackc/pgpassfile v1.0.0
#13 1.844 go: downloading github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761
#13 1.866 go: downloading github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
#13 1.866 go: downloading go.yaml.in/yaml/v2 v2.4.2
#13 1.871 go: downloading github.com/go-playground/locales v0.14.1
#13 1.894 go: downloading github.com/cenkalti/backoff/v5 v5.0.3
#13 1.917 go: downloading github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
#13 1.922 go: downloading github.com/cenkalti/backoff v2.2.1+incompatible
#13 2.104 go: downloading github.com/json-iterator/go v1.1.12
#13 2.108 go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
#13 2.205 go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
#13 2.205 go: downloading github.com/modern-go/reflect2 v1.0.2
#13 2.618 go: downloading github.com/holiman/uint256 v1.3.2
#13 2.618 go: downloading github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
#13 DONE 17.3s
```