### PR TITLE
extract LoadGun interface and AssertMessagesAsync into load

### DIFF
--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -41,7 +41,7 @@ type NonceKey struct {
 }
 
 // Compile time interface conformance check.
-var _ load.LoadGun = &EVMTXGun{}
+var _ load.LoadGun = (*EVMTXGun)(nil)
 
 type EVMTXGun struct {
 	cfg             *ccv.Cfg

--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -35,23 +35,13 @@ const (
 	avgMsgDataSize               = 1000 // bytes
 )
 
-type SrcDest struct {
-	Src  uint64
-	Dest uint64
-}
-
 type NonceKey struct {
 	Selector uint64
 	Address  string
 }
 
-// SentMessage represents a message that was sent and needs verification.
-type SentMessage struct {
-	SeqNo     uint64
-	MessageID [32]byte
-	SentTime  time.Time
-	ChainPair SrcDest
-}
+// Compile time interface conformance check.
+var _ load.LoadGun = &EVMTXGun{}
 
 type EVMTXGun struct {
 	cfg             *ccv.Cfg
@@ -59,13 +49,13 @@ type EVMTXGun struct {
 	e               *deployment.Environment
 	selectors       []uint64
 	impl            map[uint64]cciptestinterfaces.CCIP17
-	sentMsgSet      map[SentMessage]struct{}
+	sentMsgSet      map[load.SentMessage]struct{}
 	srcSelectors    []uint64
 	destSelectors   []uint64
 	seqNosMu        sync.Mutex
-	sentMsgCh       chan SentMessage // Channel for real-time message notifications
-	closeOnce       sync.Once        // Ensure channel is closed only once
-	nonce           sync.Map         // map[NonceKey]*uint64
+	sentMsgCh       chan load.SentMessage // Channel for real-time message notifications
+	closeOnce       sync.Once             // Ensure channel is closed only once
+	nonce           sync.Map              // map[NonceKey]*uint64
 	messageProfiles []load.MessageProfileConfig
 	userSelector    map[uint64]func() *bind.TransactOpts
 }
@@ -75,6 +65,11 @@ func (m *EVMTXGun) CloseSentChannel() {
 	m.closeOnce.Do(func() {
 		close(m.sentMsgCh)
 	})
+}
+
+// SentMessages returns the sent message channel for the verification pipeline.
+func (m *EVMTXGun) SentMessages() <-chan load.SentMessage {
+	return m.sentMsgCh
 }
 
 func NewEVMTransactionGun(cfg *ccv.Cfg, e *deployment.Environment, selectors []uint64, impls map[uint64]cciptestinterfaces.CCIP17, srcSelectors, destSelectors []uint64) (*EVMTXGun, error) {
@@ -91,8 +86,8 @@ func NewEVMTransactionGun(cfg *ccv.Cfg, e *deployment.Environment, selectors []u
 		e:             e,
 		selectors:     selectors,
 		impl:          impls,
-		sentMsgSet:    make(map[SentMessage]struct{}),
-		sentMsgCh:     make(chan SentMessage, sentMessageChannelBufferSize),
+		sentMsgSet:    make(map[load.SentMessage]struct{}),
+		sentMsgCh:     make(chan load.SentMessage, sentMessageChannelBufferSize),
 		srcSelectors:  srcSelectors,
 		destSelectors: destSelectors,
 		userSelector:  userSelector,
@@ -127,8 +122,8 @@ func NewEVMTransactionGunFromTestConfig(cfg *ccv.Cfg, testProfile *load.TestProf
 		e:               e,
 		selectors:       selectors,
 		impl:            impls,
-		sentMsgSet:      make(map[SentMessage]struct{}),
-		sentMsgCh:       make(chan SentMessage, sentMessageChannelBufferSize),
+		sentMsgSet:      make(map[load.SentMessage]struct{}),
+		sentMsgCh:       make(chan load.SentMessage, sentMessageChannelBufferSize),
 		srcSelectors:    srcSelectors,
 		destSelectors:   destSelectors,
 		messageProfiles: messageProfiles,
@@ -228,11 +223,11 @@ func (m *EVMTXGun) Call(_ *wasp.Generator) *wasp.Response {
 
 	// Record the actual sequence number from the sent event
 	m.seqNosMu.Lock()
-	m.sentMsgSet[SentMessage{SeqNo: uint64(sentEvent.Message.SequenceNumber), MessageID: sentEvent.MessageID, SentTime: sentTime, ChainPair: SrcDest{Src: srcSelector, Dest: destSelector}}] = struct{}{}
+	m.sentMsgSet[load.SentMessage{SeqNo: uint64(sentEvent.Message.SequenceNumber), MessageID: sentEvent.MessageID, SentTime: sentTime, ChainPair: load.SrcDest{Src: srcSelector, Dest: destSelector}}] = struct{}{}
 	m.seqNosMu.Unlock()
 
 	// Push to channel for verification
-	m.sentMsgCh <- SentMessage{SeqNo: uint64(sentEvent.Message.SequenceNumber), MessageID: sentEvent.MessageID, SentTime: sentTime, ChainPair: SrcDest{Src: srcSelector, Dest: destSelector}}
+	m.sentMsgCh <- load.SentMessage{SeqNo: uint64(sentEvent.Message.SequenceNumber), MessageID: sentEvent.MessageID, SentTime: sentTime, ChainPair: load.SrcDest{Src: srcSelector, Dest: destSelector}}
 
 	return &wasp.Response{Data: "ok"}
 }

--- a/build/devenv/tests/e2e/load/assert_messages.go
+++ b/build/devenv/tests/e2e/load/assert_messages.go
@@ -39,15 +39,20 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 	go func() {
 		defer cancelVerify()
 
+		logTimeout := sync.OnceFunc(func() {
+			vc.T.Logf("Overall verification timeout reached, stopping new verifications")
+		})
+
 		for sentMsg := range gun.SentMessages() {
 			select {
 			case <-verifyCtx.Done():
-				vc.T.Logf("Overall verification timeout reached, stopping new verifications")
-				return
+				// Log once and keep draining to avoid blocking the gun's producer goroutine.
+				logTimeout()
+				continue
 			default:
 			}
 
-			msgIDHex := hex.EncodeToString(sentMsg.MessageID[:])
+			msgIDHex := "0x" + hex.EncodeToString(sentMsg.MessageID[:])
 			totalSent.Add(1)
 			sentMessages.Store(sentMsg.SeqNo, msgIDHex)
 
@@ -55,7 +60,7 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 			go func(msg SentMessage) {
 				defer wg.Done()
 
-				msgIDHex := hex.EncodeToString(msg.MessageID[:])
+				msgIDHex := "0x" + hex.EncodeToString(msg.MessageID[:])
 
 				if _, ok := vc.Impl[msg.ChainPair.Dest]; !ok {
 					vc.T.Logf("No implementation available to verify message %d", msg.SeqNo)
@@ -85,7 +90,9 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 				totalReceived.Add(1)
 				receivedMessages.Store(msg.SeqNo, msgIDHex)
 
-				metricsData.Store(msg.SeqNo, metrics.MessageMetrics{
+				// Keyed by messageID (globally unique) rather than seqNo (per-lane) to avoid
+				// collisions if the gun sends across multiple source→dest lanes.
+				metricsData.Store(msgIDHex, metrics.MessageMetrics{
 					SeqNo:           msg.SeqNo,
 					MessageID:       msgIDHex,
 					SourceChain:     msg.ChainPair.Src,

--- a/build/devenv/tests/e2e/load/assert_messages.go
+++ b/build/devenv/tests/e2e/load/assert_messages.go
@@ -23,10 +23,10 @@ type VerificationContext struct {
 }
 
 // AssertMessagesAsync starts a background verification pipeline that reads
-// sent messages from the gun's channel and confirms execution on dest chains.
+// sent messages from the provided channel and confirms execution on dest chains.
 // Returns a closure that blocks until verification completes and returns metrics.
-// The caller must call gun.CloseSentChannel() after the load run completes to unblock the pipeline.
-func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout time.Duration) func() ([]metrics.MessageMetrics, metrics.MessageTotals) {
+// The caller must close the msgs channel after sending completes to unblock the pipeline.
+func AssertMessagesAsync(vc VerificationContext, msgs <-chan SentMessage, overallTimeout time.Duration) func() ([]metrics.MessageMetrics, metrics.MessageTotals) {
 	var wg sync.WaitGroup
 	var totalSent, totalReceived atomic.Int32
 
@@ -43,7 +43,7 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 			vc.T.Logf("Overall verification timeout reached, stopping new verifications")
 		})
 
-		for sentMsg := range gun.SentMessages() {
+		for sentMsg := range msgs {
 			// Always record sent messages for accurate totals, even after timeout.
 			msgIDHex := "0x" + hex.EncodeToString(sentMsg.MessageID[:])
 			totalSent.Add(1)
@@ -51,7 +51,7 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 
 			select {
 			case <-verifyCtx.Done():
-				// Log once and keep draining to avoid blocking the gun's producer goroutine.
+				// Log once and keep draining to avoid blocking the producer goroutine.
 				logTimeout()
 				continue
 			default:

--- a/build/devenv/tests/e2e/load/assert_messages.go
+++ b/build/devenv/tests/e2e/load/assert_messages.go
@@ -1,0 +1,150 @@
+package load
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cciptestinterfaces"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/metrics"
+)
+
+// VerificationContext holds the minimal dependencies needed by AssertMessagesAsync.
+// Callers construct a VerificationContext from whatever test harness they use (EVM, Solana, etc.),
+// keeping the verification pipeline chain-agnostic.
+type VerificationContext struct {
+	Ctx  context.Context
+	T    testing.TB
+	Impl map[uint64]cciptestinterfaces.CCIP17
+}
+
+// AssertMessagesAsync starts a background verification pipeline that reads
+// sent messages from the gun's channel and confirms execution on dest chains.
+// Returns a closure that blocks until verification completes and returns metrics.
+// The caller must call gun.CloseSentChannel() after the load run completes to unblock the pipeline.
+func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout time.Duration) func() ([]metrics.MessageMetrics, metrics.MessageTotals) {
+	var wg sync.WaitGroup
+	var totalSent, totalReceived atomic.Int32
+
+	sentMessages := &sync.Map{}
+	receivedMessages := &sync.Map{}
+	metricsData := &sync.Map{}
+
+	verifyCtx, cancelVerify := context.WithTimeout(vc.Ctx, overallTimeout)
+
+	go func() {
+		defer cancelVerify()
+
+		for sentMsg := range gun.SentMessages() {
+			select {
+			case <-verifyCtx.Done():
+				vc.T.Logf("Overall verification timeout reached, stopping new verifications")
+				return
+			default:
+			}
+
+			msgIDHex := hex.EncodeToString(sentMsg.MessageID[:])
+			totalSent.Add(1)
+			sentMessages.Store(sentMsg.SeqNo, msgIDHex)
+
+			wg.Add(1)
+			go func(msg SentMessage) {
+				defer wg.Done()
+
+				msgIDHex := hex.EncodeToString(msg.MessageID[:])
+
+				if _, ok := vc.Impl[msg.ChainPair.Dest]; !ok {
+					vc.T.Logf("No implementation available to verify message %d", msg.SeqNo)
+					return
+				}
+
+				execEvent, err := vc.Impl[msg.ChainPair.Dest].ConfirmExecOnDest(verifyCtx, msg.ChainPair.Src, cciptestinterfaces.MessageEventKey{SeqNum: msg.SeqNo}, 0)
+				if err != nil {
+					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+						vc.T.Logf("Message %d verification cancelled or timed out", msg.SeqNo)
+					} else {
+						vc.T.Logf("Failed to get execution event for sequence number %d: %v", msg.SeqNo, err)
+					}
+					return
+				}
+
+				if execEvent.State != cciptestinterfaces.ExecutionStateSuccess {
+					vc.T.Logf("Message with sequence number %d was not successfully executed, state: %d", msg.SeqNo, execEvent.State)
+					return
+				}
+
+				executedTime := time.Now()
+				latency := executedTime.Sub(msg.SentTime)
+
+				vc.T.Logf("Message with sequence number %d successfully executed (latency: %v)", msg.SeqNo, latency)
+
+				totalReceived.Add(1)
+				receivedMessages.Store(msg.SeqNo, msgIDHex)
+
+				metricsData.Store(msg.SeqNo, metrics.MessageMetrics{
+					SeqNo:           msg.SeqNo,
+					MessageID:       msgIDHex,
+					SourceChain:     msg.ChainPair.Src,
+					DestChain:       msg.ChainPair.Dest,
+					SentTime:        msg.SentTime,
+					ExecutedTime:    executedTime,
+					LatencyDuration: latency,
+				})
+			}(sentMsg)
+		}
+
+		vc.T.Logf("All messages sent, waiting for verifications to complete")
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			vc.T.Logf("All verification goroutines completed successfully")
+		case <-verifyCtx.Done():
+			vc.T.Logf("Verification timeout reached, %d messages may be unverified", totalSent.Load()-totalReceived.Load())
+		}
+	}()
+
+	return func() ([]metrics.MessageMetrics, metrics.MessageTotals) {
+		<-verifyCtx.Done()
+
+		datum := make([]metrics.MessageMetrics, 0, int(totalReceived.Load()))
+		metricsData.Range(func(key, value any) bool {
+			datum = append(datum, value.(metrics.MessageMetrics))
+			return true
+		})
+
+		sent := make(map[uint64]string)
+		sentMessages.Range(func(key, value any) bool {
+			sent[key.(uint64)] = value.(string)
+			return true
+		})
+
+		received := make(map[uint64]string)
+		receivedMessages.Range(func(key, value any) bool {
+			received[key.(uint64)] = value.(string)
+			return true
+		})
+
+		totals := metrics.MessageTotals{
+			Sent:             int(totalSent.Load()),
+			Received:         int(totalReceived.Load()),
+			SentMessages:     sent,
+			ReceivedMessages: received,
+		}
+
+		notVerified := totals.Sent - totals.Received
+		vc.T.Logf("Verification complete - Sent: %d, ReachedVerifier: %d, Verified: %d, Aggregated: %d, Indexed: %d, ReachedExecutor: %d, SentToChain: %d, Received: %d, Not Received: %d",
+			totals.Sent, totals.ReachedVerifier, totals.Verified, totals.Aggregated, totals.Indexed, totals.ReachedExecutor, totals.SentToChainInExecutor, totals.Received, notVerified)
+
+		return datum, totals
+	}
+}

--- a/build/devenv/tests/e2e/load/assert_messages.go
+++ b/build/devenv/tests/e2e/load/assert_messages.go
@@ -44,6 +44,11 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 		})
 
 		for sentMsg := range gun.SentMessages() {
+			// Always record sent messages for accurate totals, even after timeout.
+			msgIDHex := "0x" + hex.EncodeToString(sentMsg.MessageID[:])
+			totalSent.Add(1)
+			sentMessages.Store(sentMsg.SeqNo, msgIDHex)
+
 			select {
 			case <-verifyCtx.Done():
 				// Log once and keep draining to avoid blocking the gun's producer goroutine.
@@ -51,10 +56,6 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 				continue
 			default:
 			}
-
-			msgIDHex := "0x" + hex.EncodeToString(sentMsg.MessageID[:])
-			totalSent.Add(1)
-			sentMessages.Store(sentMsg.SeqNo, msgIDHex)
 
 			wg.Add(1)
 			go func(msg SentMessage) {
@@ -90,9 +91,7 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 				totalReceived.Add(1)
 				receivedMessages.Store(msg.SeqNo, msgIDHex)
 
-				// Keyed by messageID (globally unique) rather than seqNo (per-lane) to avoid
-				// collisions if the gun sends across multiple source→dest lanes.
-				metricsData.Store(msgIDHex, metrics.MessageMetrics{
+				metricsData.Store(msg.SeqNo, metrics.MessageMetrics{
 					SeqNo:           msg.SeqNo,
 					MessageID:       msgIDHex,
 					SourceChain:     msg.ChainPair.Src,

--- a/build/devenv/tests/e2e/load/assert_messages.go
+++ b/build/devenv/tests/e2e/load/assert_messages.go
@@ -148,8 +148,8 @@ func AssertMessagesAsync(vc VerificationContext, gun LoadGun, overallTimeout tim
 		}
 
 		notVerified := totals.Sent - totals.Received
-		vc.T.Logf("Verification complete - Sent: %d, ReachedVerifier: %d, Verified: %d, Aggregated: %d, Indexed: %d, ReachedExecutor: %d, SentToChain: %d, Received: %d, Not Received: %d",
-			totals.Sent, totals.ReachedVerifier, totals.Verified, totals.Aggregated, totals.Indexed, totals.ReachedExecutor, totals.SentToChainInExecutor, totals.Received, notVerified)
+		vc.T.Logf("Verification complete - Sent: %d, Received: %d, Not Received: %d",
+			totals.Sent, totals.Received, notVerified)
 
 		return datum, totals
 	}

--- a/build/devenv/tests/e2e/load/gun.go
+++ b/build/devenv/tests/e2e/load/gun.go
@@ -1,0 +1,37 @@
+package load
+
+import (
+	"time"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/wasp"
+)
+
+// SrcDest identifies a source-destination lane by chain selector.
+type SrcDest struct {
+	Src  uint64
+	Dest uint64
+}
+
+// SentMessage represents a message sent by a load gun, tracked for verification.
+type SentMessage struct {
+	SeqNo     uint64
+	MessageID [32]byte
+	SentTime  time.Time
+	ChainPair SrcDest
+}
+
+// LoadGun extends wasp.Gun with message tracking for CCIP load tests.
+// Chain-specific guns (EVMTXGun, SolanaTXGun, etc.) implement this interface
+// to plug into the shared verification and metrics pipeline (AssertMessagesAsync).
+type LoadGun interface {
+	// Call implements wasp's gun contract and fires one message per invocation.
+	Call(gen *wasp.Generator) *wasp.Response
+
+	// CloseSentChannel signals that no more messages will be sent.
+	// Must be called after the wasp profile completes to unblock verification.
+	CloseSentChannel()
+
+	// SentMessages returns a read-only channel of sent messages.
+	// The verification goroutine reads from this channel to confirm execution on dest.
+	SentMessages() <-chan SentMessage
+}

--- a/build/devenv/tests/e2e/load_test.go
+++ b/build/devenv/tests/e2e/load_test.go
@@ -228,7 +228,7 @@ func TestE2ELoad(t *testing.T) {
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + (2 * tc.Timeout)
 		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
-		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
+		waitForMetrics := load.AssertMessagesAsync(vc, gun.SentMessages(), overallTimeout)
 
 		_, err = p.Run(true)
 		require.NoError(t, err)
@@ -268,7 +268,7 @@ func TestE2ELoad(t *testing.T) {
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + timeoutDuration
 		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
-		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
+		waitForMetrics := load.AssertMessagesAsync(vc, gun.SentMessages(), overallTimeout)
 
 		_, err = p.Run(true)
 		require.NoError(t, err)
@@ -302,7 +302,7 @@ func TestE2ELoad(t *testing.T) {
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + tc.Timeout
 		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
-		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
+		waitForMetrics := load.AssertMessagesAsync(vc, gun.SentMessages(), overallTimeout)
 
 		_, err = p.Run(false)
 		require.NoError(t, err)
@@ -380,7 +380,7 @@ func TestE2ELoad(t *testing.T) {
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + (2 * tc.Timeout)
 		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
-		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
+		waitForMetrics := load.AssertMessagesAsync(vc, gun.SentMessages(), overallTimeout)
 
 		_, err = p.Run(false)
 		require.NoError(t, err)
@@ -549,7 +549,7 @@ func TestE2ELoad(t *testing.T) {
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + (2 * tc.Timeout)
 		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
-		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
+		waitForMetrics := load.AssertMessagesAsync(vc, gun.SentMessages(), overallTimeout)
 
 		_, err = p.Run(false)
 		require.NoError(t, err)

--- a/build/devenv/tests/e2e/load_test.go
+++ b/build/devenv/tests/e2e/load_test.go
@@ -2,13 +2,11 @@ package e2e
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"os"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/weth"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/load"
@@ -55,129 +54,6 @@ type GasTestCase struct {
 	name             string
 	chainURL         string
 	waitBetweenTests time.Duration
-}
-
-func assertMessagesAsync(tc TestingContext, gun *EVMTXGun, overallTimeout time.Duration) func() ([]metrics.MessageMetrics, metrics.MessageTotals) {
-	var wg sync.WaitGroup
-	var totalSent, totalReceived atomic.Int32
-
-	sentMessages := &sync.Map{}
-	receivedMessages := &sync.Map{}
-	metricsData := &sync.Map{}
-
-	verifyCtx, cancelVerify := context.WithTimeout(tc.Ctx, overallTimeout)
-
-	go func() {
-		defer cancelVerify()
-
-		for sentMsg := range gun.sentMsgCh {
-			select {
-			case <-verifyCtx.Done():
-				tc.T.Logf("Overall verification timeout reached, stopping new verifications")
-				return
-			default:
-			}
-
-			msgIDHex := common.BytesToHash(sentMsg.MessageID[:]).Hex()
-			totalSent.Add(1)
-			sentMessages.Store(sentMsg.SeqNo, msgIDHex)
-
-			wg.Add(1)
-			go func(msg SentMessage) {
-				defer wg.Done()
-
-				msgIDHex := common.BytesToHash(msg.MessageID[:]).Hex()
-
-				if _, ok := tc.Impl[msg.ChainPair.Dest]; !ok {
-					tc.T.Logf("No implementation available to verify message %d", msg.SeqNo)
-					return
-				}
-
-				execEvent, err := tc.Impl[msg.ChainPair.Dest].ConfirmExecOnDest(verifyCtx, msg.ChainPair.Src, cciptestinterfaces.MessageEventKey{SeqNum: msg.SeqNo}, 0)
-				if err != nil {
-					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-						tc.T.Logf("Message %d verification cancelled or timed out", msg.SeqNo)
-					} else {
-						tc.T.Logf("Failed to get execution event for sequence number %d: %v", msg.SeqNo, err)
-					}
-					return
-				}
-
-				if execEvent.State != cciptestinterfaces.ExecutionStateSuccess {
-					tc.T.Logf("Message with sequence number %d was not successfully executed, state: %d", msg.SeqNo, execEvent.State)
-					return
-				}
-
-				executedTime := time.Now()
-				latency := executedTime.Sub(msg.SentTime)
-
-				tc.T.Logf("Message with sequence number %d successfully executed (latency: %v)", msg.SeqNo, latency)
-
-				totalReceived.Add(1)
-				receivedMessages.Store(msg.SeqNo, msgIDHex)
-
-				metricsData.Store(msg.SeqNo, metrics.MessageMetrics{
-					SeqNo:           msg.SeqNo,
-					MessageID:       msgIDHex,
-					SourceChain:     msg.ChainPair.Src,
-					DestChain:       msg.ChainPair.Dest,
-					SentTime:        msg.SentTime,
-					ExecutedTime:    executedTime,
-					LatencyDuration: latency,
-				})
-			}(sentMsg)
-		}
-
-		tc.T.Logf("All messages sent, waiting for verifications to complete")
-
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
-
-		select {
-		case <-done:
-			tc.T.Logf("All verification goroutines completed successfully")
-		case <-verifyCtx.Done():
-			tc.T.Logf("Verification timeout reached, %d messages may be unverified", totalSent.Load()-totalReceived.Load())
-		}
-	}()
-
-	return func() ([]metrics.MessageMetrics, metrics.MessageTotals) {
-		<-verifyCtx.Done()
-
-		datum := make([]metrics.MessageMetrics, 0, int(totalReceived.Load()))
-		metricsData.Range(func(key, value any) bool {
-			datum = append(datum, value.(metrics.MessageMetrics))
-			return true
-		})
-
-		sent := make(map[uint64]string)
-		sentMessages.Range(func(key, value any) bool {
-			sent[key.(uint64)] = value.(string)
-			return true
-		})
-
-		received := make(map[uint64]string)
-		receivedMessages.Range(func(key, value any) bool {
-			received[key.(uint64)] = value.(string)
-			return true
-		})
-
-		totals := metrics.MessageTotals{
-			Sent:             int(totalSent.Load()),
-			Received:         int(totalReceived.Load()),
-			SentMessages:     sent,
-			ReceivedMessages: received,
-		}
-
-		notVerified := totals.Sent - totals.Received
-		tc.T.Logf("Verification complete - Sent: %d, ReachedVerifier: %d, Verified: %d, Aggregated: %d, Indexed: %d, ReachedExecutor: %d, SentToChain: %d, Received: %d, Not Received: %d",
-			totals.Sent, totals.ReachedVerifier, totals.Verified, totals.Aggregated, totals.Indexed, totals.ReachedExecutor, totals.SentToChainInExecutor, totals.Received, notVerified)
-
-		return datum, totals
-	}
 }
 
 func ensureWETHBalanceAndApproval(ctx context.Context, t *testing.T, logger zerolog.Logger, e *deployment.Environment, chain cldfevm.Chain, requiredWETH *big.Int) {
@@ -351,7 +227,8 @@ func TestE2ELoad(t *testing.T) {
 
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + (2 * tc.Timeout)
-		waitForMetrics := assertMessagesAsync(tc, gun, overallTimeout)
+		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
+		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
 
 		_, err = p.Run(true)
 		require.NoError(t, err)
@@ -390,7 +267,8 @@ func TestE2ELoad(t *testing.T) {
 
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + timeoutDuration
-		waitForMetrics := assertMessagesAsync(tc, gun, overallTimeout)
+		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
+		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
 
 		_, err = p.Run(true)
 		require.NoError(t, err)
@@ -423,7 +301,8 @@ func TestE2ELoad(t *testing.T) {
 
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + tc.Timeout
-		waitForMetrics := assertMessagesAsync(tc, gun, overallTimeout)
+		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
+		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
 
 		_, err = p.Run(false)
 		require.NoError(t, err)
@@ -500,7 +379,8 @@ func TestE2ELoad(t *testing.T) {
 
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + (2 * tc.Timeout)
-		waitForMetrics := assertMessagesAsync(tc, gun, overallTimeout)
+		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
+		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
 
 		_, err = p.Run(false)
 		require.NoError(t, err)
@@ -668,7 +548,8 @@ func TestE2ELoad(t *testing.T) {
 
 		p, gun := createLoadProfile(in, rps, testDuration, e, selectors, chainImpls, srcChain, dstChain)
 		overallTimeout := testDuration + (2 * tc.Timeout)
-		waitForMetrics := assertMessagesAsync(tc, gun, overallTimeout)
+		vc := load.VerificationContext{Ctx: tc.Ctx, T: tc.T, Impl: tc.Impl}
+		waitForMetrics := load.AssertMessagesAsync(vc, gun, overallTimeout)
 
 		_, err = p.Run(false)
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

Introduces a `LoadGun` interface and moves `AssertMessagesAsync` into `tests/e2e/load/` so non-EVM chains can reuse the shared verification and metrics pipeline without importing go-ethereum.

This PR breaks that coupling by:
- Defining a `LoadGun` interface in `load/` that any chain-specific gun can implement
- Moving the verification pipeline (`AssertMessagesAsync`) into the same package
- Introducing `VerificationContext` to avoid a circular import between `load/` and `e2e/`
- Replacing `common.BytesToHash` with `encoding/hex` to remove the go-ethereum dep

After this change, `load/` depends only on stdlib, wasp, cciptestinterfaces, and metrics. No EVM deps. Solana (and future chains) implement `LoadGun`, construct a `VerificationContext`, and call `load.AssertMessagesAsync` directly.

No behavioral changes to existing EVM load tests.