### PR TITLE
build/devenv: add env metadata to env-out.toml

### DIFF
--- a/build/devenv/cldf.go
+++ b/build/devenv/cldf.go
@@ -26,8 +26,15 @@ import (
 var Plog = log.Output(zerolog.ConsoleWriter{Out: os.Stderr}).Level(zerolog.DebugLevel).With().Fields(map[string]any{"component": "ccv"}).Logger()
 
 type CLDF struct {
-	mu        sync.Mutex          `toml:"-"`
-	Addresses []string            `toml:"addresses"`
+	mu sync.Mutex `toml:"-"`
+
+	// Addresses contains the addresses of all the contracts deployed to the environment.
+	// Each element corresponds to a chain.
+	Addresses []string `toml:"addresses"`
+
+	// EnvMetadata contains the EnvMetadata portion of the datastore, as populated by the environment setup.
+	EnvMetadata string `toml:"env_metadata"`
+
 	DataStore datastore.DataStore `toml:"-"`
 }
 
@@ -39,6 +46,12 @@ func (c *CLDF) AddAddresses(addresses string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.Addresses = append(c.Addresses, addresses)
+}
+
+func (c *CLDF) AddEnvMetadata(envMetadata string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.EnvMetadata = envMetadata
 }
 
 type CLDFEnvironmentConfig struct {

--- a/build/devenv/config.go
+++ b/build/devenv/config.go
@@ -125,15 +125,13 @@ func LoadOutput[T any](outputPath string) (*T, error) {
 	}
 
 	// Load env metadata into the datastore so that tests can query it appropriately.
-	envMetadataOut := make(map[string]any)
+	var dsMetaData datastore.EnvMetadata
 	if c.CLDF.EnvMetadata != "" {
-		if err := json.Unmarshal([]byte(c.CLDF.EnvMetadata), &envMetadataOut); err != nil {
+		if err := json.Unmarshal([]byte(c.CLDF.EnvMetadata), &dsMetaData); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal env metadata from config: %w", err)
 		}
 	}
-	err = ds.EnvMetadataStore.Set(datastore.EnvMetadata{
-		Metadata: envMetadataOut,
-	})
+	err = ds.EnvMetadata().Set(dsMetaData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set env metadata in datastore: %w", err)
 	}

--- a/build/devenv/config.go
+++ b/build/devenv/config.go
@@ -123,7 +123,23 @@ func LoadOutput[T any](outputPath string) (*T, error) {
 			}
 		}
 	}
+
+	// Load env metadata into the datastore so that tests can query it appropriately.
+	envMetadataOut := make(map[string]any)
+	if c.CLDF.EnvMetadata != "" {
+		if err := json.Unmarshal([]byte(c.CLDF.EnvMetadata), &envMetadataOut); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal env metadata from config: %w", err)
+		}
+	}
+	err = ds.EnvMetadataStore.Set(datastore.EnvMetadata{
+		Metadata: envMetadataOut,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set env metadata in datastore: %w", err)
+	}
+
 	c.CLDF.DataStore = ds.Seal()
+
 	return config, nil
 }
 

--- a/build/devenv/environment_monolith.go
+++ b/build/devenv/environment_monolith.go
@@ -777,6 +777,17 @@ func NewEnvironment() (in *Cfg, err error) {
 
 	e.DataStore = ds.Seal()
 
+	// Save the env metadata to the output CLDF struct so that it can be used by tests.
+	envMetadata, err := e.DataStore.EnvMetadata().Get()
+	if err != nil && err != datastore.ErrEnvMetadataNotSet {
+		return nil, fmt.Errorf("failed to get env metadata from datastore: %w", err)
+	}
+	envMetadataJSON, err := json.Marshal(envMetadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal env metadata: %w", err)
+	}
+	in.CLDF.AddEnvMetadata(string(envMetadataJSON))
+
 	if in.JDInfra != nil {
 		if err := jobs.AcceptPendingJobs(ctx, in.ClientLookup); err != nil {
 			return nil, fmt.Errorf("failed to accept pending jobs: %w", err)

--- a/build/devenv/environment_phased.go
+++ b/build/devenv/environment_phased.go
@@ -670,6 +670,17 @@ func runPhasedEnvironmentFinish(ctx context.Context, setup *phasedSetup) (cfg *C
 
 	e.DataStore = ds.Seal()
 
+	// Save the env metadata to the output CLDF struct so that it can be used by tests.
+	envMetadata, err := e.DataStore.EnvMetadata().Get()
+	if err != nil && err != datastore.ErrEnvMetadataNotSet {
+		return nil, nil, fmt.Errorf("failed to get env metadata from datastore: %w", err)
+	}
+	envMetadataJSON, err := json.Marshal(envMetadata)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal env metadata: %w", err)
+	}
+	in.CLDF.AddEnvMetadata(string(envMetadataJSON))
+
 	setup.TimeTrack.Print()
 	if err = PrintCLDFAddresses(in); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Since we've phased out passing the raw devenv Cfg object to chain
implementations, some data like Canton's EDS URL must be saved to the
datastore instead.

This makes it so that the EnvMetadata portion of the datastore that is
populated by the env spinup process is persisted to the env-out.toml
file so that when it is loaded, the metadata is available for chain
implementations to read from.

Supports https://github.com/smartcontractkit/chainlink-canton/pull/509

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
