### PR TITLE
tcapi: chain-agnostic address lookup in std test suite

### DIFF
--- a/build/devenv/evm/addressresolver/resolver.go
+++ b/build/devenv/evm/addressresolver/resolver.go
@@ -36,45 +36,52 @@ func New() addressresolver.AddressResolver {
 	return Resolver{}
 }
 
-// Resolve implements [addressresolver.AddressResolver].
-func (Resolver) Resolve(ds datastore.DataStore, chainSelector uint64, ref addressresolver.ContractRef) (protocol.UnknownAddress, error) {
-	switch ref.Role {
-	case addressresolver.RoleMockReceiver:
-		return getContractAddress(ds, chainSelector,
-			datastore.ContractType(mock_receiver_v2.ContractType),
-			mock_receiver_v2.Deploy.Version(),
-			ref.Qualifier,
-			"mock receiver",
-		)
-	case addressresolver.RoleExecutor:
-		return getContractAddress(ds, chainSelector,
-			datastore.ContractType(sequences.ExecutorProxyType),
-			proxy.Deploy.Version(),
-			ref.Qualifier,
-			"executor",
-		)
-	case addressresolver.RoleExecutorImpl:
-		return getContractAddress(ds, chainSelector,
-			datastore.ContractType(sequences.ExecutorProxyType),
-			executor.Deploy.Version(),
-			ref.Qualifier,
-			"executor",
-		)
-	case addressresolver.RoleCommitteeVerifierResolver:
-		return getContractAddress(ds, chainSelector,
-			datastore.ContractType(versioned_verifier_resolver.CommitteeVerifierResolverType),
-			versioned_verifier_resolver.Version.String(),
-			ref.Qualifier,
-			"committee verifier proxy",
-		)
-	case addressresolver.RoleBurnMintERC20:
-		return getContractAddress(ds, chainSelector,
-			datastore.ContractType(burn_mint_erc20_with_drip.ContractType),
-			burn_mint_erc20_with_drip.Deploy.Version(),
-			ref.Qualifier,
-			"burn mint erc677",
-		)
-	default:
-		return protocol.UnknownAddress{}, fmt.Errorf("evmaddr: unsupported contract role %q", ref.Role)
-	}
+// GetContractReceiver implements [addressresolver.AddressResolver].
+func (Resolver) GetContractReceiver(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error) {
+	return getContractAddress(ds, chainSelector,
+		datastore.ContractType(mock_receiver_v2.ContractType),
+		mock_receiver_v2.Deploy.Version(),
+		qualifier,
+		"mock receiver",
+	)
+}
+
+// GetExecutor implements [addressresolver.AddressResolver].
+func (Resolver) GetExecutor(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error) {
+	return getContractAddress(ds, chainSelector,
+		datastore.ContractType(sequences.ExecutorProxyType),
+		proxy.Deploy.Version(),
+		qualifier,
+		"executor",
+	)
+}
+
+// GetExecutorImpl implements [addressresolver.AddressResolver].
+func (Resolver) GetExecutorImpl(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error) {
+	return getContractAddress(ds, chainSelector,
+		datastore.ContractType(sequences.ExecutorProxyType),
+		executor.Deploy.Version(),
+		qualifier,
+		"executor",
+	)
+}
+
+// GetCommitteeCCV implements [addressresolver.AddressResolver].
+func (Resolver) GetCommitteeCCV(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error) {
+	return getContractAddress(ds, chainSelector,
+		datastore.ContractType(versioned_verifier_resolver.CommitteeVerifierResolverType),
+		versioned_verifier_resolver.Version.String(),
+		qualifier,
+		"committee verifier proxy",
+	)
+}
+
+// GetBurnMintERC20 implements [addressresolver.AddressResolver].
+func (Resolver) GetBurnMintERC20(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error) {
+	return getContractAddress(ds, chainSelector,
+		datastore.ContractType(burn_mint_erc20_with_drip.ContractType),
+		burn_mint_erc20_with_drip.Deploy.Version(),
+		qualifier,
+		"burn mint erc677",
+	)
 }

--- a/build/devenv/evm/addressresolver/resolver.go
+++ b/build/devenv/evm/addressresolver/resolver.go
@@ -1,0 +1,80 @@
+// Package evmaddr implements [addressresolver.AddressResolver] for EVM devenv deployments.
+package evmaddr
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20_with_drip"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/executor"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/mock_receiver_v2"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/proxy"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/versioned_verifier_resolver"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/addressresolver"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+)
+
+func getContractAddress(ds datastore.DataStore, chainSelector uint64, contractType datastore.ContractType, version, qualifier, contractName string) (protocol.UnknownAddress, error) {
+	ref, err := ds.Addresses().Get(
+		datastore.NewAddressRefKey(chainSelector, contractType, semver.MustParse(version), qualifier),
+	)
+	if err != nil {
+		return protocol.UnknownAddress{}, fmt.Errorf("failed to get %s address for chain selector %d, ContractType: %s, ContractVersion: %s: %w",
+			contractName, chainSelector, contractType, version, err)
+	}
+	return protocol.NewUnknownAddressFromHex(ref.Address)
+}
+
+// Resolver implements [addressresolver.AddressResolver] for EVM chains using v2.0.0 devenv deployments.
+type Resolver struct{}
+
+// New returns an [addressresolver.AddressResolver] for EVM chains.
+func New() addressresolver.AddressResolver {
+	return Resolver{}
+}
+
+// Resolve implements [addressresolver.AddressResolver].
+func (Resolver) Resolve(ds datastore.DataStore, chainSelector uint64, ref addressresolver.ContractRef) (protocol.UnknownAddress, error) {
+	switch ref.Role {
+	case addressresolver.RoleMockReceiver:
+		return getContractAddress(ds, chainSelector,
+			datastore.ContractType(mock_receiver_v2.ContractType),
+			mock_receiver_v2.Deploy.Version(),
+			ref.Qualifier,
+			"mock receiver",
+		)
+	case addressresolver.RoleExecutor:
+		return getContractAddress(ds, chainSelector,
+			datastore.ContractType(sequences.ExecutorProxyType),
+			proxy.Deploy.Version(),
+			ref.Qualifier,
+			"executor",
+		)
+	case addressresolver.RoleExecutorImpl:
+		return getContractAddress(ds, chainSelector,
+			datastore.ContractType(sequences.ExecutorProxyType),
+			executor.Deploy.Version(),
+			ref.Qualifier,
+			"executor",
+		)
+	case addressresolver.RoleCommitteeVerifierResolver:
+		return getContractAddress(ds, chainSelector,
+			datastore.ContractType(versioned_verifier_resolver.CommitteeVerifierResolverType),
+			versioned_verifier_resolver.Version.String(),
+			ref.Qualifier,
+			"committee verifier proxy",
+		)
+	case addressresolver.RoleBurnMintERC20:
+		return getContractAddress(ds, chainSelector,
+			datastore.ContractType(burn_mint_erc20_with_drip.ContractType),
+			burn_mint_erc20_with_drip.Deploy.Version(),
+			ref.Qualifier,
+			"burn mint erc677",
+		)
+	default:
+		return protocol.UnknownAddress{}, fmt.Errorf("evmaddr: unsupported contract role %q", ref.Role)
+	}
+}

--- a/build/devenv/tests/e2e/smoke_test.go
+++ b/build/devenv/tests/e2e/smoke_test.go
@@ -8,10 +8,12 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	burn_mint_erc20_with_drip_v1_5 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/burn_mint_erc20_with_drip"
 	ccv "github.com/smartcontractkit/chainlink-ccv/build/devenv"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cciptestinterfaces"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/common"
+	evmaddr "github.com/smartcontractkit/chainlink-ccv/build/devenv/evm/addressresolver"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/basic"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/token_transfer"
@@ -48,9 +50,12 @@ func TestE2ESmoke_Basic(t *testing.T) {
 		tcapi.WithAggregatorClients(aggregators),
 		tcapi.WithIndexerMonitor(mon),
 	}
+	addressResolvers := tcapi.AddressResolvers{
+		chainsel.FamilyEVM: evmaddr.New(),
+	}
 
 	t.Run("extra args v3 messaging", func(t *testing.T) {
-		cases, err := basic.All(ctx, env, caseOpts...)
+		cases, err := basic.All(ctx, env, addressResolvers, caseOpts...)
 		require.NoError(t, err)
 		for _, tc := range cases {
 			if tc.HavePrerequisites(ctx) {
@@ -66,7 +71,7 @@ func TestE2ESmoke_Basic(t *testing.T) {
 
 	t.Run("extra args v3 token transfer", func(t *testing.T) {
 		combos := common.AllTokenCombinations()
-		cases, err := token_transfer.All(ctx, env, combos, caseOpts...)
+		cases, err := token_transfer.All(ctx, env, addressResolvers, combos, caseOpts...)
 		require.NoError(t, err)
 		for _, tc := range cases {
 			if tc.HavePrerequisites(ctx) {
@@ -78,7 +83,7 @@ func TestE2ESmoke_Basic(t *testing.T) {
 				t.Logf("Skipping %s because current environment does not have the prerequisites", tc.Name())
 			}
 		}
-		cases17, err := token_transfer.All17(ctx, env, combos, caseOpts...)
+		cases17, err := token_transfer.All17(ctx, env, addressResolvers, combos, caseOpts...)
 		require.NoError(t, err)
 		for _, tc := range cases17 {
 			if tc.HavePrerequisites(ctx) {

--- a/build/devenv/tests/e2e/tcapi/address_resolver.go
+++ b/build/devenv/tests/e2e/tcapi/address_resolver.go
@@ -2,37 +2,17 @@ package tcapi
 
 import (
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/addressresolver"
-	"github.com/smartcontractkit/chainlink-ccv/protocol"
 )
 
-// Contract roles and refs (see package addressresolver).
 type (
-	ContractRole     = addressresolver.ContractRole
-	ContractRef      = addressresolver.ContractRef
 	AddressResolver  = addressresolver.AddressResolver
 	AddressResolvers = addressresolver.Resolvers
 )
 
-const (
-	RoleMockReceiver              = addressresolver.RoleMockReceiver
-	RoleExecutor                  = addressresolver.RoleExecutor
-	RoleExecutorImpl              = addressresolver.RoleExecutorImpl
-	RoleCommitteeVerifierResolver = addressresolver.RoleCommitteeVerifierResolver
-	RoleBurnMintERC20             = addressresolver.RoleBurnMintERC20
-)
-
-// ResolveAddress looks up ref on chainSelector using the resolver for that chain's family.
-func (d *CaseDeps) ResolveAddress(chainSelector uint64, ref ContractRef) (protocol.UnknownAddress, error) {
-	if d == nil {
-		return protocol.UnknownAddress{}, addressresolver.ErrResolversRequired
+// ResolverAt returns the [AddressResolver] for the chain family of chainSelector.
+func (d *CaseDeps) ResolverAt(chainSelector uint64) (AddressResolver, error) {
+	if d == nil || len(d.AddressResolvers) == 0 {
+		return nil, addressresolver.ErrResolversRequired
 	}
-	return addressresolver.Resolve(d.AddressResolvers, d.DataStore, chainSelector, ref)
-}
-
-// CommitteeCCV resolves a committee verifier proxy on the source chain as protocol.CCV.
-func (d *CaseDeps) CommitteeCCV(chainSelector uint64, qualifier string) (protocol.CCV, error) {
-	if d == nil {
-		return protocol.CCV{}, addressresolver.ErrResolversRequired
-	}
-	return addressresolver.CommitteeCCV(d.AddressResolvers, d.DataStore, chainSelector, qualifier)
+	return addressresolver.ResolverFor(d.AddressResolvers, chainSelector)
 }

--- a/build/devenv/tests/e2e/tcapi/address_resolver.go
+++ b/build/devenv/tests/e2e/tcapi/address_resolver.go
@@ -1,0 +1,38 @@
+package tcapi
+
+import (
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/addressresolver"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+// Contract roles and refs (see package addressresolver).
+type (
+	ContractRole     = addressresolver.ContractRole
+	ContractRef      = addressresolver.ContractRef
+	AddressResolver  = addressresolver.AddressResolver
+	AddressResolvers = addressresolver.Resolvers
+)
+
+const (
+	RoleMockReceiver              = addressresolver.RoleMockReceiver
+	RoleExecutor                  = addressresolver.RoleExecutor
+	RoleExecutorImpl              = addressresolver.RoleExecutorImpl
+	RoleCommitteeVerifierResolver = addressresolver.RoleCommitteeVerifierResolver
+	RoleBurnMintERC20             = addressresolver.RoleBurnMintERC20
+)
+
+// ResolveAddress looks up ref on chainSelector using the resolver for that chain's family.
+func (d *CaseDeps) ResolveAddress(chainSelector uint64, ref ContractRef) (protocol.UnknownAddress, error) {
+	if d == nil {
+		return protocol.UnknownAddress{}, addressresolver.ErrResolversRequired
+	}
+	return addressresolver.Resolve(d.AddressResolvers, d.DataStore, chainSelector, ref)
+}
+
+// CommitteeCCV resolves a committee verifier proxy on the source chain as protocol.CCV.
+func (d *CaseDeps) CommitteeCCV(chainSelector uint64, qualifier string) (protocol.CCV, error) {
+	if d == nil {
+		return protocol.CCV{}, addressresolver.ErrResolversRequired
+	}
+	return addressresolver.CommitteeCCV(d.AddressResolvers, d.DataStore, chainSelector, qualifier)
+}

--- a/build/devenv/tests/e2e/tcapi/addressresolver/resolver.go
+++ b/build/devenv/tests/e2e/tcapi/addressresolver/resolver.go
@@ -1,6 +1,6 @@
-// Package addressresolver defines the contract-role address lookup used by tcapi test cases.
-// It lives under tcapi as a separate package so evmaddr can implement [AddressResolver]
-// without importing the parent tcapi package (import cycles).
+// Package addressresolver defines family-specific address lookup for tcapi test cases.
+// It lives as a subpackage so evmaddr can implement [AddressResolver] without importing
+// the parent tcapi package (import cycles).
 package addressresolver
 
 import (
@@ -16,58 +16,37 @@ import (
 // ErrResolversRequired is returned when address resolver dependencies are missing.
 var ErrResolversRequired = errors.New("address resolvers are required")
 
-// ContractRole identifies a logical contract deployed in devenv (family-specific type/version
-// are resolved by the AddressResolver for that chain's family).
-type ContractRole string
-
-const (
-	RoleMockReceiver              ContractRole = "mock_receiver"
-	RoleExecutor                  ContractRole = "executor"
-	RoleExecutorImpl              ContractRole = "executor_impl"
-	RoleCommitteeVerifierResolver ContractRole = "committee_verifier_resolver"
-	RoleBurnMintERC20             ContractRole = "burn_mint_erc20"
-)
-
-// ContractRef selects a contract on a chain by role and datastore qualifier.
-type ContractRef struct {
-	Role      ContractRole
-	Qualifier string
-}
-
-// AddressResolver maps a logical contract reference to an on-chain address for one chain family.
+// AddressResolver resolves well-known devenv contracts for one chain family.
 type AddressResolver interface {
-	Resolve(ds datastore.DataStore, chainSelector uint64, ref ContractRef) (protocol.UnknownAddress, error)
+	// GetContractReceiver returns the mock receiver contract address for the given qualifier.
+	GetContractReceiver(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error)
+	// GetExecutor returns the executor proxy address (standard proxy deployment version).
+	GetExecutor(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error)
+	// GetExecutorImpl returns the executor proxy address when registered under the executor-impl deployment version.
+	GetExecutorImpl(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error)
+	// GetCommitteeCCV returns the committee verifier resolver proxy address (not a full protocol.CCV; tests set args).
+	GetCommitteeCCV(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error)
+	// GetBurnMintERC20 returns the burn-mint ERC-20 / ERC-677 token contract address for the pool qualifier.
+	GetBurnMintERC20(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error)
 }
 
 // Resolvers maps chain family (e.g. chainsel.FamilyEVM) to a resolver for that family.
 type Resolvers map[string]AddressResolver
 
-// Resolve looks up ref on the chain identified by chainSelector using the resolver for that family.
-func Resolve(resolvers Resolvers, ds datastore.DataStore, chainSelector uint64, ref ContractRef) (protocol.UnknownAddress, error) {
+// ResolverFor returns the [AddressResolver] for the chain family of chainSelector.
+func ResolverFor(resolvers Resolvers, chainSelector uint64) (AddressResolver, error) {
 	if len(resolvers) == 0 {
-		return protocol.UnknownAddress{}, fmt.Errorf("address resolvers map is required")
+		return nil, fmt.Errorf("address resolvers map is required")
 	}
 	family, err := chainsel.GetSelectorFamily(chainSelector)
 	if err != nil {
-		return protocol.UnknownAddress{}, fmt.Errorf("chain selector %d: %w", chainSelector, err)
+		return nil, fmt.Errorf("chain selector %d: %w", chainSelector, err)
 	}
-	resolver, ok := resolvers[family]
-	if !ok || resolver == nil {
-		return protocol.UnknownAddress{}, fmt.Errorf("no address resolver for chain family %q (selector %d)", family, chainSelector)
+	r, ok := resolvers[family]
+	if !ok || r == nil {
+		return nil, fmt.Errorf("no address resolver for chain family %q (selector %d)", family, chainSelector)
 	}
-	return resolver.Resolve(ds, chainSelector, ref)
-}
-
-// CommitteeCCV resolves a committee verifier proxy as protocol.CCV.
-func CommitteeCCV(resolvers Resolvers, ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.CCV, error) {
-	addr, err := Resolve(resolvers, ds, chainSelector, ContractRef{
-		Role:      RoleCommitteeVerifierResolver,
-		Qualifier: qualifier,
-	})
-	if err != nil {
-		return protocol.CCV{}, err
-	}
-	return protocol.CCV{CCVAddress: addr, Args: []byte{}, ArgsLen: 0}, nil
+	return r, nil
 }
 
 // ValidateResolvers ensures resolvers are present for the source and destination chain families.
@@ -76,13 +55,8 @@ func ValidateResolvers(resolvers Resolvers, srcSel, dstSel uint64) error {
 		return fmt.Errorf("address resolvers map is required")
 	}
 	for _, sel := range []uint64{srcSel, dstSel} {
-		family, err := chainsel.GetSelectorFamily(sel)
-		if err != nil {
-			return fmt.Errorf("chain selector %d: %w", sel, err)
-		}
-		resolver, ok := resolvers[family]
-		if !ok || resolver == nil {
-			return fmt.Errorf("no address resolver for chain family %q (selector %d)", family, sel)
+		if _, err := ResolverFor(resolvers, sel); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/build/devenv/tests/e2e/tcapi/addressresolver/resolver.go
+++ b/build/devenv/tests/e2e/tcapi/addressresolver/resolver.go
@@ -1,0 +1,89 @@
+// Package addressresolver defines the contract-role address lookup used by tcapi test cases.
+// It lives under tcapi as a separate package so evmaddr can implement [AddressResolver]
+// without importing the parent tcapi package (import cycles).
+package addressresolver
+
+import (
+	"errors"
+	"fmt"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+)
+
+// ErrResolversRequired is returned when address resolver dependencies are missing.
+var ErrResolversRequired = errors.New("address resolvers are required")
+
+// ContractRole identifies a logical contract deployed in devenv (family-specific type/version
+// are resolved by the AddressResolver for that chain's family).
+type ContractRole string
+
+const (
+	RoleMockReceiver              ContractRole = "mock_receiver"
+	RoleExecutor                  ContractRole = "executor"
+	RoleExecutorImpl              ContractRole = "executor_impl"
+	RoleCommitteeVerifierResolver ContractRole = "committee_verifier_resolver"
+	RoleBurnMintERC20             ContractRole = "burn_mint_erc20"
+)
+
+// ContractRef selects a contract on a chain by role and datastore qualifier.
+type ContractRef struct {
+	Role      ContractRole
+	Qualifier string
+}
+
+// AddressResolver maps a logical contract reference to an on-chain address for one chain family.
+type AddressResolver interface {
+	Resolve(ds datastore.DataStore, chainSelector uint64, ref ContractRef) (protocol.UnknownAddress, error)
+}
+
+// Resolvers maps chain family (e.g. chainsel.FamilyEVM) to a resolver for that family.
+type Resolvers map[string]AddressResolver
+
+// Resolve looks up ref on the chain identified by chainSelector using the resolver for that family.
+func Resolve(resolvers Resolvers, ds datastore.DataStore, chainSelector uint64, ref ContractRef) (protocol.UnknownAddress, error) {
+	if len(resolvers) == 0 {
+		return protocol.UnknownAddress{}, fmt.Errorf("address resolvers map is required")
+	}
+	family, err := chainsel.GetSelectorFamily(chainSelector)
+	if err != nil {
+		return protocol.UnknownAddress{}, fmt.Errorf("chain selector %d: %w", chainSelector, err)
+	}
+	resolver, ok := resolvers[family]
+	if !ok || resolver == nil {
+		return protocol.UnknownAddress{}, fmt.Errorf("no address resolver for chain family %q (selector %d)", family, chainSelector)
+	}
+	return resolver.Resolve(ds, chainSelector, ref)
+}
+
+// CommitteeCCV resolves a committee verifier proxy as protocol.CCV.
+func CommitteeCCV(resolvers Resolvers, ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.CCV, error) {
+	addr, err := Resolve(resolvers, ds, chainSelector, ContractRef{
+		Role:      RoleCommitteeVerifierResolver,
+		Qualifier: qualifier,
+	})
+	if err != nil {
+		return protocol.CCV{}, err
+	}
+	return protocol.CCV{CCVAddress: addr, Args: []byte{}, ArgsLen: 0}, nil
+}
+
+// ValidateResolvers ensures resolvers are present for the source and destination chain families.
+func ValidateResolvers(resolvers Resolvers, srcSel, dstSel uint64) error {
+	if len(resolvers) == 0 {
+		return fmt.Errorf("address resolvers map is required")
+	}
+	for _, sel := range []uint64{srcSel, dstSel} {
+		family, err := chainsel.GetSelectorFamily(sel)
+		if err != nil {
+			return fmt.Errorf("chain selector %d: %w", sel, err)
+		}
+		resolver, ok := resolvers[family]
+		if !ok || resolver == nil {
+			return fmt.Errorf("no address resolver for chain family %q (selector %d)", family, sel)
+		}
+	}
+	return nil
+}

--- a/build/devenv/tests/e2e/tcapi/basic/v3.go
+++ b/build/devenv/tests/e2e/tcapi/basic/v3.go
@@ -119,6 +119,42 @@ func (tc *v3TestCase) HavePrerequisites(ctx context.Context) bool {
 	return tc.hydrate(ctx, tc)
 }
 
+func committeeVerifierCCV(deps *tcapi.CaseDeps, srcSel uint64, qual string) (protocol.CCV, error) {
+	r, err := deps.ResolverAt(srcSel)
+	if err != nil {
+		return protocol.CCV{}, err
+	}
+	addr, err := r.GetCommitteeCCV(deps.DataStore, srcSel, qual)
+	if err != nil {
+		return protocol.CCV{}, err
+	}
+	return protocol.CCV{CCVAddress: addr, Args: []byte{}, ArgsLen: 0}, nil
+}
+
+func mockReceiverAddr(deps *tcapi.CaseDeps, dstSel uint64, qual string) (protocol.UnknownAddress, error) {
+	r, err := deps.ResolverAt(dstSel)
+	if err != nil {
+		return protocol.UnknownAddress{}, err
+	}
+	return r.GetContractReceiver(deps.DataStore, dstSel, qual)
+}
+
+func executorAddr(deps *tcapi.CaseDeps, srcSel uint64, qual string) (protocol.UnknownAddress, error) {
+	r, err := deps.ResolverAt(srcSel)
+	if err != nil {
+		return protocol.UnknownAddress{}, err
+	}
+	return r.GetExecutor(deps.DataStore, srcSel, qual)
+}
+
+func executorImplAddr(deps *tcapi.CaseDeps, srcSel uint64, qual string) (protocol.UnknownAddress, error) {
+	r, err := deps.ResolverAt(srcSel)
+	if err != nil {
+		return protocol.UnknownAddress{}, err
+	}
+	return r.GetExecutorImpl(deps.DataStore, srcSel, qual)
+}
+
 // CustomExecutor returns a test case that uses the custom executor.
 func CustomExecutor(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps) tcapi.TestCase {
 	return customExecutor(src, dest, deps)
@@ -138,17 +174,17 @@ func customExecutor(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps) *
 			numExpectedVerifications: 1,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tc.deps.ResolveAddress(dest.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.DefaultReceiverQualifier})
+			receiver, err := mockReceiverAddr(tc.deps, dest.ChainSelector(), common.DefaultReceiverQualifier)
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := tc.deps.CommitteeCCV(src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
+			ccv, err := committeeVerifierCCV(tc.deps, src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tc.deps.ResolveAddress(src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.CustomExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, src.ChainSelector(), common.CustomExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -181,12 +217,12 @@ func eoaReceiverDefaultVerifier(src, dest cciptestinterfaces.CCIP17, deps *tcapi
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
+			ccv, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -219,16 +255,16 @@ func eoaReceiverSecondaryVerifier(src, dest cciptestinterfaces.CCIP17, deps *tca
 				return false
 			}
 			tc.receiver = receiver
-			sec, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
+			sec, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			def, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
+			def, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{sec, def}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -257,17 +293,17 @@ func receiverSecondaryVerifierRequired(src, dest cciptestinterfaces.CCIP17, deps
 			aggregatorQualifier:      common.SecondaryCommitteeVerifierQualifier,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.SecondaryReceiverQualifier})
+			receiver, err := mockReceiverAddr(tc.deps, tc.dst.ChainSelector(), common.SecondaryReceiverQualifier)
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
+			ccv, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -296,21 +332,21 @@ func receiverSecondaryRequiredTertiaryOptionalThreshold1(src, dest cciptestinter
 			aggregatorQualifier:      common.SecondaryCommitteeVerifierQualifier,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.SecondaryReceiverQualifier})
+			receiver, err := mockReceiverAddr(tc.deps, tc.dst.ChainSelector(), common.SecondaryReceiverQualifier)
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			sec, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
+			sec, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			ter, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
+			ter, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{sec, ter}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutorImpl, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorImplAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -338,25 +374,25 @@ func receiverQuaternaryAllThreeVerifiers(src, dest cciptestinterfaces.CCIP17, de
 			numExpectedVerifications: 3,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.QuaternaryReceiverQualifier})
+			receiver, err := mockReceiverAddr(tc.deps, tc.dst.ChainSelector(), common.QuaternaryReceiverQualifier)
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			def, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
+			def, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			sec, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
+			sec, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			ter, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
+			ter, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{def, sec, ter}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -384,21 +420,21 @@ func receiverQuaternaryDefaultAndSecondary(src, dest cciptestinterfaces.CCIP17, 
 			numExpectedVerifications: 2,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.QuaternaryReceiverQualifier})
+			receiver, err := mockReceiverAddr(tc.deps, tc.dst.ChainSelector(), common.QuaternaryReceiverQualifier)
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			def, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
+			def, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			sec, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
+			sec, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{def, sec}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -426,21 +462,21 @@ func receiverQuaternaryDefaultAndTertiary(src, dest cciptestinterfaces.CCIP17, d
 			numExpectedVerifications: 2,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.QuaternaryReceiverQualifier})
+			receiver, err := mockReceiverAddr(tc.deps, tc.dst.ChainSelector(), common.QuaternaryReceiverQualifier)
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			def, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
+			def, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			ter, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
+			ter, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{def, ter}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -473,17 +509,17 @@ func maxDataSize(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps) *v3T
 				return false
 			}
 			tc.msgData = bytes.Repeat([]byte("a"), int(maxDataBytes))
-			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.DefaultReceiverQualifier})
+			receiver, err := mockReceiverAddr(tc.deps, tc.dst.ChainSelector(), common.DefaultReceiverQualifier)
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
+			ccv, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}
@@ -518,12 +554,12 @@ func eoaReceiverDefaultVerifierSafeTag(src, dest cciptestinterfaces.CCIP17, deps
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
+			ccv, err := committeeVerifierCCV(tc.deps, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			executorAddr, err := executorAddr(tc.deps, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			if err != nil {
 				return false
 			}

--- a/build/devenv/tests/e2e/tcapi/basic/v3.go
+++ b/build/devenv/tests/e2e/tcapi/basic/v3.go
@@ -8,16 +8,10 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/executor"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/mock_receiver_v2"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/proxy"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/versioned_verifier_resolver"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cciptestinterfaces"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/common"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
@@ -125,14 +119,6 @@ func (tc *v3TestCase) HavePrerequisites(ctx context.Context) bool {
 	return tc.hydrate(ctx, tc)
 }
 
-func getCommitteeCCV(ds datastore.DataStore, srcChainSelector uint64, qualifier, contractName string) (protocol.CCV, error) {
-	addr, err := tcapi.GetContractAddress(ds, srcChainSelector, datastore.ContractType(versioned_verifier_resolver.CommitteeVerifierResolverType), versioned_verifier_resolver.Version.String(), qualifier, contractName)
-	if err != nil {
-		return protocol.CCV{}, err
-	}
-	return protocol.CCV{CCVAddress: addr, Args: []byte{}, ArgsLen: 0}, nil
-}
-
 // CustomExecutor returns a test case that uses the custom executor.
 func CustomExecutor(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps) tcapi.TestCase {
 	return customExecutor(src, dest, deps)
@@ -152,17 +138,17 @@ func customExecutor(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps) *
 			numExpectedVerifications: 1,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tcapi.GetContractAddress(tc.deps.DataStore, dest.ChainSelector(), datastore.ContractType(mock_receiver_v2.ContractType), mock_receiver_v2.Deploy.Version(), common.DefaultReceiverQualifier, "default mock receiver")
+			receiver, err := tc.deps.ResolveAddress(dest.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.DefaultReceiverQualifier})
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			ccvAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, src.ChainSelector(), datastore.ContractType(versioned_verifier_resolver.CommitteeVerifierResolverType), versioned_verifier_resolver.Version.String(), common.DefaultCommitteeVerifierQualifier, "committee verifier proxy")
+			ccv, err := tc.deps.CommitteeCCV(src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			tc.ccvs = []protocol.CCV{{CCVAddress: ccvAddr, Args: []byte{}, ArgsLen: 0}}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.CustomExecutorQualifier, "executor")
+			tc.ccvs = []protocol.CCV{ccv}
+			executorAddr, err := tc.deps.ResolveAddress(src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.CustomExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -195,12 +181,12 @@ func eoaReceiverDefaultVerifier(src, dest cciptestinterfaces.CCIP17, deps *tcapi
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier, "committee verifier proxy")
+			ccv, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -233,16 +219,16 @@ func eoaReceiverSecondaryVerifier(src, dest cciptestinterfaces.CCIP17, deps *tca
 				return false
 			}
 			tc.receiver = receiver
-			sec, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier, "secondary committee verifier proxy")
+			sec, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			def, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier, "default committee verifier proxy")
+			def, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{sec, def}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -271,17 +257,17 @@ func receiverSecondaryVerifierRequired(src, dest cciptestinterfaces.CCIP17, deps
 			aggregatorQualifier:      common.SecondaryCommitteeVerifierQualifier,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.dst.ChainSelector(), datastore.ContractType(mock_receiver_v2.ContractType), mock_receiver_v2.Deploy.Version(), common.SecondaryReceiverQualifier, "secondary mock receiver")
+			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.SecondaryReceiverQualifier})
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier, "secondary committee verifier proxy")
+			ccv, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -310,21 +296,21 @@ func receiverSecondaryRequiredTertiaryOptionalThreshold1(src, dest cciptestinter
 			aggregatorQualifier:      common.SecondaryCommitteeVerifierQualifier,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.dst.ChainSelector(), datastore.ContractType(mock_receiver_v2.ContractType), mock_receiver_v2.Deploy.Version(), common.SecondaryReceiverQualifier, "secondary mock receiver")
+			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.SecondaryReceiverQualifier})
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			sec, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier, "secondary committee verifier proxy")
+			sec, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			ter, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier, "tertiary committee verifier proxy")
+			ter, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{sec, ter}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), executor.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutorImpl, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -352,25 +338,25 @@ func receiverQuaternaryAllThreeVerifiers(src, dest cciptestinterfaces.CCIP17, de
 			numExpectedVerifications: 3,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.dst.ChainSelector(), datastore.ContractType(mock_receiver_v2.ContractType), mock_receiver_v2.Deploy.Version(), common.QuaternaryReceiverQualifier, "quaternary mock receiver")
+			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.QuaternaryReceiverQualifier})
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			def, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier, "default committee verifier proxy")
+			def, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			sec, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier, "secondary committee verifier proxy")
+			sec, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			ter, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier, "tertiary committee verifier proxy")
+			ter, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{def, sec, ter}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -398,21 +384,21 @@ func receiverQuaternaryDefaultAndSecondary(src, dest cciptestinterfaces.CCIP17, 
 			numExpectedVerifications: 2,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.dst.ChainSelector(), datastore.ContractType(mock_receiver_v2.ContractType), mock_receiver_v2.Deploy.Version(), common.QuaternaryReceiverQualifier, "quaternary mock receiver")
+			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.QuaternaryReceiverQualifier})
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			def, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier, "default committee verifier proxy")
+			def, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			sec, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier, "secondary committee verifier proxy")
+			sec, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.SecondaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{def, sec}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -440,21 +426,21 @@ func receiverQuaternaryDefaultAndTertiary(src, dest cciptestinterfaces.CCIP17, d
 			numExpectedVerifications: 2,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
-			receiver, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.dst.ChainSelector(), datastore.ContractType(mock_receiver_v2.ContractType), mock_receiver_v2.Deploy.Version(), common.QuaternaryReceiverQualifier, "quaternary mock receiver")
+			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.QuaternaryReceiverQualifier})
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			def, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier, "default committee verifier proxy")
+			def, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
-			ter, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier, "tertiary committee verifier proxy")
+			ter, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.TertiaryCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{def, ter}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -487,17 +473,17 @@ func maxDataSize(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps) *v3T
 				return false
 			}
 			tc.msgData = bytes.Repeat([]byte("a"), int(maxDataBytes))
-			receiver, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.dst.ChainSelector(), datastore.ContractType(mock_receiver_v2.ContractType), mock_receiver_v2.Deploy.Version(), common.DefaultReceiverQualifier, "default mock receiver")
+			receiver, err := tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.DefaultReceiverQualifier})
 			if err != nil {
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier, "committee verifier proxy")
+			ccv, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -532,12 +518,12 @@ func eoaReceiverDefaultVerifierSafeTag(src, dest cciptestinterfaces.CCIP17, deps
 				return false
 			}
 			tc.receiver = receiver
-			ccv, err := getCommitteeCCV(tc.deps.DataStore, tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier, "committee verifier proxy")
+			ccv, err := tc.deps.CommitteeCCV(tc.src.ChainSelector(), common.DefaultCommitteeVerifierQualifier)
 			if err != nil {
 				return false
 			}
 			tc.ccvs = []protocol.CCV{ccv}
-			executorAddr, err := tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			executorAddr, err := tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			if err != nil {
 				return false
 			}
@@ -548,8 +534,8 @@ func eoaReceiverDefaultVerifierSafeTag(src, dest cciptestinterfaces.CCIP17, deps
 }
 
 // All returns all basic v3 messaging test cases (custom executor, multi-verifier, max data size).
-func All(ctx context.Context, env *deployment.Environment, opts ...tcapi.CaseOption) ([]tcapi.TestCase, error) {
-	deps, err := tcapi.BuildCaseDeps(ctx, env, opts...)
+func All(ctx context.Context, env *deployment.Environment, addressResolvers tcapi.AddressResolvers, opts ...tcapi.CaseOption) ([]tcapi.TestCase, error) {
+	deps, err := tcapi.BuildCaseDeps(ctx, env, addressResolvers, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/build/devenv/tests/e2e/tcapi/contracts.go
+++ b/build/devenv/tests/e2e/tcapi/contracts.go
@@ -1,28 +1,8 @@
 package tcapi
 
-import (
-	"fmt"
-	"time"
-
-	"github.com/Masterminds/semver/v3"
-
-	"github.com/smartcontractkit/chainlink-ccv/protocol"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-)
+import "time"
 
 const (
 	DefaultExecTimeout = 40 * time.Second
 	DefaultSentTimeout = 10 * time.Second
 )
-
-// GetContractAddress returns the contract address for the given chain and contract reference.
-func GetContractAddress(ds datastore.DataStore, chainSelector uint64, contractType datastore.ContractType, version, qualifier, contractName string) (protocol.UnknownAddress, error) {
-	ref, err := ds.Addresses().Get(
-		datastore.NewAddressRefKey(chainSelector, contractType, semver.MustParse(version), qualifier),
-	)
-	if err != nil {
-		return protocol.UnknownAddress{}, fmt.Errorf("failed to get %s address for chain selector %d, ContractType: %s, ContractVersion: %s: %w",
-			contractName, chainSelector, contractType, version, err)
-	}
-	return protocol.NewUnknownAddressFromHex(ref.Address)
-}

--- a/build/devenv/tests/e2e/tcapi/options.go
+++ b/build/devenv/tests/e2e/tcapi/options.go
@@ -1,7 +1,7 @@
-// Test wiring is configured with functional options (WithLane, WithAggregatorClients,
-// WithIndexerMonitor). Pass those to case constructors—for example basic.All or
-// token_transfer.All—alongside a deployment.Environment. BuildCaseDeps resolves options
-// inside those subpackages into CaseDeps; external test code should not call it directly.
+// Test wiring requires AddressResolvers (one per chain family on the lane) plus optional
+// functional options (WithLane, WithAggregatorClients, WithIndexerMonitor). Pass those to
+// case constructors—for example basic.All or token_transfer.All—alongside a
+// deployment.Environment.
 package tcapi
 
 import (
@@ -12,6 +12,7 @@ import (
 
 	ccv "github.com/smartcontractkit/chainlink-ccv/build/devenv"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cciptestinterfaces"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/addressresolver"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
@@ -25,6 +26,7 @@ type CaseDeps struct {
 	AggregatorClients map[string]*ccv.AggregatorClient
 	IndexerMonitor    *ccv.IndexerMonitor
 	ChainMap          map[uint64]cciptestinterfaces.CCIP17
+	AddressResolvers  AddressResolvers
 }
 
 type caseConfig struct {
@@ -89,9 +91,12 @@ func resolveCaseConfig(env *deployment.Environment, opts ...CaseOption) (*caseCo
 // BuildCaseDeps resolves CaseOptions into CaseDeps (CCIP17 handles and optional off-chain clients).
 // It is intended for use inside this module (basic and token_transfer packages), not as the primary
 // API for test authors; pass CaseOptions built from the With* functions to those constructors instead.
-func BuildCaseDeps(ctx context.Context, env *deployment.Environment, opts ...CaseOption) (*CaseDeps, error) {
+func BuildCaseDeps(ctx context.Context, env *deployment.Environment, addressResolvers AddressResolvers, opts ...CaseOption) (*CaseDeps, error) {
 	rc, err := resolveCaseConfig(env, opts...)
 	if err != nil {
+		return nil, err
+	}
+	if err := addressresolver.ValidateResolvers(addressResolvers, rc.srcSel, rc.dstSel); err != nil {
 		return nil, err
 	}
 	lg := zerolog.Ctx(ctx)
@@ -115,5 +120,6 @@ func BuildCaseDeps(ctx context.Context, env *deployment.Environment, opts ...Cas
 		AggregatorClients: rc.aggregators,
 		IndexerMonitor:    rc.indexer,
 		ChainMap:          chainMap,
+		AddressResolvers:  addressResolvers,
 	}, nil
 }

--- a/build/devenv/tests/e2e/tcapi/token_transfer/v3.go
+++ b/build/devenv/tests/e2e/tcapi/token_transfer/v3.go
@@ -187,24 +187,41 @@ func tokenTransferCase(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps
 			if tc.useEOAReceiver {
 				tc.receiver, err = tc.dst.GetEOAReceiverAddress()
 			} else {
-				tc.receiver, err = tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.DefaultReceiverQualifier})
+				var r tcapi.AddressResolver
+				r, err = tc.deps.ResolverAt(tc.dst.ChainSelector())
+				if err != nil {
+					return false
+				}
+				tc.receiver, err = r.GetContractReceiver(tc.deps.DataStore, tc.dst.ChainSelector(), common.DefaultReceiverQualifier)
 			}
 			if err != nil {
 				return false
 			}
 
 			srcQualifier := tc.combo.LocalPoolAddressRef().Qualifier
-			tc.srcToken, err = tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleBurnMintERC20, Qualifier: srcQualifier})
+			rSrc, err := tc.deps.ResolverAt(tc.src.ChainSelector())
+			if err != nil {
+				return false
+			}
+			tc.srcToken, err = rSrc.GetBurnMintERC20(tc.deps.DataStore, tc.src.ChainSelector(), srcQualifier)
 			if err != nil {
 				return false
 			}
 			destQualifier := tc.combo.RemotePoolAddressRef().Qualifier
-			tc.destToken, err = tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleBurnMintERC20, Qualifier: destQualifier})
+			rDst, err := tc.deps.ResolverAt(tc.dst.ChainSelector())
+			if err != nil {
+				return false
+			}
+			tc.destToken, err = rDst.GetBurnMintERC20(tc.deps.DataStore, tc.dst.ChainSelector(), destQualifier)
 			if err != nil {
 				return false
 			}
 
-			tc.executor, err = tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
+			rExec, err := tc.deps.ResolverAt(tc.src.ChainSelector())
+			if err != nil {
+				return false
+			}
+			tc.executor, err = rExec.GetExecutor(tc.deps.DataStore, tc.src.ChainSelector(), common.DefaultExecutorQualifier)
 			return err == nil
 		},
 	}

--- a/build/devenv/tests/e2e/tcapi/token_transfer/v3.go
+++ b/build/devenv/tests/e2e/tcapi/token_transfer/v3.go
@@ -8,15 +8,10 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20_with_drip"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/mock_receiver_v2"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/proxy"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cciptestinterfaces"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/common"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
@@ -164,14 +159,6 @@ func (tc *tokenTransferV3TestCase) HavePrerequisites(ctx context.Context) bool {
 	return tc.hydrate(ctx, tc)
 }
 
-func getTokenAddress(ds datastore.DataStore, chainSelector uint64, qualifier string) (protocol.UnknownAddress, error) {
-	return tcapi.GetContractAddress(ds, chainSelector,
-		datastore.ContractType(burn_mint_erc20_with_drip.ContractType),
-		burn_mint_erc20_with_drip.Deploy.Version(),
-		qualifier,
-		"burn mint erc677")
-}
-
 // TokenTransfer returns a single token transfer test case for the given combo, finality, receiver type, and name.
 func TokenTransfer(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string) tcapi.TestCase {
 	return tokenTransferCase(src, dest, deps, combo, finalityConfig, useEOAReceiver, name)
@@ -200,32 +187,32 @@ func tokenTransferCase(src, dest cciptestinterfaces.CCIP17, deps *tcapi.CaseDeps
 			if tc.useEOAReceiver {
 				tc.receiver, err = tc.dst.GetEOAReceiverAddress()
 			} else {
-				tc.receiver, err = tcapi.GetContractAddress(tc.deps.DataStore, tc.dst.ChainSelector(), datastore.ContractType(mock_receiver_v2.ContractType), mock_receiver_v2.Deploy.Version(), common.DefaultReceiverQualifier, "default mock receiver")
+				tc.receiver, err = tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleMockReceiver, Qualifier: common.DefaultReceiverQualifier})
 			}
 			if err != nil {
 				return false
 			}
 
 			srcQualifier := tc.combo.LocalPoolAddressRef().Qualifier
-			tc.srcToken, err = getTokenAddress(tc.deps.DataStore, tc.src.ChainSelector(), srcQualifier)
+			tc.srcToken, err = tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleBurnMintERC20, Qualifier: srcQualifier})
 			if err != nil {
 				return false
 			}
 			destQualifier := tc.combo.RemotePoolAddressRef().Qualifier
-			tc.destToken, err = getTokenAddress(tc.deps.DataStore, tc.dst.ChainSelector(), destQualifier)
+			tc.destToken, err = tc.deps.ResolveAddress(tc.dst.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleBurnMintERC20, Qualifier: destQualifier})
 			if err != nil {
 				return false
 			}
 
-			tc.executor, err = tcapi.GetContractAddress(tc.deps.DataStore, tc.src.ChainSelector(), datastore.ContractType(sequences.ExecutorProxyType), proxy.Deploy.Version(), common.DefaultExecutorQualifier, "executor")
+			tc.executor, err = tc.deps.ResolveAddress(tc.src.ChainSelector(), tcapi.ContractRef{Role: tcapi.RoleExecutor, Qualifier: common.DefaultExecutorQualifier})
 			return err == nil
 		},
 	}
 }
 
 // All returns test cases for the given token combinations with EOA receiver and combo finality.
-func All(ctx context.Context, env *deployment.Environment, combos []common.TokenCombination, opts ...tcapi.CaseOption) ([]tcapi.TestCase, error) {
-	deps, err := tcapi.BuildCaseDeps(ctx, env, opts...)
+func All(ctx context.Context, env *deployment.Environment, addressResolvers tcapi.AddressResolvers, combos []common.TokenCombination, opts ...tcapi.CaseOption) ([]tcapi.TestCase, error) {
+	deps, err := tcapi.BuildCaseDeps(ctx, env, addressResolvers, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -240,8 +227,8 @@ func All(ctx context.Context, env *deployment.Environment, combos []common.Token
 }
 
 // All17 returns test cases for 2.0.0-only token combinations: EOA and mock receiver with default finality (0).
-func All17(ctx context.Context, env *deployment.Environment, combos []common.TokenCombination, opts ...tcapi.CaseOption) ([]tcapi.TestCase, error) {
-	deps, err := tcapi.BuildCaseDeps(ctx, env, opts...)
+func All17(ctx context.Context, env *deployment.Environment, addressResolvers tcapi.AddressResolvers, combos []common.TokenCombination, opts ...tcapi.CaseOption) ([]tcapi.TestCase, error) {
+	deps, err := tcapi.BuildCaseDeps(ctx, env, addressResolvers, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

The standard test suite in `tcapi` was using the evm-specific type and versions when looking up required contract addresses.

This PR adds an `AddressResolver` type that is implemented by each chain family, which contains explicit methods about how to look up each specific address needed by tests.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
