### PR TITLE
CI: spin up envs using production images

### DIFF
--- a/.github/actions/run-load-test/action.yaml
+++ b/.github/actions/run-load-test/action.yaml
@@ -82,7 +82,7 @@ runs:
     - name: Build Docker Images
       shell: bash
       working-directory: build/devenv
-      run: just build-docker-dev-ci
+      run: just build-docker-ci
       env:
         DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/test-cl-smoke.yaml
+++ b/.github/workflows/test-cl-smoke.yaml
@@ -149,7 +149,7 @@ jobs:
           go mod download
 
       - name: Build Docker Images
-        run: just build-docker-dev-ci
+        run: just build-docker-ci
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/test-nightly-performance-chaos.yaml
+++ b/.github/workflows/test-nightly-performance-chaos.yaml
@@ -71,7 +71,7 @@ jobs:
           go mod download
 
       - name: Build Docker Images
-        run: just build-docker-dev-ci
+        run: just build-docker-ci
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/test-performance-on-demand.yaml
+++ b/.github/workflows/test-performance-on-demand.yaml
@@ -79,7 +79,7 @@ jobs:
           go mod download
 
       - name: Build Docker Images
-        run: just build-docker-dev-ci
+        run: just build-docker-ci
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/test-services.yaml
+++ b/.github/workflows/test-services.yaml
@@ -62,7 +62,7 @@ jobs:
           go mod download
 
       - name: Build Docker Images
-        run: just build-docker-dev-ci
+        run: just build-docker-ci
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -139,7 +139,7 @@ jobs:
           go mod download
 
       - name: Build Docker Images
-        run: just build-docker-dev-ci
+        run: just build-docker-ci
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/test-testnets-integration.yaml
+++ b/.github/workflows/test-testnets-integration.yaml
@@ -72,7 +72,7 @@ jobs:
           go mod download
 
       - name: Build Docker Images
-        run: just build-docker-dev-ci
+        run: just build-docker-ci
         env:
           DOCKER_BUILDKIT: 1
 

--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -14,9 +14,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     cd aggregator && CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/aggregator cmd/main.go
 
 FROM alpine:latest
-WORKDIR /app
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/aggregator bin/
+COPY --from=builder /bin/aggregator /bin/
 COPY --from=builder /app/aggregator/migrations /migrations
+WORKDIR /app
 RUN ln -s /migrations /app/migrations || true
-CMD ["/app/bin/aggregator"]
+CMD ["/bin/aggregator"]

--- a/build/devenv/Justfile
+++ b/build/devenv/Justfile
@@ -33,7 +33,7 @@ clean-docker-dev:
     just ../../aggregator/clean-dev >/dev/null 2>&1 || true
     rm -rf job-distributor/ >/dev/null 2>&1 || true
 
-# Build all the services (hot-reload dev mode)
+# Build all the services in hot-reload dev mode.
 build-docker-dev:
     @just build-jd-docker
     @just ../../build/devenv/fakes/build-dev
@@ -43,6 +43,8 @@ build-docker-dev:
     @just ../../indexer/build-dev
     @just ../../aggregator/build-dev
 
+# Build all the services using the production dockerfiles,
+# as well as the JD image from source.
 build-docker:
     @just build-jd-docker
     @just ../../build/devenv/fakes/build
@@ -52,23 +54,25 @@ build-docker:
     @just ../../indexer/build
     @just ../../aggregator/build
 
-# Build all the services (hot-reload dev mode but with default JD image)
-build-docker-dev-ci:
-    @just ../../build/devenv/fakes/build-dev
-    @just ../../pricer/build-dev
-    @just ../../verifier/build-dev
-    @just ../../executor/build-dev
-    @just ../../indexer/build-dev
-    @just ../../aggregator/build-dev
+# Remove all the production images.
+clean-docker:
+    just ../../build/devenv/fakes/clean >/dev/null 2>&1 || true
+    just ../../pricer/clean >/dev/null 2>&1 || true
+    just ../../verifier/clean >/dev/null 2>&1 || true
+    just ../../executor/clean >/dev/null 2>&1 || true
+    just ../../indexer/clean >/dev/null 2>&1 || true
+    just ../../aggregator/clean >/dev/null 2>&1 || true
+    rm -rf job-distributor/ >/dev/null 2>&1 || true
 
-# Build all the services for production
-build-docker-rc:
-    @just fakes/build
-    @just ../../services/pricer/build-rc
-    @just ../../services/verifier/build-rc
-    @just ../../services/executor/build-rc
-    @just ../../services/indexer/build-rc
-    @just ../../services/aggregator/build-rc
+# Build all the services using the production dockerfiles,
+# except for JD, which uses an image tag in CI.
+build-docker-ci:
+    @just ../../build/devenv/fakes/build
+    @just ../../pricer/build
+    @just ../../verifier/build
+    @just ../../executor/build
+    @just ../../indexer/build
+    @just ../../aggregator/build
 
 # Rebuild CLI
 cli:
@@ -76,13 +80,12 @@ cli:
 
 # Rebuild all (optionally pass config, defaults to env.toml)
 rebuild-all config="env.toml":
-    @just build-jd-docker
     echo "Building CLI and all services"
     @just cli
     ccv down
     echo "Cleaning up old images..."
-    @just clean-docker-dev
-    @just build-docker-dev
+    @just clean-docker
+    @just build-docker
     ccv up {{ config }}
 
 # Clone and build job-distributor Docker image

--- a/build/devenv/README.md
+++ b/build/devenv/README.md
@@ -28,11 +28,13 @@ All build command are run using [Justfile](https://github.com/casey/just?tab=rea
 ```
 brew install just # click the link above if you are not on OS X
 cd build/devenv
-just clean-docker-dev # needed in case you have old JD image
-just build-docker-dev
+just clean-docker # needed in case you have old JD image
+just build-docker
 just setup-gh
 just cli
 ```
+
+> **Note:** By default, the environment runs production images (`:latest`). If you need hot-reloading for a specific service, change its tag in your configuration (e.g. `env.toml`) to `:dev` and run `just ../../<service>/build-dev` (or simply run `just build-docker-dev` to build all dev images).
 
 Enter `ccv` shell and follow auto-completion hints
 ```

--- a/build/devenv/env-cl-16.toml
+++ b/build/devenv/env-cl-16.toml
@@ -218,7 +218,7 @@ execution_interval = 15_000_000_000
   type = "anvil"
 
 [fake]
-  image = "ccv-fakes:dev"
+  image = "ccv-fakes:latest"
   port = 9111
   source_code_path = "../build/devenv/fakes"
   root_path = "../../"
@@ -414,7 +414,7 @@ execution_interval = 15_000_000_000
 ## Default Verifier Setup (16 nodes)
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-1"
   nop_alias = "node-0"
   port = 8100
@@ -432,7 +432,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-2"
   nop_alias = "node-1"
   port = 8200
@@ -449,7 +449,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-3"
   nop_alias = "node-2"
   port = 8300
@@ -466,7 +466,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-4"
   nop_alias = "node-3"
   port = 8400
@@ -483,7 +483,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-5"
   nop_alias = "node-4"
   port = 8500
@@ -500,7 +500,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-6"
   nop_alias = "node-5"
   port = 8600
@@ -517,7 +517,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-7"
   nop_alias = "node-6"
   port = 8700
@@ -534,7 +534,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-8"
   nop_alias = "node-7"
   port = 9100
@@ -551,7 +551,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-9"
   nop_alias = "node-8"
   port = 9200
@@ -568,7 +568,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-10"
   nop_alias = "node-9"
   port = 9300
@@ -585,7 +585,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-11"
   nop_alias = "node-10"
   port = 9400
@@ -602,7 +602,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-12"
   nop_alias = "node-11"
   port = 9500
@@ -619,7 +619,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-13"
   nop_alias = "node-12"
   port = 9600
@@ -636,7 +636,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-14"
   nop_alias = "node-13"
   port = 9700
@@ -653,7 +653,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-15"
   nop_alias = "node-14"
   port = 9800
@@ -670,7 +670,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-16"
   nop_alias = "node-15"
   port = 10100
@@ -688,7 +688,7 @@ execution_interval = 15_000_000_000
 # Secondary Verifier Setup
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "secondary-verifier-1"
   nop_alias = "node-0"
   port = 10200
@@ -705,7 +705,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "secondary-verifier-2"
   nop_alias = "node-1"
   port = 10300
@@ -723,7 +723,7 @@ execution_interval = 15_000_000_000
 # Tertiary Verifier Setup
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "tertiary-verifier-1"
   nop_alias = "node-0"
   port = 10400
@@ -740,7 +740,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "tertiary-verifier-2"
   nop_alias = "node-1"
   port = 10500
@@ -757,7 +757,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-1"
@@ -769,7 +769,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-2"
@@ -781,7 +781,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-3"
@@ -793,7 +793,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-4"
@@ -805,7 +805,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-5"
@@ -817,7 +817,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-6"
@@ -829,7 +829,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-7"
@@ -841,7 +841,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-8"
@@ -853,7 +853,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-9"
@@ -865,7 +865,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-10"
@@ -877,7 +877,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-11"
@@ -889,7 +889,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-12"
@@ -901,7 +901,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-13"
@@ -913,7 +913,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-14"
@@ -925,7 +925,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-15"
@@ -937,7 +937,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-16"
@@ -949,7 +949,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "custom-executor-1"
@@ -960,7 +960,7 @@ execution_interval = 15_000_000_000
     name = "custom-executor-1-db"
 
 [[indexer]]
-  image = "indexer:dev"
+  image = "indexer:latest"
   port = 8103
   source_code_path = "../indexer"
   root_path = "../../"
@@ -1053,7 +1053,7 @@ LockTimeout = 30
 
 [[aggregator]]
   committee_name = "default"
-  image = "aggregator:dev"
+  image = "aggregator:latest"
   host_port = 50051
   source_code_path = "../aggregator"
   root_path = "../../"
@@ -1183,7 +1183,7 @@ LockTimeout = 30
 
 [[aggregator]]
   committee_name = "secondary"
-  image = "aggregator:dev"
+  image = "aggregator:latest"
   host_port = 50052
   source_code_path = "../aggregator"
   root_path = "../../"
@@ -1229,7 +1229,7 @@ LockTimeout = 30
 
 [[aggregator]]
   committee_name = "tertiary"
-  image = "aggregator:dev"
+  image = "aggregator:latest"
   host_port = 50053
   source_code_path = "../aggregator"
   root_path = "../../"

--- a/build/devenv/env-cl.toml
+++ b/build/devenv/env-cl.toml
@@ -157,7 +157,7 @@ execution_interval = 15_000_000_000
 ## Default Verifier Setup (2 nodes)
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-1"
   nop_alias = "node-0"
   port = 8100
@@ -173,7 +173,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-2"
   nop_alias = "node-1"
   port = 8200
@@ -190,7 +190,7 @@ execution_interval = 15_000_000_000
 # Secondary Verifier Setup (shares same 2 nodes)
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "secondary-verifier-1"
   nop_alias = "node-0"
   port = 8300
@@ -206,7 +206,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "secondary-verifier-2"
   nop_alias = "node-1"
   port = 8400
@@ -223,7 +223,7 @@ execution_interval = 15_000_000_000
 # Tertiary Verifier Setup (shares same 2 nodes)
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "tertiary-verifier-1"
   nop_alias = "node-0"
   port = 8500
@@ -239,7 +239,7 @@ execution_interval = 15_000_000_000
 
 [[verifier]]
   mode = "cl"
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "tertiary-verifier-2"
   nop_alias = "node-1"
   port = 8600
@@ -255,7 +255,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-1"
@@ -267,7 +267,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-2"
@@ -279,7 +279,7 @@ execution_interval = 15_000_000_000
 
 [[executor]]
   mode = "cl"
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "custom-executor-1"

--- a/build/devenv/env-pricer.toml
+++ b/build/devenv/env-pricer.toml
@@ -1,5 +1,5 @@
 [pricer]
-  image = "pricer:dev"
+  image = "pricer:latest"
   source_code_path = "../pricer"
   root_path = "../../"
   [pricer.keystore]

--- a/build/devenv/env.toml
+++ b/build/devenv/env.toml
@@ -192,14 +192,14 @@ execution_interval = 15_000_000_000
   type = "anvil"
 
 [fake]
-  image = "ccv-fakes:dev"
+  image = "ccv-fakes:latest"
   port = 9111
   source_code_path = "../build/devenv/fakes"
   root_path = "../../"
 
 ## Default Verifier Setup
 [[verifier]]
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-1"
   nop_alias = "default-verifier-1"
   port = 8100
@@ -215,7 +215,7 @@ execution_interval = 15_000_000_000
 
 
 [[verifier]]
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "default-verifier-2"
   nop_alias = "default-verifier-2"
   port = 8200
@@ -231,7 +231,7 @@ execution_interval = 15_000_000_000
 
 # Secondary Verifier Setup
 [[verifier]]
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "secondary-verifier-1"
   nop_alias = "secondary-verifier-1"
   port = 8300
@@ -246,7 +246,7 @@ execution_interval = 15_000_000_000
 
 
 [[verifier]]
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "secondary-verifier-2"
   nop_alias = "secondary-verifier-2"
   port = 8400
@@ -262,7 +262,7 @@ execution_interval = 15_000_000_000
 
 # Tertiary Verifier Setup
 [[verifier]]
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "tertiary-verifier-1"
   nop_alias = "tertiary-verifier-1"
   port = 8500
@@ -277,7 +277,7 @@ execution_interval = 15_000_000_000
 
 
 [[verifier]]
-  image = "verifier:dev"
+  image = "verifier:latest"
   container_name = "tertiary-verifier-2"
   nop_alias = "tertiary-verifier-2"
   port = 8600
@@ -293,7 +293,7 @@ execution_interval = 15_000_000_000
 
 [[token_verifier]]
   mode = "standalone"
-  image = "token-verifier:dev"
+  image = "token-verifier:latest"
   container_name = "token-verifier-1"
   port = 8700
   source_code_path = "../verifier"
@@ -305,7 +305,7 @@ execution_interval = 15_000_000_000
 
 
 [[executor]]
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-1"
@@ -316,7 +316,7 @@ execution_interval = 15_000_000_000
     name = "default-executor-1-db"
 
 [[executor]]
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "default-executor-2"
@@ -327,7 +327,7 @@ execution_interval = 15_000_000_000
     name = "default-executor-2-db"
 
 [[executor]]
-  image = "executor:dev"
+  image = "executor:latest"
   source_code_path = "../executor"
   root_path = "../../"
   container_name = "custom-executor-1"
@@ -338,7 +338,7 @@ execution_interval = 15_000_000_000
     name = "custom-executor-1-db"
 
 [[indexer]]
-  image = "indexer:dev"
+  image = "indexer:latest"
   port = 8104
   # will spawn additional indexers IF high_availability is set to true
   redundant_indexers = 1
@@ -454,7 +454,7 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
 
 [[aggregator]]
   committee_name = "default"
-  image = "aggregator:dev"
+  image = "aggregator:latest"
   host_port = 50051
   ## will spawn additional Aggregators IF high_availability is true
   redundant_aggregators = 1
@@ -502,7 +502,7 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
 
 [[aggregator]]
   committee_name = "secondary"
-  image = "aggregator:dev"
+  image = "aggregator:latest"
   host_port = 50052
   redundant_aggregators = 0
   source_code_path = "../aggregator"
@@ -548,7 +548,7 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
 
 [[aggregator]]
   committee_name = "tertiary"
-  image = "aggregator:dev"
+  image = "aggregator:latest"
   host_port = 50053
   redundant_aggregators = 0
   source_code_path = "../aggregator"

--- a/build/devenv/services/committeeverifier/base.go
+++ b/build/devenv/services/committeeverifier/base.go
@@ -28,7 +28,7 @@ import (
 const (
 	DefaultVerifierName    = "verifier"
 	DefaultVerifierDBName  = "verifier-db"
-	DefaultVerifierImage   = "verifier:dev"
+	DefaultVerifierImage   = "verifier:latest"
 	DefaultVerifierPort    = 8100
 	DefaultVerifierPortTCP = "8100/tcp"
 	DefaultVerifierDBPort  = 8432

--- a/build/devenv/services/executor/base.go
+++ b/build/devenv/services/executor/base.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	DefaultExecutorName    = "executor"
-	DefaultExecutorImage   = "executor:dev"
+	DefaultExecutorImage   = "executor:latest"
 	DefaultExecutorPort    = 8101
 	DefaultExecutorPortTCP = "8101/tcp"
 	DefaultExecutorMode    = services.Standalone

--- a/build/devenv/services/fake.go
+++ b/build/devenv/services/fake.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	DefaultFakeName  = "fake"
-	DefaultFakeImage = "ccv-fakes:dev"
+	DefaultFakeImage = "ccv-fakes:latest"
 	DefaultFakePort  = 9111
 )
 

--- a/build/devenv/services/indexer.go
+++ b/build/devenv/services/indexer.go
@@ -26,7 +26,7 @@ const (
 	FirstIndexerContainerName  = "indexer-1"
 	DefaultIndexerDBName       = "indexer-db"
 	IndexerDBContainerSuffix   = "-db"
-	DefaultIndexerImage        = "indexer:dev"
+	DefaultIndexerImage        = "indexer:latest"
 	DefaultIndexerHTTPPort     = 8102
 	DefaultIndexerInternalPort = 8100
 	DefaultIndexerDBPort       = 6432

--- a/build/devenv/services/pricer.go
+++ b/build/devenv/services/pricer.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	DefaultPricerName  = "pricer"
-	DefaultPricerImage = "pricer:dev"
+	DefaultPricerImage = "pricer:latest"
 	// default vars for a local devenv src chain: 1337.
 	DefaultKeystoreAddress      = "0x9221E2E83903C731C2927CCd84e5fa02B22Bb1E2"
 	DefaultKeystoreFilePath     = "../pricer/keystore.json"

--- a/build/devenv/tests/e2e/aggregatorcli/client.go
+++ b/build/devenv/tests/e2e/aggregatorcli/client.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	// DefaultBinaryPath is the in-container path of the aggregator binary.
-	// In devenv the binary is built by air into /tmp/aggregator (see aggregator/air.toml).
 	DefaultBinaryPath = "/bin/aggregator"
 )
 

--- a/build/devenv/tests/e2e/aggregatorcli/client.go
+++ b/build/devenv/tests/e2e/aggregatorcli/client.go
@@ -19,7 +19,7 @@ import (
 const (
 	// DefaultBinaryPath is the in-container path of the aggregator binary.
 	// In devenv the binary is built by air into /tmp/aggregator (see aggregator/air.toml).
-	DefaultBinaryPath = "/tmp/aggregator"
+	DefaultBinaryPath = "/bin/aggregator"
 )
 
 // Client talks to a single aggregator container. It is cheap to construct

--- a/build/devenv/tests/e2e/chaos_test.go
+++ b/build/devenv/tests/e2e/chaos_test.go
@@ -110,7 +110,7 @@ func TestChaos_VerifierFaultToleranceThresholdViolated(t *testing.T) {
 	containerRe2 := fmt.Sprintf("(%s)", strings.Join(func() []string {
 		names := make([]string, 0, len(toStop))
 		for _, verifier := range toStop {
-			names = append(names, verifier.Out.ContainerName)
+			names = append(names, fmt.Sprintf("^%s$", verifier.Out.ContainerName))
 		}
 		return names
 	}(), "|"))
@@ -164,7 +164,7 @@ func TestChaos_AllExecutorsDown(t *testing.T) {
 	var defaultExecutorContainerNames []string
 	for _, executor := range setup.in.Executor {
 		if executor.ExecutorQualifier == devenvcommon.DefaultExecutorQualifier {
-			defaultExecutorContainerNames = append(defaultExecutorContainerNames, executor.Out.ContainerName)
+			defaultExecutorContainerNames = append(defaultExecutorContainerNames, fmt.Sprintf("^%s$", executor.Out.ContainerName))
 		}
 	}
 	require.NotEmpty(t, defaultExecutorContainerNames, "default executor container names not found")
@@ -211,7 +211,7 @@ func TestChaos_IndexerDown(t *testing.T) {
 	indexerContainerName := setup.in.Indexer[0].Out.ContainerName
 	require.NotEmpty(t, indexerContainerName, "indexer container name not found")
 
-	pumbaCmd := fmt.Sprintf("stop --duration=%s --restart re2:%s", 30*time.Second, indexerContainerName)
+	pumbaCmd := fmt.Sprintf("stop --duration=%s --restart re2:%s", 30*time.Second, fmt.Sprintf("^%s$", indexerContainerName))
 	setup.l.Info().Str("pumbaCmd", pumbaCmd).Msg("Stopping the indexer prior to sending the message to simulate an outage")
 	pumbaClose, err := chaos.ExecPumba(
 		pumbaCmd,

--- a/build/devenv/tests/e2e/verifiercli/client.go
+++ b/build/devenv/tests/e2e/verifiercli/client.go
@@ -21,11 +21,11 @@ const (
 	// DefaultBinaryPath is the in-container path of the committee binary
 	// in the standard devenv image. Override with WithBinaryPath for
 	// alternate layouts.
-	DefaultBinaryPath = "/app/cmd/verifier/committee/tmp/committee"
+	DefaultBinaryPath = "/bin/verifier"
 
 	// DefaultProcessMatch is the pgrep/pkill pattern that matches the
 	// running committee process inside the container.
-	DefaultProcessMatch = "tmp/committee"
+	DefaultProcessMatch = "verifier"
 
 	// defaultRestartReadyTimeout bounds how long RestartAndWaitReady
 	// will poll the CLI before giving up.

--- a/build/devenv/tests/e2e/verifiercli/client.go
+++ b/build/devenv/tests/e2e/verifiercli/client.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// DefaultBinaryPath is the in-container path of the committee binary
-	// in the standard devenv image. Override with WithBinaryPath for
+	// in the standard production image. Override with WithBinaryPath for
 	// alternate layouts.
 	DefaultBinaryPath = "/bin/verifier"
 

--- a/build/devenv/tests/services/aggregator_test.go
+++ b/build/devenv/tests/services/aggregator_test.go
@@ -58,7 +58,7 @@ func TestServiceAggregator(t *testing.T) {
 
 	out, err := services.NewAggregator(&services.AggregatorInput{
 		CommitteeName:  committeeName,
-		Image:          "aggregator:dev",
+		Image:          "aggregator:latest",
 		HostPort:       8103,
 		SourceCodePath: "../../../aggregator",
 		RootPath:       "../../../../",
@@ -125,7 +125,7 @@ func TestServiceAggregatorAuthentication(t *testing.T) {
 
 	out, err := services.NewAggregator(&services.AggregatorInput{
 		CommitteeName:   committeeName,
-		Image:           "aggregator:dev",
+		Image:           "aggregator:latest",
 		HostPort:        8104,
 		ExposedHostPort: grpcHostPort,
 		SourceCodePath:  "../../../aggregator",
@@ -444,7 +444,7 @@ func setupAggregatorTestFixture(t *testing.T) *aggregatorTestFixture {
 	sourceChainSelStr := fmt.Sprintf("%d", sourceChainSel)
 	out, err := services.NewAggregator(&services.AggregatorInput{
 		CommitteeName:                committeeName,
-		Image:                        "aggregator:dev",
+		Image:                        "aggregator:latest",
 		HostPort:                     8110,
 		ExposedHostPort:              grpcHostPort, // Expose gRPC port directly for test
 		SourceCodePath:               "../../../aggregator",

--- a/build/devenv/tests/services/indexer_test.go
+++ b/build/devenv/tests/services/indexer_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestServiceIndexer(t *testing.T) {
 	out, err := services.NewIndexer(&services.IndexerInput{
+		Image:          "indexer:latest",
 		SourceCodePath: "../../../indexer",
 		RootPath:       "../../../../",
 		IndexerConfig: &config.Config{

--- a/verifier/Dockerfile
+++ b/verifier/Dockerfile
@@ -18,6 +18,11 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/verifier main.go
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates tini
 COPY --from=builder /bin/verifier /bin/
-CMD ["/bin/verifier"]
+# tini is needed here because the verifier would otherwise run as PID 1
+# and we wouldn't be able to pause it with pkill -STOP.
+# Sometimes that is required because we have to run a CLI command to
+# set the finalized height in order to replay messages that were dropped
+# under a curse.
+ENTRYPOINT ["/sbin/tini", "--", "/bin/verifier"]


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

So far we've been testing with the "dev" images which provide some hot
reload functionality which is in theory useful in dev mode. There are
downsides to this though:

1. The dev image is not the one shipped to producation. This means we're
   currently only testing dev images in CI, which are built using
   a different Dockerfile, which can diverge from the production
   version.
2. The dev image is far slower to start because it recompiles the Go
   code on each run. This is wasted cycles in CI because we spin up way
   more containers than we build images.

This commit:

1. Updates then env*.toml files to use ":latest" instead of ":dev",
   which are tags that refer to the images built using the production
   Dockerfiles.
2. Updates CI to test using the production images.


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
