### PR TITLE
CCIP-11476 adjust metrics_aware_storage in Aggregator and Indexer

### DIFF
--- a/aggregator/pkg/common/metrics.go
+++ b/aggregator/pkg/common/metrics.go
@@ -39,9 +39,9 @@ type AggregatorMetricLabeler interface {
 	// DecrementPendingAggregationsChannelBuffer decrements the pending aggregations channel buffer counter.
 	DecrementPendingAggregationsChannelBuffer(ctx context.Context, count int)
 	// RecordStorageLatency records storage operation latency in milliseconds.
-	RecordStorageLatency(ctx context.Context, duration time.Duration)
+	RecordStorageLatency(ctx context.Context, operation string, duration time.Duration, errored bool)
 	// IncrementStorageError increments the storage error counter.
-	IncrementStorageError(ctx context.Context)
+	IncrementStorageError(ctx context.Context, operation string)
 	// RecordTimeToAggregation records the time taken to complete an aggregation.
 	RecordTimeToAggregation(ctx context.Context, duration time.Duration)
 	// SetOrphanBacklog sets the gauge for non-expired orphan records (recovery queue).

--- a/aggregator/pkg/monitoring/metrics.go
+++ b/aggregator/pkg/monitoring/metrics.go
@@ -380,14 +380,19 @@ func (c *AggregatorMetricLabeler) DecrementPendingAggregationsChannelBuffer(ctx 
 	c.am.pendingAggregationsChannelBuffer.Add(ctx, -int64(count), metric.WithAttributes(otelLabels...))
 }
 
-func (c *AggregatorMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
+func (c *AggregatorMetricLabeler) RecordStorageLatency(ctx context.Context, operation string, duration time.Duration, errored bool) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
-	c.am.storageLatency.Record(ctx, duration.Seconds(), metric.WithAttributes(otelLabels...))
+	c.am.storageLatency.Record(ctx, duration.Seconds(), metric.WithAttributes([]attribute.KeyValue{
+		attribute.String("operation", operation),
+		attribute.Bool("errored", errored),
+	}...), metric.WithAttributes(otelLabels...))
 }
 
-func (c *AggregatorMetricLabeler) IncrementStorageError(ctx context.Context) {
+func (c *AggregatorMetricLabeler) IncrementStorageError(ctx context.Context, operation string) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
-	c.am.storageError.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+	c.am.storageError.Add(ctx, 1, metric.WithAttributes([]attribute.KeyValue{
+		attribute.String("operation", operation),
+	}...), metric.WithAttributes(otelLabels...))
 }
 
 func (c *AggregatorMetricLabeler) RecordTimeToAggregation(ctx context.Context, duration time.Duration) {

--- a/aggregator/pkg/monitoring/noop.go
+++ b/aggregator/pkg/monitoring/noop.go
@@ -73,12 +73,10 @@ func (c *NoopAggregatorMetricLabeler) DecrementPendingAggregationsChannelBuffer(
 	// No-op
 }
 
-func (c *NoopAggregatorMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
-	// No-op
+func (c *NoopAggregatorMetricLabeler) RecordStorageLatency(_ context.Context, _ string, _ time.Duration, _ bool) {
 }
 
-func (c *NoopAggregatorMetricLabeler) IncrementStorageError(ctx context.Context) {
-	// No-op
+func (c *NoopAggregatorMetricLabeler) IncrementStorageError(_ context.Context, _ string) {
 }
 
 func (c *NoopAggregatorMetricLabeler) RecordTimeToAggregation(ctx context.Context, duration time.Duration) {

--- a/aggregator/pkg/storage/metrics_aware_storage.go
+++ b/aggregator/pkg/storage/metrics_aware_storage.go
@@ -74,7 +74,7 @@ func WrapWithMetrics(inner CommitVerificationStorage, m common.AggregatorMonitor
 }
 
 func (s *MetricsAwareStorage) SaveCommitVerification(ctx context.Context, record *model.CommitVerificationRecord, aggregationKey model.AggregationKey) error {
-	return s.captureMetricsNoReturn(ctx, saveOp, func() error {
+	return captureMetricsNoReturn(ctx, s.metrics(ctx, saveOp), s.logger(ctx), s.slowQueryThreshold, saveOp, func() error {
 		return s.inner.SaveCommitVerification(ctx, record, aggregationKey)
 	})
 }
@@ -110,7 +110,7 @@ func (s *MetricsAwareStorage) GetBatchAggregatedReportByMessageIDs(ctx context.C
 }
 
 func (s *MetricsAwareStorage) SubmitAggregatedReport(ctx context.Context, report *model.CommitAggregatedReport) error {
-	return s.captureMetricsNoReturn(ctx, submitReportOp, func() error {
+	return captureMetricsNoReturn(ctx, s.metrics(ctx, submitReportOp), s.logger(ctx), s.slowQueryThreshold, submitReportOp, func() error {
 		return s.inner.SubmitAggregatedReport(ctx, report)
 	})
 }
@@ -134,7 +134,7 @@ func (s *MetricsAwareStorage) Get(ctx context.Context, id string) (*messagerules
 }
 
 func (s *MetricsAwareStorage) Delete(ctx context.Context, id string) error {
-	return s.captureMetricsNoReturn(ctx, deleteMessageDisablementRuleOp, func() error {
+	return captureMetricsNoReturn(ctx, s.metrics(ctx, deleteMessageDisablementRuleOp), s.logger(ctx), s.slowQueryThreshold, deleteMessageDisablementRuleOp, func() error {
 		return s.inner.Delete(ctx, id)
 	})
 }
@@ -200,8 +200,8 @@ func captureMetrics[T any](ctx context.Context, metrics common.AggregatorMetricL
 	return res, err
 }
 
-func (s *MetricsAwareStorage) captureMetricsNoReturn(ctx context.Context, operation string, fn func() error) error {
-	_, err := captureMetrics(ctx, s.metrics(ctx, operation), s.logger(ctx), s.slowQueryThreshold, operation, func() (struct{}, error) {
+func captureMetricsNoReturn(ctx context.Context, metrics common.AggregatorMetricLabeler, l logger.SugaredLogger, threshold time.Duration, operation string, fn func() error) error {
+	_, err := captureMetrics(ctx, metrics, l, threshold, operation, func() (struct{}, error) {
 		return struct{}{}, fn()
 	})
 	return err

--- a/aggregator/pkg/storage/metrics_aware_storage.go
+++ b/aggregator/pkg/storage/metrics_aware_storage.go
@@ -12,10 +12,9 @@ import (
 )
 
 const (
-	operationLabel = "operation"
-	saveOp         = "SaveCommitVerification"
-	getOp          = "GetCommitVerification"
-	listByMsgIDOp  = "ListCommitVerificationByMessageID"
+	saveOp        = "SaveCommitVerification"
+	getOp         = "GetCommitVerification"
+	listByMsgIDOp = "ListCommitVerificationByMessageID"
 
 	queryAggregatedReportsOp = "QueryAggregatedReports"
 	getCCVDataOp             = "GetCCVData"
@@ -60,9 +59,8 @@ func NewMetricsAwareStorage(inner CommitVerificationStorage, m common.Aggregator
 	return s
 }
 
-func (s *MetricsAwareStorage) metrics(ctx context.Context, operation string) common.AggregatorMetricLabeler {
-	metrics := scope.AugmentMetrics(ctx, s.m.Metrics())
-	return metrics.With(operationLabel, operation)
+func (s *MetricsAwareStorage) metrics(ctx context.Context) common.AggregatorMetricLabeler {
+	return scope.AugmentMetrics(ctx, s.m.Metrics())
 }
 
 func (s *MetricsAwareStorage) logger(ctx context.Context) logger.SugaredLogger {
@@ -74,73 +72,73 @@ func WrapWithMetrics(inner CommitVerificationStorage, m common.AggregatorMonitor
 }
 
 func (s *MetricsAwareStorage) SaveCommitVerification(ctx context.Context, record *model.CommitVerificationRecord, aggregationKey model.AggregationKey) error {
-	return captureMetricsNoReturn(ctx, s.metrics(ctx, saveOp), s.logger(ctx), s.slowQueryThreshold, saveOp, func() error {
+	return captureMetricsNoReturn(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, saveOp, func() error {
 		return s.inner.SaveCommitVerification(ctx, record, aggregationKey)
 	})
 }
 
 func (s *MetricsAwareStorage) GetCommitVerification(ctx context.Context, id model.CommitVerificationRecordIdentifier) (*model.CommitVerificationRecord, error) {
-	return captureMetrics(ctx, s.metrics(ctx, getOp), s.logger(ctx), s.slowQueryThreshold, getOp, func() (*model.CommitVerificationRecord, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, getOp, func() (*model.CommitVerificationRecord, error) {
 		return s.inner.GetCommitVerification(ctx, id)
 	})
 }
 
 func (s *MetricsAwareStorage) ListCommitVerificationByAggregationKey(ctx context.Context, messageID model.MessageID, aggregationKey model.AggregationKey) ([]*model.CommitVerificationRecord, error) {
-	return captureMetrics(ctx, s.metrics(ctx, listByMsgIDOp), s.logger(ctx), s.slowQueryThreshold, listByMsgIDOp, func() ([]*model.CommitVerificationRecord, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, listByMsgIDOp, func() ([]*model.CommitVerificationRecord, error) {
 		return s.inner.ListCommitVerificationByAggregationKey(ctx, messageID, aggregationKey)
 	})
 }
 
 func (s *MetricsAwareStorage) QueryAggregatedReports(ctx context.Context, sinceSequenceInclusive int64) (*model.AggregatedReportBatch, error) {
-	return captureMetrics(ctx, s.metrics(ctx, queryAggregatedReportsOp), s.logger(ctx), s.slowQueryThreshold, queryAggregatedReportsOp, func() (*model.AggregatedReportBatch, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, queryAggregatedReportsOp, func() (*model.AggregatedReportBatch, error) {
 		return s.inner.QueryAggregatedReports(ctx, sinceSequenceInclusive)
 	})
 }
 
 func (s *MetricsAwareStorage) GetCommitAggregatedReportByAggregationKey(ctx context.Context, messageID model.MessageID, aggregationKey model.AggregationKey) (*model.CommitAggregatedReport, error) {
-	return captureMetrics(ctx, s.metrics(ctx, getCCVDataOp), s.logger(ctx), s.slowQueryThreshold, getCCVDataOp, func() (*model.CommitAggregatedReport, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, getCCVDataOp, func() (*model.CommitAggregatedReport, error) {
 		return s.inner.GetCommitAggregatedReportByAggregationKey(ctx, messageID, aggregationKey)
 	})
 }
 
 func (s *MetricsAwareStorage) GetBatchAggregatedReportByMessageIDs(ctx context.Context, messageIDs []model.MessageID) (map[string]*model.CommitAggregatedReport, error) {
-	return captureMetrics(ctx, s.metrics(ctx, getBatchCCVDataOp), s.logger(ctx), s.slowQueryThreshold, getBatchCCVDataOp, func() (map[string]*model.CommitAggregatedReport, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, getBatchCCVDataOp, func() (map[string]*model.CommitAggregatedReport, error) {
 		return s.inner.GetBatchAggregatedReportByMessageIDs(ctx, messageIDs)
 	})
 }
 
 func (s *MetricsAwareStorage) SubmitAggregatedReport(ctx context.Context, report *model.CommitAggregatedReport) error {
-	return captureMetricsNoReturn(ctx, s.metrics(ctx, submitReportOp), s.logger(ctx), s.slowQueryThreshold, submitReportOp, func() error {
+	return captureMetricsNoReturn(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, submitReportOp, func() error {
 		return s.inner.SubmitAggregatedReport(ctx, report)
 	})
 }
 
 func (s *MetricsAwareStorage) Create(ctx context.Context, data messagerules.RuleData) (messagerules.Rule, error) {
-	return captureMetrics(ctx, s.metrics(ctx, createMessageDisablementRuleOp), s.logger(ctx), s.slowQueryThreshold, createMessageDisablementRuleOp, func() (messagerules.Rule, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, createMessageDisablementRuleOp, func() (messagerules.Rule, error) {
 		return s.inner.Create(ctx, data)
 	})
 }
 
 func (s *MetricsAwareStorage) List(ctx context.Context, ruleType *messagerules.RuleType) ([]messagerules.Rule, error) {
-	return captureMetrics(ctx, s.metrics(ctx, listMessageDisablementRulesOp), s.logger(ctx), s.slowQueryThreshold, listMessageDisablementRulesOp, func() ([]messagerules.Rule, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, listMessageDisablementRulesOp, func() ([]messagerules.Rule, error) {
 		return s.inner.List(ctx, ruleType)
 	})
 }
 
 func (s *MetricsAwareStorage) Get(ctx context.Context, id string) (*messagerules.Rule, error) {
-	return captureMetrics(ctx, s.metrics(ctx, getMessageDisablementRuleOp), s.logger(ctx), s.slowQueryThreshold, getMessageDisablementRuleOp, func() (*messagerules.Rule, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, getMessageDisablementRuleOp, func() (*messagerules.Rule, error) {
 		return s.inner.Get(ctx, id)
 	})
 }
 
 func (s *MetricsAwareStorage) Delete(ctx context.Context, id string) error {
-	return captureMetricsNoReturn(ctx, s.metrics(ctx, deleteMessageDisablementRuleOp), s.logger(ctx), s.slowQueryThreshold, deleteMessageDisablementRuleOp, func() error {
+	return captureMetricsNoReturn(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, deleteMessageDisablementRuleOp, func() error {
 		return s.inner.Delete(ctx, id)
 	})
 }
 
 func (s *MetricsAwareStorage) ListOrphanedKeys(ctx context.Context, newerThan time.Time, pageSize int) (<-chan model.OrphanedKey, <-chan error) {
-	metrics := s.metrics(ctx, ListOrphanedKeysOp)
+	metrics := s.metrics(ctx)
 	resultChan := make(chan model.OrphanedKey, 100)
 	errorChan := make(chan error, 1)
 
@@ -151,7 +149,7 @@ func (s *MetricsAwareStorage) ListOrphanedKeys(ctx context.Context, newerThan ti
 		defer func() {
 			close(resultChan)
 			close(errorChan)
-			metrics.RecordStorageLatency(ctx, time.Since(now))
+			metrics.RecordStorageLatency(ctx, ListOrphanedKeysOp, time.Since(now), false)
 		}()
 
 		for {
@@ -177,24 +175,23 @@ func (s *MetricsAwareStorage) ListOrphanedKeys(ctx context.Context, newerThan ti
 }
 
 func (s *MetricsAwareStorage) OrphanedKeyStats(ctx context.Context, cutoff time.Time) (*model.OrphanStats, error) {
-	return captureMetrics(ctx, s.metrics(ctx, orphanedKeyStatsOp), s.logger(ctx), s.slowQueryThreshold, orphanedKeyStatsOp, func() (*model.OrphanStats, error) {
+	return captureMetrics(ctx, s.metrics(ctx), s.logger(ctx), s.slowQueryThreshold, orphanedKeyStatsOp, func() (*model.OrphanStats, error) {
 		return s.inner.OrphanedKeyStats(ctx, cutoff)
 	})
 }
 
 func captureMetrics[T any](ctx context.Context, metrics common.AggregatorMetricLabeler, l logger.SugaredLogger, threshold time.Duration, operation string, fn func() (T, error)) (T, error) {
 	start := time.Now()
-	defer func() {
-		duration := time.Since(start)
-		metrics.RecordStorageLatency(ctx, duration)
-		if duration > threshold {
-			l.Warnw("Slow storage operation", "operation", operation, "duration_ms", duration.Milliseconds())
-		}
-	}()
 
 	res, err := fn()
+
+	duration := time.Since(start)
+	metrics.RecordStorageLatency(ctx, operation, duration, err != nil)
+	if duration > threshold {
+		l.Warnw("Slow storage operation", "operation", operation, "duration_ms", duration.Milliseconds())
+	}
 	if err != nil {
-		metrics.IncrementStorageError(ctx)
+		metrics.IncrementStorageError(ctx, operation)
 	}
 
 	return res, err

--- a/indexer/cmd/main.go
+++ b/indexer/cmd/main.go
@@ -294,5 +294,5 @@ func createPostgresStorage(ctx context.Context, lggr logger.Logger, cfg *config.
 		lggr.Fatalf("Failed to create postgres storage: %v", err)
 	}
 
-	return dbStore
+	return storage.WrapWithMetrics(dbStore, indexerMonitoring, lggr)
 }

--- a/indexer/pkg/common/metrics.go
+++ b/indexer/pkg/common/metrics.go
@@ -28,12 +28,10 @@ type IndexerMetricLabeler interface {
 	RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path, method string, status int)
 	// IncrementVerificationRecordsCounter increments the verification records counter.
 	IncrementVerificationRecordsCounter(ctx context.Context)
-	// RecordStorageQueryDuration records the storage query duration.
-	RecordStorageQueryDuration(ctx context.Context, duration time.Duration, queryName string, errored bool)
-	// RecordStorageWriteDuration records the storage write duration.
-	RecordStorageWriteDuration(ctx context.Context, duration time.Duration)
-	// RecordStorageInsertErrorsCounter records the storage insert errors counter.
-	RecordStorageInsertErrorsCounter(ctx context.Context, queryName string)
+	// RecordStorageLatency records storage operation latency.
+	RecordStorageLatency(ctx context.Context, duration time.Duration)
+	// IncrementStorageError increments the storage error counter.
+	IncrementStorageError(ctx context.Context)
 	// RecordScannerPollingErrorsCounter records the scanner polling errors counter.
 	RecordScannerPollingErrorsCounter(ctx context.Context)
 	// RecordVerificationRecordChannelSizeGauge records the verification record channel size gauge.

--- a/indexer/pkg/common/metrics.go
+++ b/indexer/pkg/common/metrics.go
@@ -29,9 +29,9 @@ type IndexerMetricLabeler interface {
 	// IncrementVerificationRecordsCounter increments the verification records counter.
 	IncrementVerificationRecordsCounter(ctx context.Context)
 	// RecordStorageLatency records storage operation latency.
-	RecordStorageLatency(ctx context.Context, duration time.Duration)
+	RecordStorageLatency(ctx context.Context, operation string, duration time.Duration, errored bool)
 	// IncrementStorageError increments the storage error counter.
-	IncrementStorageError(ctx context.Context)
+	IncrementStorageError(ctx context.Context, operation string)
 	// RecordScannerPollingErrorsCounter records the scanner polling errors counter.
 	RecordScannerPollingErrorsCounter(ctx context.Context)
 	// RecordVerificationRecordChannelSizeGauge records the verification record channel size gauge.

--- a/indexer/pkg/monitoring/metrics.go
+++ b/indexer/pkg/monitoring/metrics.go
@@ -229,14 +229,19 @@ func (c *IndexerMetricLabeler) IncrementVerificationRecordsCounter(ctx context.C
 	c.im.verificationRecordsCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
-func (c *IndexerMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
+func (c *IndexerMetricLabeler) RecordStorageLatency(ctx context.Context, operation string, duration time.Duration, errored bool) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
-	c.im.storageDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes(otelLabels...))
+	c.im.storageDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes([]attribute.KeyValue{
+		attribute.String("operation", operation),
+		attribute.Bool("errored", errored),
+	}...), metric.WithAttributes(otelLabels...))
 }
 
-func (c *IndexerMetricLabeler) IncrementStorageError(ctx context.Context) {
+func (c *IndexerMetricLabeler) IncrementStorageError(ctx context.Context, operation string) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
-	c.im.storageErrorsCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
+	c.im.storageErrorsCounter.Add(ctx, 1, metric.WithAttributes([]attribute.KeyValue{
+		attribute.String("operation", operation),
+	}...), metric.WithAttributes(otelLabels...))
 }
 
 func (c *IndexerMetricLabeler) RecordScannerPollingErrorsCounter(ctx context.Context) {

--- a/indexer/pkg/monitoring/metrics.go
+++ b/indexer/pkg/monitoring/metrics.go
@@ -22,10 +22,9 @@ type IndexerMetrics struct {
 	requestDurationSeconds      metric.Float64Histogram
 
 	// Storage Metrics
-	verificationRecordsCounter  metric.Int64Counter
-	storageQueryDurationSeconds metric.Float64Histogram
-	storageWriteDurationSeconds metric.Float64Histogram
-	storageInsertErrorsCounter  metric.Int64Counter
+	verificationRecordsCounter metric.Int64Counter
+	storageDurationSeconds     metric.Float64Histogram
+	storageErrorsCounter       metric.Int64Counter
 
 	// Scanner Metrics
 	scannerPollingErrorsCounter        metric.Int64Counter
@@ -67,21 +66,13 @@ func InitMetrics() (im *IndexerMetrics, err error) {
 		return nil, fmt.Errorf("failed to register verification records counter: %w", err)
 	}
 
-	im.storageQueryDurationSeconds, err = beholder.GetMeter().Float64Histogram(
-		"indexer_storage_query_duration_seconds",
-		metric.WithDescription("Total duration of querying the storage of the Indexer"),
+	im.storageDurationSeconds, err = beholder.GetMeter().Float64Histogram(
+		"indexer_storage_operation_duration_seconds",
+		metric.WithDescription("Duration of storage operations in the Indexer"),
 		metric.WithUnit("seconds"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register storage query duration histogram: %w", err)
-	}
-
-	im.storageWriteDurationSeconds, err = beholder.GetMeter().Float64Histogram("indexer_storage_write_duration_seconds",
-		metric.WithDescription("Total duration of writing to the storage of the Indexer"),
-		metric.WithUnit("seconds"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to register storage write duration histogram: %w", err)
+		return nil, fmt.Errorf("failed to register storage operation duration histogram: %w", err)
 	}
 
 	im.discoveryLatencySeconds, err = beholder.GetMeter().Float64Histogram("indexer_message_discovery_latency_seconds",
@@ -92,11 +83,11 @@ func InitMetrics() (im *IndexerMetrics, err error) {
 		return nil, fmt.Errorf("failed to register message discovery latency histogram: %w", err)
 	}
 
-	im.storageInsertErrorsCounter, err = beholder.GetMeter().Int64Counter("indexer_storage_insert_errors_total",
-		metric.WithDescription("Total number of errors when inserting into Indexer Storage"),
+	im.storageErrorsCounter, err = beholder.GetMeter().Int64Counter("indexer_storage_errors_total",
+		metric.WithDescription("Total number of storage errors in the Indexer"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to register storage insert errors counter: %w", err)
+		return nil, fmt.Errorf("failed to register storage errors counter: %w", err)
 	}
 
 	im.scannerPollingErrorsCounter, err = beholder.GetMeter().Int64Counter("indexer_scanner_polling_errors_total",
@@ -164,13 +155,7 @@ var grpcPayloadSizeBuckets = []float64{
 func MetricViews() []sdkmetric.View {
 	return []sdkmetric.View{
 		sdkmetric.NewView(
-			sdkmetric.Instrument{Name: "indexer_storage_query_duration_seconds"},
-			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60, 300, 720},
-			}},
-		),
-		sdkmetric.NewView(
-			sdkmetric.Instrument{Name: "indexer_storage_write_duration_seconds"},
+			sdkmetric.Instrument{Name: "indexer_storage_operation_duration_seconds"},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
 				Boundaries: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 60, 300, 720},
 			}},
@@ -244,24 +229,14 @@ func (c *IndexerMetricLabeler) IncrementVerificationRecordsCounter(ctx context.C
 	c.im.verificationRecordsCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
-func (c *IndexerMetricLabeler) RecordStorageQueryDuration(ctx context.Context, duration time.Duration, queryName string, errored bool) {
+func (c *IndexerMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
-	c.im.storageQueryDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes([]attribute.KeyValue{
-		attribute.String("query", queryName),
-		attribute.Bool("errored", errored),
-	}...), metric.WithAttributes(otelLabels...))
+	c.im.storageDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes(otelLabels...))
 }
 
-func (c *IndexerMetricLabeler) RecordStorageWriteDuration(ctx context.Context, duration time.Duration) {
+func (c *IndexerMetricLabeler) IncrementStorageError(ctx context.Context) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
-	c.im.storageWriteDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes(otelLabels...))
-}
-
-func (c *IndexerMetricLabeler) RecordStorageInsertErrorsCounter(ctx context.Context, queryName string) {
-	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
-	c.im.storageInsertErrorsCounter.Add(ctx, 1, metric.WithAttributes([]attribute.KeyValue{
-		attribute.String("query", queryName),
-	}...), metric.WithAttributes(otelLabels...))
+	c.im.storageErrorsCounter.Add(ctx, 1, metric.WithAttributes(otelLabels...))
 }
 
 func (c *IndexerMetricLabeler) RecordScannerPollingErrorsCounter(ctx context.Context) {

--- a/indexer/pkg/monitoring/noop.go
+++ b/indexer/pkg/monitoring/noop.go
@@ -29,17 +29,9 @@ func (n *NoopIndexerMetricLabeler) DecrementActiveRequestsCounter(ctx context.Co
 func (n *NoopIndexerMetricLabeler) RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path, method string, status int) {
 }
 func (n *NoopIndexerMetricLabeler) IncrementVerificationRecordsCounter(ctx context.Context) {}
-func (n *NoopIndexerMetricLabeler) RecordStorageQueryDuration(ctx context.Context, duration time.Duration, queryName string, errored bool) {
+func (n *NoopIndexerMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
 }
-
-func (n *NoopIndexerMetricLabeler) RecordStorageWriteDuration(ctx context.Context, duration time.Duration) {
-}
-
-func (n *NoopIndexerMetricLabeler) RecordStorageInsertErrorsCounter(ctx context.Context, queryName string) {
-}
-
-func (n *NoopIndexerMetricLabeler) RecordVerificationRecordRequestDuration(ctx context.Context, duration time.Duration) {
-}
+func (n *NoopIndexerMetricLabeler) IncrementStorageError(ctx context.Context)             {}
 func (n *NoopIndexerMetricLabeler) RecordScannerPollingErrorsCounter(ctx context.Context) {}
 func (n *NoopIndexerMetricLabeler) RecordVerificationRecordChannelSizeGauge(ctx context.Context, size int64) {
 }

--- a/indexer/pkg/monitoring/noop.go
+++ b/indexer/pkg/monitoring/noop.go
@@ -29,9 +29,9 @@ func (n *NoopIndexerMetricLabeler) DecrementActiveRequestsCounter(ctx context.Co
 func (n *NoopIndexerMetricLabeler) RecordHTTPRequestDuration(ctx context.Context, duration time.Duration, path, method string, status int) {
 }
 func (n *NoopIndexerMetricLabeler) IncrementVerificationRecordsCounter(ctx context.Context) {}
-func (n *NoopIndexerMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
+func (n *NoopIndexerMetricLabeler) RecordStorageLatency(_ context.Context, _ string, _ time.Duration, _ bool) {
 }
-func (n *NoopIndexerMetricLabeler) IncrementStorageError(ctx context.Context)             {}
+func (n *NoopIndexerMetricLabeler) IncrementStorageError(_ context.Context, _ string)     {}
 func (n *NoopIndexerMetricLabeler) RecordScannerPollingErrorsCounter(ctx context.Context) {}
 func (n *NoopIndexerMetricLabeler) RecordVerificationRecordChannelSizeGauge(ctx context.Context, size int64) {
 }

--- a/indexer/pkg/storage/metrics_aware_storage.go
+++ b/indexer/pkg/storage/metrics_aware_storage.go
@@ -1,0 +1,141 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/common"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+const (
+	operationLabel = "operation"
+
+	opGetCCVData            = "GetCCVData"
+	opQueryCCVData          = "QueryCCVData"
+	opInsertVerifierResults = "InsertVerifierResults"
+	opGetMessage            = "GetMessage"
+	opQueryMessages         = "QueryMessages"
+	opUpdateMessageStatus   = "UpdateMessageStatus"
+	opCreateDiscoveryState  = "CreateDiscoveryState"
+	opGetDiscoverySequence  = "GetDiscoverySequenceNumber"
+	opPersistDiscoveryBatch = "PersistDiscoveryBatch"
+
+	defaultSlowQueryThreshold = 500 * time.Millisecond
+)
+
+type MetricsAwareStorage struct {
+	inner              common.IndexerStorage
+	m                  common.IndexerMonitoring
+	l                  logger.Logger
+	slowQueryThreshold time.Duration
+}
+
+type MetricsAwareStorageOption func(*MetricsAwareStorage)
+
+func WithSlowQueryThreshold(threshold time.Duration) MetricsAwareStorageOption {
+	return func(s *MetricsAwareStorage) {
+		s.slowQueryThreshold = threshold
+	}
+}
+
+func NewMetricsAwareStorage(inner common.IndexerStorage, m common.IndexerMonitoring, l logger.Logger, opts ...MetricsAwareStorageOption) *MetricsAwareStorage {
+	s := &MetricsAwareStorage{
+		inner:              inner,
+		m:                  m,
+		l:                  l,
+		slowQueryThreshold: defaultSlowQueryThreshold,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func WrapWithMetrics(inner common.IndexerStorage, m common.IndexerMonitoring, l logger.Logger, opts ...MetricsAwareStorageOption) common.IndexerStorage {
+	return NewMetricsAwareStorage(inner, m, l, opts...)
+}
+
+func (s *MetricsAwareStorage) metrics(operation string) common.IndexerMetricLabeler {
+	return s.m.Metrics().With(operationLabel, operation)
+}
+
+func (s *MetricsAwareStorage) GetCCVData(ctx context.Context, messageID protocol.Bytes32) ([]common.VerifierResultWithMetadata, error) {
+	return captureMetrics(ctx, s.metrics(opGetCCVData), s.l, s.slowQueryThreshold, opGetCCVData, func() ([]common.VerifierResultWithMetadata, error) {
+		return s.inner.GetCCVData(ctx, messageID)
+	})
+}
+
+func (s *MetricsAwareStorage) QueryCCVData(ctx context.Context, start, end int64, sourceChainSelectors, destChainSelectors []protocol.ChainSelector, limit, offset uint64) (map[string][]common.VerifierResultWithMetadata, error) {
+	return captureMetrics(ctx, s.metrics(opQueryCCVData), s.l, s.slowQueryThreshold, opQueryCCVData, func() (map[string][]common.VerifierResultWithMetadata, error) {
+		return s.inner.QueryCCVData(ctx, start, end, sourceChainSelectors, destChainSelectors, limit, offset)
+	})
+}
+
+func (s *MetricsAwareStorage) InsertVerifierResults(ctx context.Context, verifierResults []common.VerifierResultWithMetadata) error {
+	return captureMetricsNoReturn(ctx, s.metrics(opInsertVerifierResults), s.l, s.slowQueryThreshold, opInsertVerifierResults, func() error {
+		return s.inner.InsertVerifierResults(ctx, verifierResults)
+	})
+}
+
+func (s *MetricsAwareStorage) GetMessage(ctx context.Context, messageID protocol.Bytes32) (common.MessageWithMetadata, error) {
+	return captureMetrics(ctx, s.metrics(opGetMessage), s.l, s.slowQueryThreshold, opGetMessage, func() (common.MessageWithMetadata, error) {
+		return s.inner.GetMessage(ctx, messageID)
+	})
+}
+
+func (s *MetricsAwareStorage) QueryMessages(ctx context.Context, start, end int64, sourceChainSelectors, destChainSelectors []protocol.ChainSelector, limit, offset uint64) ([]common.MessageWithMetadata, error) {
+	return captureMetrics(ctx, s.metrics(opQueryMessages), s.l, s.slowQueryThreshold, opQueryMessages, func() ([]common.MessageWithMetadata, error) {
+		return s.inner.QueryMessages(ctx, start, end, sourceChainSelectors, destChainSelectors, limit, offset)
+	})
+}
+
+func (s *MetricsAwareStorage) UpdateMessageStatus(ctx context.Context, messageID protocol.Bytes32, status common.MessageStatus, lastErr string) error {
+	return captureMetricsNoReturn(ctx, s.metrics(opUpdateMessageStatus), s.l, s.slowQueryThreshold, opUpdateMessageStatus, func() error {
+		return s.inner.UpdateMessageStatus(ctx, messageID, status, lastErr)
+	})
+}
+
+func (s *MetricsAwareStorage) CreateDiscoveryState(ctx context.Context, discoveryLocation string, startingSequenceNumber int) error {
+	return captureMetricsNoReturn(ctx, s.metrics(opCreateDiscoveryState), s.l, s.slowQueryThreshold, opCreateDiscoveryState, func() error {
+		return s.inner.CreateDiscoveryState(ctx, discoveryLocation, startingSequenceNumber)
+	})
+}
+
+func (s *MetricsAwareStorage) GetDiscoverySequenceNumber(ctx context.Context, discoveryLocation string) (int, error) {
+	return captureMetrics(ctx, s.metrics(opGetDiscoverySequence), s.l, s.slowQueryThreshold, opGetDiscoverySequence, func() (int, error) {
+		return s.inner.GetDiscoverySequenceNumber(ctx, discoveryLocation)
+	})
+}
+
+func (s *MetricsAwareStorage) PersistDiscoveryBatch(ctx context.Context, batch common.DiscoveryBatch) error {
+	return captureMetricsNoReturn(ctx, s.metrics(opPersistDiscoveryBatch), s.l, s.slowQueryThreshold, opPersistDiscoveryBatch, func() error {
+		return s.inner.PersistDiscoveryBatch(ctx, batch)
+	})
+}
+
+func captureMetrics[T any](ctx context.Context, metrics common.IndexerMetricLabeler, l logger.Logger, threshold time.Duration, operation string, fn func() (T, error)) (T, error) {
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		metrics.RecordStorageLatency(ctx, duration)
+		if duration > threshold {
+			l.Warnw("Slow storage operation", "operation", operation, "duration_ms", duration.Milliseconds())
+		}
+	}()
+
+	res, err := fn()
+	if err != nil {
+		metrics.IncrementStorageError(ctx)
+	}
+
+	return res, err
+}
+
+func captureMetricsNoReturn(ctx context.Context, metrics common.IndexerMetricLabeler, l logger.Logger, threshold time.Duration, operation string, fn func() error) error {
+	_, err := captureMetrics(ctx, metrics, l, threshold, operation, func() (struct{}, error) {
+		return struct{}{}, fn()
+	})
+	return err
+}

--- a/indexer/pkg/storage/metrics_aware_storage.go
+++ b/indexer/pkg/storage/metrics_aware_storage.go
@@ -10,8 +10,6 @@ import (
 )
 
 const (
-	operationLabel = "operation"
-
 	opGetCCVData            = "GetCCVData"
 	opQueryCCVData          = "QueryCCVData"
 	opInsertVerifierResults = "InsertVerifierResults"
@@ -57,77 +55,73 @@ func WrapWithMetrics(inner common.IndexerStorage, m common.IndexerMonitoring, l 
 	return NewMetricsAwareStorage(inner, m, l, opts...)
 }
 
-func (s *MetricsAwareStorage) metrics(operation string) common.IndexerMetricLabeler {
-	return s.m.Metrics().With(operationLabel, operation)
-}
-
 func (s *MetricsAwareStorage) GetCCVData(ctx context.Context, messageID protocol.Bytes32) ([]common.VerifierResultWithMetadata, error) {
-	return captureMetrics(ctx, s.metrics(opGetCCVData), s.l, s.slowQueryThreshold, opGetCCVData, func() ([]common.VerifierResultWithMetadata, error) {
+	return captureMetrics(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opGetCCVData, func() ([]common.VerifierResultWithMetadata, error) {
 		return s.inner.GetCCVData(ctx, messageID)
 	})
 }
 
 func (s *MetricsAwareStorage) QueryCCVData(ctx context.Context, start, end int64, sourceChainSelectors, destChainSelectors []protocol.ChainSelector, limit, offset uint64) (map[string][]common.VerifierResultWithMetadata, error) {
-	return captureMetrics(ctx, s.metrics(opQueryCCVData), s.l, s.slowQueryThreshold, opQueryCCVData, func() (map[string][]common.VerifierResultWithMetadata, error) {
+	return captureMetrics(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opQueryCCVData, func() (map[string][]common.VerifierResultWithMetadata, error) {
 		return s.inner.QueryCCVData(ctx, start, end, sourceChainSelectors, destChainSelectors, limit, offset)
 	})
 }
 
 func (s *MetricsAwareStorage) InsertVerifierResults(ctx context.Context, verifierResults []common.VerifierResultWithMetadata) error {
-	return captureMetricsNoReturn(ctx, s.metrics(opInsertVerifierResults), s.l, s.slowQueryThreshold, opInsertVerifierResults, func() error {
+	return captureMetricsNoReturn(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opInsertVerifierResults, func() error {
 		return s.inner.InsertVerifierResults(ctx, verifierResults)
 	})
 }
 
 func (s *MetricsAwareStorage) GetMessage(ctx context.Context, messageID protocol.Bytes32) (common.MessageWithMetadata, error) {
-	return captureMetrics(ctx, s.metrics(opGetMessage), s.l, s.slowQueryThreshold, opGetMessage, func() (common.MessageWithMetadata, error) {
+	return captureMetrics(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opGetMessage, func() (common.MessageWithMetadata, error) {
 		return s.inner.GetMessage(ctx, messageID)
 	})
 }
 
 func (s *MetricsAwareStorage) QueryMessages(ctx context.Context, start, end int64, sourceChainSelectors, destChainSelectors []protocol.ChainSelector, limit, offset uint64) ([]common.MessageWithMetadata, error) {
-	return captureMetrics(ctx, s.metrics(opQueryMessages), s.l, s.slowQueryThreshold, opQueryMessages, func() ([]common.MessageWithMetadata, error) {
+	return captureMetrics(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opQueryMessages, func() ([]common.MessageWithMetadata, error) {
 		return s.inner.QueryMessages(ctx, start, end, sourceChainSelectors, destChainSelectors, limit, offset)
 	})
 }
 
 func (s *MetricsAwareStorage) UpdateMessageStatus(ctx context.Context, messageID protocol.Bytes32, status common.MessageStatus, lastErr string) error {
-	return captureMetricsNoReturn(ctx, s.metrics(opUpdateMessageStatus), s.l, s.slowQueryThreshold, opUpdateMessageStatus, func() error {
+	return captureMetricsNoReturn(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opUpdateMessageStatus, func() error {
 		return s.inner.UpdateMessageStatus(ctx, messageID, status, lastErr)
 	})
 }
 
 func (s *MetricsAwareStorage) CreateDiscoveryState(ctx context.Context, discoveryLocation string, startingSequenceNumber int) error {
-	return captureMetricsNoReturn(ctx, s.metrics(opCreateDiscoveryState), s.l, s.slowQueryThreshold, opCreateDiscoveryState, func() error {
+	return captureMetricsNoReturn(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opCreateDiscoveryState, func() error {
 		return s.inner.CreateDiscoveryState(ctx, discoveryLocation, startingSequenceNumber)
 	})
 }
 
 func (s *MetricsAwareStorage) GetDiscoverySequenceNumber(ctx context.Context, discoveryLocation string) (int, error) {
-	return captureMetrics(ctx, s.metrics(opGetDiscoverySequence), s.l, s.slowQueryThreshold, opGetDiscoverySequence, func() (int, error) {
+	return captureMetrics(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opGetDiscoverySequence, func() (int, error) {
 		return s.inner.GetDiscoverySequenceNumber(ctx, discoveryLocation)
 	})
 }
 
 func (s *MetricsAwareStorage) PersistDiscoveryBatch(ctx context.Context, batch common.DiscoveryBatch) error {
-	return captureMetricsNoReturn(ctx, s.metrics(opPersistDiscoveryBatch), s.l, s.slowQueryThreshold, opPersistDiscoveryBatch, func() error {
+	return captureMetricsNoReturn(ctx, s.m.Metrics(), s.l, s.slowQueryThreshold, opPersistDiscoveryBatch, func() error {
 		return s.inner.PersistDiscoveryBatch(ctx, batch)
 	})
 }
 
 func captureMetrics[T any](ctx context.Context, metrics common.IndexerMetricLabeler, l logger.Logger, threshold time.Duration, operation string, fn func() (T, error)) (T, error) {
 	start := time.Now()
-	defer func() {
-		duration := time.Since(start)
-		metrics.RecordStorageLatency(ctx, duration)
-		if duration > threshold {
-			l.Warnw("Slow storage operation", "operation", operation, "duration_ms", duration.Milliseconds())
-		}
-	}()
 
 	res, err := fn()
+
+	duration := time.Since(start)
+	metrics.RecordStorageLatency(ctx, operation, duration, err != nil)
+	if duration > threshold {
+		l.Warnw("Slow storage operation", "operation", operation, "duration_ms", duration.Milliseconds())
+	}
+
 	if err != nil {
-		metrics.IncrementStorageError(ctx)
+		metrics.IncrementStorageError(ctx, operation)
 	}
 
 	return res, err

--- a/indexer/pkg/storage/postgres.go
+++ b/indexer/pkg/storage/postgres.go
@@ -21,14 +21,6 @@ import (
 var _ common.IndexerStorage = (*PostgresStorage)(nil)
 
 const (
-	opGetCCVData            = "GetCCVData"
-	opQueryCCVData          = "QueryCCVData"
-	opBatchInsertCCVData    = "BatchInsertCCVData"
-	opQueryMessages         = "QueryMessages"
-	opUpdateMessageStatus   = "UpdateMessageStatus"
-	opCreateDiscoveryState  = "CreateDiscoveryState"
-	opPersistDiscoveryBatch = "PersistDiscoveryBatch"
-
 	// maxBatchSizeCCVData is the maximum number of CCV data rows that can be inserted in a single query
 	// to avoid Postgres bind parameter overflow (65535 limit). With 11 parameters per row, 5000 rows = 55000 parameters.
 	maxBatchSizeCCVData = 5000
@@ -90,12 +82,6 @@ func NewPostgresStorage(ctx context.Context, lggr logger.Logger, monitoring comm
 
 // GetCCVData performs a lookup by messageID in the database.
 func (d *PostgresStorage) GetCCVData(ctx context.Context, messageID protocol.Bytes32) ([]common.VerifierResultWithMetadata, error) {
-	startQueryMetric := time.Now()
-	var err error
-	defer func() {
-		d.monitoring.Metrics().RecordStorageQueryDuration(ctx, time.Since(startQueryMetric), opGetCCVData, err != nil)
-	}()
-
 	query := `
 		SELECT 
 			message_id,
@@ -151,12 +137,6 @@ func (d *PostgresStorage) QueryCCVData(
 	sourceChainSelectors, destChainSelectors []protocol.ChainSelector,
 	limit, offset uint64,
 ) (map[string][]common.VerifierResultWithMetadata, error) {
-	startQueryMetric := time.Now()
-	var err error
-	defer func() {
-		d.monitoring.Metrics().RecordStorageQueryDuration(ctx, time.Since(startQueryMetric), opQueryCCVData, err != nil)
-	}()
-
 	// Build dynamic query with filters
 	query := `
 		SELECT 
@@ -303,19 +283,14 @@ func (d *PostgresStorage) InsertVerifierResults(ctx context.Context, verifierRes
 		return nil
 	}
 
-	startInsertMetric := time.Now()
-
 	query, args, err := buildBatchInsertCCVDataQuery(verifierResults)
 	if err != nil {
-		d.monitoring.Metrics().RecordStorageInsertErrorsCounter(ctx, opBatchInsertCCVData)
 		return err
 	}
 
 	result, err := d.execContext(ctx, query, args...)
 	if err != nil {
 		d.lggr.Errorw("Failed to batch insert CCV data", "error", err, "count", len(verifierResults))
-		d.monitoring.Metrics().RecordStorageInsertErrorsCounter(ctx, opBatchInsertCCVData)
-		d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startInsertMetric))
 		return fmt.Errorf("failed to batch insert CCV data: %w", err)
 	}
 
@@ -330,7 +305,6 @@ func (d *PostgresStorage) InsertVerifierResults(ctx context.Context, verifierRes
 		d.monitoring.Metrics().IncrementVerificationRecordsCounter(ctx)
 	}
 
-	d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startInsertMetric))
 	return nil
 }
 
@@ -489,12 +463,6 @@ func (d *PostgresStorage) QueryMessages(
 	sourceChainSelectors, destChainSelectors []protocol.ChainSelector,
 	limit, offset uint64,
 ) ([]common.MessageWithMetadata, error) {
-	startQueryMetric := time.Now()
-	var err error
-	defer func() {
-		d.monitoring.Metrics().RecordStorageQueryDuration(ctx, time.Since(startQueryMetric), opQueryMessages, err != nil)
-	}()
-
 	query := `
 		SELECT 
 			message_id,
@@ -555,8 +523,6 @@ func (d *PostgresStorage) QueryMessages(
 
 // UpdateMessageStatus implements common.IndexerStorage.
 func (d *PostgresStorage) UpdateMessageStatus(ctx context.Context, messageID protocol.Bytes32, status common.MessageStatus, lastErr string) error {
-	startUpdateMetric := time.Now()
-
 	query := `
 		UPDATE indexer.messages
 		SET status = $1, lastErr = $2
@@ -566,30 +532,23 @@ func (d *PostgresStorage) UpdateMessageStatus(ctx context.Context, messageID pro
 	result, err := d.execContext(ctx, query, status.String(), lastErr, messageID.String())
 	if err != nil {
 		d.lggr.Errorw("Failed to update message status", "error", err, "messageID", messageID.String())
-		d.monitoring.Metrics().RecordStorageInsertErrorsCounter(ctx, opUpdateMessageStatus)
-		d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startUpdateMetric))
 		return fmt.Errorf("failed to update message status: %w", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
 		d.lggr.Warnw("Failed to get rows affected", "error", err)
-		d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startUpdateMetric))
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 
 	if rowsAffected == 0 {
-		d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startUpdateMetric))
 		return fmt.Errorf("message not found: %s", messageID.String())
 	}
 
-	d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startUpdateMetric))
 	return nil
 }
 
 func (d *PostgresStorage) CreateDiscoveryState(ctx context.Context, discoveryLocation string, startingSequenceNumber int) error {
-	startInsertMetric := time.Now()
-
 	query := `
     INSERT INTO indexer.discovery_state (
       discovery_location,
@@ -604,15 +563,12 @@ func (d *PostgresStorage) CreateDiscoveryState(ctx context.Context, discoveryLoc
 	)
 	if err != nil {
 		d.lggr.Errorw("Failed to create discovery state record", "error", err, "discoveryLocation", discoveryLocation, "sequenceNumber", startingSequenceNumber)
-		d.monitoring.Metrics().RecordStorageInsertErrorsCounter(ctx, opCreateDiscoveryState)
-		d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startInsertMetric))
 		return fmt.Errorf("failed to create discovery state: %w", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
 		d.lggr.Warnw("Failed to get rows affected", "error", err)
-		d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startInsertMetric))
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 
@@ -621,7 +577,6 @@ func (d *PostgresStorage) CreateDiscoveryState(ctx context.Context, discoveryLoc
 		return nil
 	}
 
-	d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startInsertMetric))
 	return nil
 }
 
@@ -629,8 +584,6 @@ func (d *PostgresStorage) PersistDiscoveryBatch(ctx context.Context, batch commo
 	if len(batch.Messages) == 0 && len(batch.Verifications) == 0 {
 		return nil
 	}
-
-	startMetric := time.Now()
 
 	var verificationsInserted int64
 
@@ -692,8 +645,6 @@ func (d *PostgresStorage) PersistDiscoveryBatch(ctx context.Context, batch commo
 	})
 	if err != nil {
 		d.lggr.Errorw("Failed to persist discovery batch", "error", err)
-		d.monitoring.Metrics().RecordStorageInsertErrorsCounter(ctx, opPersistDiscoveryBatch)
-		d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startMetric))
 		return err
 	}
 
@@ -708,7 +659,6 @@ func (d *PostgresStorage) PersistDiscoveryBatch(ctx context.Context, batch commo
 		"verifications", len(batch.Verifications),
 		"sequenceNumber", batch.SequenceNumber,
 	)
-	d.monitoring.Metrics().RecordStorageWriteDuration(ctx, time.Since(startMetric))
 	return nil
 }
 

--- a/internal/mocks/mock_AggregatorMetricLabeler.go
+++ b/internal/mocks/mock_AggregatorMetricLabeler.go
@@ -358,9 +358,9 @@ func (_c *MockAggregatorMetricLabeler_IncrementPendingAggregationsChannelBuffer_
 	return _c
 }
 
-// IncrementStorageError provides a mock function with given fields: ctx
-func (_m *MockAggregatorMetricLabeler) IncrementStorageError(ctx context.Context) {
-	_m.Called(ctx)
+// IncrementStorageError provides a mock function with given fields: ctx, operation
+func (_m *MockAggregatorMetricLabeler) IncrementStorageError(ctx context.Context, operation string) {
+	_m.Called(ctx, operation)
 }
 
 // MockAggregatorMetricLabeler_IncrementStorageError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IncrementStorageError'
@@ -370,13 +370,14 @@ type MockAggregatorMetricLabeler_IncrementStorageError_Call struct {
 
 // IncrementStorageError is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockAggregatorMetricLabeler_Expecter) IncrementStorageError(ctx interface{}) *MockAggregatorMetricLabeler_IncrementStorageError_Call {
-	return &MockAggregatorMetricLabeler_IncrementStorageError_Call{Call: _e.mock.On("IncrementStorageError", ctx)}
+//   - operation string
+func (_e *MockAggregatorMetricLabeler_Expecter) IncrementStorageError(ctx interface{}, operation interface{}) *MockAggregatorMetricLabeler_IncrementStorageError_Call {
+	return &MockAggregatorMetricLabeler_IncrementStorageError_Call{Call: _e.mock.On("IncrementStorageError", ctx, operation)}
 }
 
-func (_c *MockAggregatorMetricLabeler_IncrementStorageError_Call) Run(run func(ctx context.Context)) *MockAggregatorMetricLabeler_IncrementStorageError_Call {
+func (_c *MockAggregatorMetricLabeler_IncrementStorageError_Call) Run(run func(ctx context.Context, operation string)) *MockAggregatorMetricLabeler_IncrementStorageError_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -386,7 +387,7 @@ func (_c *MockAggregatorMetricLabeler_IncrementStorageError_Call) Return() *Mock
 	return _c
 }
 
-func (_c *MockAggregatorMetricLabeler_IncrementStorageError_Call) RunAndReturn(run func(context.Context)) *MockAggregatorMetricLabeler_IncrementStorageError_Call {
+func (_c *MockAggregatorMetricLabeler_IncrementStorageError_Call) RunAndReturn(run func(context.Context, string)) *MockAggregatorMetricLabeler_IncrementStorageError_Call {
 	_c.Run(run)
 	return _c
 }
@@ -595,9 +596,9 @@ func (_c *MockAggregatorMetricLabeler_RecordOrphanRecoveryDuration_Call) RunAndR
 	return _c
 }
 
-// RecordStorageLatency provides a mock function with given fields: ctx, duration
-func (_m *MockAggregatorMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
-	_m.Called(ctx, duration)
+// RecordStorageLatency provides a mock function with given fields: ctx, operation, duration, errored
+func (_m *MockAggregatorMetricLabeler) RecordStorageLatency(ctx context.Context, operation string, duration time.Duration, errored bool) {
+	_m.Called(ctx, operation, duration, errored)
 }
 
 // MockAggregatorMetricLabeler_RecordStorageLatency_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordStorageLatency'
@@ -607,14 +608,16 @@ type MockAggregatorMetricLabeler_RecordStorageLatency_Call struct {
 
 // RecordStorageLatency is a helper method to define mock.On call
 //   - ctx context.Context
+//   - operation string
 //   - duration time.Duration
-func (_e *MockAggregatorMetricLabeler_Expecter) RecordStorageLatency(ctx interface{}, duration interface{}) *MockAggregatorMetricLabeler_RecordStorageLatency_Call {
-	return &MockAggregatorMetricLabeler_RecordStorageLatency_Call{Call: _e.mock.On("RecordStorageLatency", ctx, duration)}
+//   - errored bool
+func (_e *MockAggregatorMetricLabeler_Expecter) RecordStorageLatency(ctx interface{}, operation interface{}, duration interface{}, errored interface{}) *MockAggregatorMetricLabeler_RecordStorageLatency_Call {
+	return &MockAggregatorMetricLabeler_RecordStorageLatency_Call{Call: _e.mock.On("RecordStorageLatency", ctx, operation, duration, errored)}
 }
 
-func (_c *MockAggregatorMetricLabeler_RecordStorageLatency_Call) Run(run func(ctx context.Context, duration time.Duration)) *MockAggregatorMetricLabeler_RecordStorageLatency_Call {
+func (_c *MockAggregatorMetricLabeler_RecordStorageLatency_Call) Run(run func(ctx context.Context, operation string, duration time.Duration, errored bool)) *MockAggregatorMetricLabeler_RecordStorageLatency_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(time.Duration))
+		run(args[0].(context.Context), args[1].(string), args[2].(time.Duration), args[3].(bool))
 	})
 	return _c
 }
@@ -624,7 +627,7 @@ func (_c *MockAggregatorMetricLabeler_RecordStorageLatency_Call) Return() *MockA
 	return _c
 }
 
-func (_c *MockAggregatorMetricLabeler_RecordStorageLatency_Call) RunAndReturn(run func(context.Context, time.Duration)) *MockAggregatorMetricLabeler_RecordStorageLatency_Call {
+func (_c *MockAggregatorMetricLabeler_RecordStorageLatency_Call) RunAndReturn(run func(context.Context, string, time.Duration, bool)) *MockAggregatorMetricLabeler_RecordStorageLatency_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/mocks/mock_IndexerMetricLabeler.go
+++ b/internal/mocks/mock_IndexerMetricLabeler.go
@@ -124,6 +124,39 @@ func (_c *MockIndexerMetricLabeler_IncrementGRPCErrors_Call) RunAndReturn(run fu
 	return _c
 }
 
+// IncrementStorageError provides a mock function with given fields: ctx
+func (_m *MockIndexerMetricLabeler) IncrementStorageError(ctx context.Context) {
+	_m.Called(ctx)
+}
+
+// MockIndexerMetricLabeler_IncrementStorageError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IncrementStorageError'
+type MockIndexerMetricLabeler_IncrementStorageError_Call struct {
+	*mock.Call
+}
+
+// IncrementStorageError is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockIndexerMetricLabeler_Expecter) IncrementStorageError(ctx interface{}) *MockIndexerMetricLabeler_IncrementStorageError_Call {
+	return &MockIndexerMetricLabeler_IncrementStorageError_Call{Call: _e.mock.On("IncrementStorageError", ctx)}
+}
+
+func (_c *MockIndexerMetricLabeler_IncrementStorageError_Call) Run(run func(ctx context.Context)) *MockIndexerMetricLabeler_IncrementStorageError_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockIndexerMetricLabeler_IncrementStorageError_Call) Return() *MockIndexerMetricLabeler_IncrementStorageError_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockIndexerMetricLabeler_IncrementStorageError_Call) RunAndReturn(run func(context.Context)) *MockIndexerMetricLabeler_IncrementStorageError_Call {
+	_c.Run(run)
+	return _c
+}
+
 // IncrementVerificationRecordsCounter provides a mock function with given fields: ctx
 func (_m *MockIndexerMetricLabeler) IncrementVerificationRecordsCounter(ctx context.Context) {
 	_m.Called(ctx)
@@ -365,106 +398,36 @@ func (_c *MockIndexerMetricLabeler_RecordScannerPollingErrorsCounter_Call) RunAn
 	return _c
 }
 
-// RecordStorageInsertErrorsCounter provides a mock function with given fields: ctx, queryName
-func (_m *MockIndexerMetricLabeler) RecordStorageInsertErrorsCounter(ctx context.Context, queryName string) {
-	_m.Called(ctx, queryName)
-}
-
-// MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordStorageInsertErrorsCounter'
-type MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call struct {
-	*mock.Call
-}
-
-// RecordStorageInsertErrorsCounter is a helper method to define mock.On call
-//   - ctx context.Context
-//   - queryName string
-func (_e *MockIndexerMetricLabeler_Expecter) RecordStorageInsertErrorsCounter(ctx interface{}, queryName interface{}) *MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call {
-	return &MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call{Call: _e.mock.On("RecordStorageInsertErrorsCounter", ctx, queryName)}
-}
-
-func (_c *MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call) Run(run func(ctx context.Context, queryName string)) *MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call) Return() *MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call) RunAndReturn(run func(context.Context, string)) *MockIndexerMetricLabeler_RecordStorageInsertErrorsCounter_Call {
-	_c.Run(run)
-	return _c
-}
-
-// RecordStorageQueryDuration provides a mock function with given fields: ctx, duration, queryName, errored
-func (_m *MockIndexerMetricLabeler) RecordStorageQueryDuration(ctx context.Context, duration time.Duration, queryName string, errored bool) {
-	_m.Called(ctx, duration, queryName, errored)
-}
-
-// MockIndexerMetricLabeler_RecordStorageQueryDuration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordStorageQueryDuration'
-type MockIndexerMetricLabeler_RecordStorageQueryDuration_Call struct {
-	*mock.Call
-}
-
-// RecordStorageQueryDuration is a helper method to define mock.On call
-//   - ctx context.Context
-//   - duration time.Duration
-//   - queryName string
-//   - errored bool
-func (_e *MockIndexerMetricLabeler_Expecter) RecordStorageQueryDuration(ctx interface{}, duration interface{}, queryName interface{}, errored interface{}) *MockIndexerMetricLabeler_RecordStorageQueryDuration_Call {
-	return &MockIndexerMetricLabeler_RecordStorageQueryDuration_Call{Call: _e.mock.On("RecordStorageQueryDuration", ctx, duration, queryName, errored)}
-}
-
-func (_c *MockIndexerMetricLabeler_RecordStorageQueryDuration_Call) Run(run func(ctx context.Context, duration time.Duration, queryName string, errored bool)) *MockIndexerMetricLabeler_RecordStorageQueryDuration_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(time.Duration), args[2].(string), args[3].(bool))
-	})
-	return _c
-}
-
-func (_c *MockIndexerMetricLabeler_RecordStorageQueryDuration_Call) Return() *MockIndexerMetricLabeler_RecordStorageQueryDuration_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockIndexerMetricLabeler_RecordStorageQueryDuration_Call) RunAndReturn(run func(context.Context, time.Duration, string, bool)) *MockIndexerMetricLabeler_RecordStorageQueryDuration_Call {
-	_c.Run(run)
-	return _c
-}
-
-// RecordStorageWriteDuration provides a mock function with given fields: ctx, duration
-func (_m *MockIndexerMetricLabeler) RecordStorageWriteDuration(ctx context.Context, duration time.Duration) {
+// RecordStorageLatency provides a mock function with given fields: ctx, duration
+func (_m *MockIndexerMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
 	_m.Called(ctx, duration)
 }
 
-// MockIndexerMetricLabeler_RecordStorageWriteDuration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordStorageWriteDuration'
-type MockIndexerMetricLabeler_RecordStorageWriteDuration_Call struct {
+// MockIndexerMetricLabeler_RecordStorageLatency_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordStorageLatency'
+type MockIndexerMetricLabeler_RecordStorageLatency_Call struct {
 	*mock.Call
 }
 
-// RecordStorageWriteDuration is a helper method to define mock.On call
+// RecordStorageLatency is a helper method to define mock.On call
 //   - ctx context.Context
 //   - duration time.Duration
-func (_e *MockIndexerMetricLabeler_Expecter) RecordStorageWriteDuration(ctx interface{}, duration interface{}) *MockIndexerMetricLabeler_RecordStorageWriteDuration_Call {
-	return &MockIndexerMetricLabeler_RecordStorageWriteDuration_Call{Call: _e.mock.On("RecordStorageWriteDuration", ctx, duration)}
+func (_e *MockIndexerMetricLabeler_Expecter) RecordStorageLatency(ctx interface{}, duration interface{}) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
+	return &MockIndexerMetricLabeler_RecordStorageLatency_Call{Call: _e.mock.On("RecordStorageLatency", ctx, duration)}
 }
 
-func (_c *MockIndexerMetricLabeler_RecordStorageWriteDuration_Call) Run(run func(ctx context.Context, duration time.Duration)) *MockIndexerMetricLabeler_RecordStorageWriteDuration_Call {
+func (_c *MockIndexerMetricLabeler_RecordStorageLatency_Call) Run(run func(ctx context.Context, duration time.Duration)) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(time.Duration))
 	})
 	return _c
 }
 
-func (_c *MockIndexerMetricLabeler_RecordStorageWriteDuration_Call) Return() *MockIndexerMetricLabeler_RecordStorageWriteDuration_Call {
+func (_c *MockIndexerMetricLabeler_RecordStorageLatency_Call) Return() *MockIndexerMetricLabeler_RecordStorageLatency_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockIndexerMetricLabeler_RecordStorageWriteDuration_Call) RunAndReturn(run func(context.Context, time.Duration)) *MockIndexerMetricLabeler_RecordStorageWriteDuration_Call {
+func (_c *MockIndexerMetricLabeler_RecordStorageLatency_Call) RunAndReturn(run func(context.Context, time.Duration)) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/mocks/mock_IndexerMetricLabeler.go
+++ b/internal/mocks/mock_IndexerMetricLabeler.go
@@ -124,9 +124,9 @@ func (_c *MockIndexerMetricLabeler_IncrementGRPCErrors_Call) RunAndReturn(run fu
 	return _c
 }
 
-// IncrementStorageError provides a mock function with given fields: ctx
-func (_m *MockIndexerMetricLabeler) IncrementStorageError(ctx context.Context) {
-	_m.Called(ctx)
+// IncrementStorageError provides a mock function with given fields: ctx, operation
+func (_m *MockIndexerMetricLabeler) IncrementStorageError(ctx context.Context, operation string) {
+	_m.Called(ctx, operation)
 }
 
 // MockIndexerMetricLabeler_IncrementStorageError_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IncrementStorageError'
@@ -136,13 +136,14 @@ type MockIndexerMetricLabeler_IncrementStorageError_Call struct {
 
 // IncrementStorageError is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockIndexerMetricLabeler_Expecter) IncrementStorageError(ctx interface{}) *MockIndexerMetricLabeler_IncrementStorageError_Call {
-	return &MockIndexerMetricLabeler_IncrementStorageError_Call{Call: _e.mock.On("IncrementStorageError", ctx)}
+//   - operation string
+func (_e *MockIndexerMetricLabeler_Expecter) IncrementStorageError(ctx interface{}, operation interface{}) *MockIndexerMetricLabeler_IncrementStorageError_Call {
+	return &MockIndexerMetricLabeler_IncrementStorageError_Call{Call: _e.mock.On("IncrementStorageError", ctx, operation)}
 }
 
-func (_c *MockIndexerMetricLabeler_IncrementStorageError_Call) Run(run func(ctx context.Context)) *MockIndexerMetricLabeler_IncrementStorageError_Call {
+func (_c *MockIndexerMetricLabeler_IncrementStorageError_Call) Run(run func(ctx context.Context, operation string)) *MockIndexerMetricLabeler_IncrementStorageError_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -152,7 +153,7 @@ func (_c *MockIndexerMetricLabeler_IncrementStorageError_Call) Return() *MockInd
 	return _c
 }
 
-func (_c *MockIndexerMetricLabeler_IncrementStorageError_Call) RunAndReturn(run func(context.Context)) *MockIndexerMetricLabeler_IncrementStorageError_Call {
+func (_c *MockIndexerMetricLabeler_IncrementStorageError_Call) RunAndReturn(run func(context.Context, string)) *MockIndexerMetricLabeler_IncrementStorageError_Call {
 	_c.Run(run)
 	return _c
 }
@@ -398,9 +399,9 @@ func (_c *MockIndexerMetricLabeler_RecordScannerPollingErrorsCounter_Call) RunAn
 	return _c
 }
 
-// RecordStorageLatency provides a mock function with given fields: ctx, duration
-func (_m *MockIndexerMetricLabeler) RecordStorageLatency(ctx context.Context, duration time.Duration) {
-	_m.Called(ctx, duration)
+// RecordStorageLatency provides a mock function with given fields: ctx, operation, duration, errored
+func (_m *MockIndexerMetricLabeler) RecordStorageLatency(ctx context.Context, operation string, duration time.Duration, errored bool) {
+	_m.Called(ctx, operation, duration, errored)
 }
 
 // MockIndexerMetricLabeler_RecordStorageLatency_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordStorageLatency'
@@ -410,14 +411,16 @@ type MockIndexerMetricLabeler_RecordStorageLatency_Call struct {
 
 // RecordStorageLatency is a helper method to define mock.On call
 //   - ctx context.Context
+//   - operation string
 //   - duration time.Duration
-func (_e *MockIndexerMetricLabeler_Expecter) RecordStorageLatency(ctx interface{}, duration interface{}) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
-	return &MockIndexerMetricLabeler_RecordStorageLatency_Call{Call: _e.mock.On("RecordStorageLatency", ctx, duration)}
+//   - errored bool
+func (_e *MockIndexerMetricLabeler_Expecter) RecordStorageLatency(ctx interface{}, operation interface{}, duration interface{}, errored interface{}) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
+	return &MockIndexerMetricLabeler_RecordStorageLatency_Call{Call: _e.mock.On("RecordStorageLatency", ctx, operation, duration, errored)}
 }
 
-func (_c *MockIndexerMetricLabeler_RecordStorageLatency_Call) Run(run func(ctx context.Context, duration time.Duration)) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
+func (_c *MockIndexerMetricLabeler_RecordStorageLatency_Call) Run(run func(ctx context.Context, operation string, duration time.Duration, errored bool)) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(time.Duration))
+		run(args[0].(context.Context), args[1].(string), args[2].(time.Duration), args[3].(bool))
 	})
 	return _c
 }
@@ -427,7 +430,7 @@ func (_c *MockIndexerMetricLabeler_RecordStorageLatency_Call) Return() *MockInde
 	return _c
 }
 
-func (_c *MockIndexerMetricLabeler_RecordStorageLatency_Call) RunAndReturn(run func(context.Context, time.Duration)) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
+func (_c *MockIndexerMetricLabeler_RecordStorageLatency_Call) RunAndReturn(run func(context.Context, string, time.Duration, bool)) *MockIndexerMetricLabeler_RecordStorageLatency_Call {
 	_c.Run(run)
 	return _c
 }


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
- Refactors Aggregator storage metrics to pass `operation` and `errored` explicitly instead of baking labels into the metric instance.
- Centralizes Aggregator storage latency/error tracking in shared wrapper helpers for more consistent instrumentation.
- Introduces a new `metrics_aware_storage` wrapper for the Indexer so storage operations are instrumented outside the Postgres implementation.
- Simplifies Indexer metrics by replacing separate query/write/error metrics with unified storage latency and storage error metrics.
- Updates Indexer startup wiring to wrap the DB store with metrics instrumentation by default.
- Regenerates noop and mock metric labelers to match the new method signatures.


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing
```
just cli
ccv up
ccv obs up
ccv test smoke-v3 --build false
```
And checked new metrics in the dashboard

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
