### PR TITLE
feat(devenv): add LockRelease 1.6.1 token pool support 

### DIFF
--- a/build/devenv/common/common.go
+++ b/build/devenv/common/common.go
@@ -170,6 +170,15 @@ func AllTokenCombinations() []TokenCombination {
 			expectedReceiptIssuers:  4, // default CCV, token pool, executor, network fee
 			expectedVerifierResults: 1, // default CCV
 		},
+		{ // 2.0.0 burn <-> 1.6.1 release
+			localPoolType:           BurnMintTokenPoolType,
+			localPoolVersion:        "2.0.0",
+			localPoolCCVQualifiers:  []string{DefaultCommitteeVerifierQualifier},
+			remotePoolType:          LockReleaseTokenPoolType,
+			remotePoolVersion:       "1.6.1",
+			expectedReceiptIssuers:  4, // default CCV, token pool, executor, network fee
+			expectedVerifierResults: 1, // default CCV
+		},
 		{ // 2.0.0 lock <-> 2.0.0 burn
 			localPoolType:           LockReleaseTokenPoolType,
 			localPoolVersion:        "2.0.0",

--- a/build/devenv/common/common.go
+++ b/build/devenv/common/common.go
@@ -483,3 +483,35 @@ func dataStoreHasAddressRef(ds datastore.DataStore, chainSelector uint64, ref da
 	))
 	return err == nil
 }
+
+// PoolCapabilityKey returns a unique key for a pool capability using "::" as separator.
+// Used for building lookup maps of supported pools.
+func PoolCapabilityKey(cap PoolCapability) string {
+	return cap.PoolType + "::" + cap.PoolVersion.String()
+}
+
+// AddressRefPoolKey returns a key for an address ref's pool type and version (without qualifier).
+// Used for checking if a pool type/version is supported.
+func AddressRefPoolKey(ref datastore.AddressRef) string {
+	return string(ref.Type) + "::" + ref.Version.String()
+}
+
+// AddressRefFullKey returns a full key including type, version, and qualifier.
+// Used for de-duplicating pool deployments.
+func AddressRefFullKey(ref datastore.AddressRef) string {
+	return string(ref.Type) + "::" + ref.Version.String() + "::" + ref.Qualifier
+}
+
+// BuildSupportedPoolsMap creates a map of supported pool keys from capabilities.
+func BuildSupportedPoolsMap(caps []PoolCapability) map[string]bool {
+	supported := make(map[string]bool, len(caps))
+	for _, cap := range caps {
+		supported[PoolCapabilityKey(cap)] = true
+	}
+	return supported
+}
+
+// IsPoolSupported checks if an address ref's pool type/version is in the supported map.
+func IsPoolSupported(supported map[string]bool, ref datastore.AddressRef) bool {
+	return supported[AddressRefPoolKey(ref)]
+}

--- a/build/devenv/common/common.go
+++ b/build/devenv/common/common.go
@@ -179,6 +179,15 @@ func AllTokenCombinations() []TokenCombination {
 			expectedReceiptIssuers:  4, // default CCV, token pool, executor, network fee
 			expectedVerifierResults: 1, // default CCV
 		},
+		{ // 1.6.1 release <-> 2.0.0 burn
+			localPoolType:           LockReleaseTokenPoolType,
+			localPoolVersion:        "1.6.1",
+			remotePoolType:          BurnMintTokenPoolType,
+			remotePoolVersion:       "2.0.0",
+			remotePoolCCVQualifiers: []string{DefaultCommitteeVerifierQualifier},
+			expectedReceiptIssuers:  4, // default CCV, token pool, executor, network fee
+			expectedVerifierResults: 1, // default CCV
+		},
 		{ // 2.0.0 lock <-> 2.0.0 burn
 			localPoolType:           LockReleaseTokenPoolType,
 			localPoolVersion:        "2.0.0",

--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -1191,6 +1191,13 @@ func (m *CCIP17EVMConfig) GetTokenExpansionConfigs(
 	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(DefaultDecimals), nil)
 	preMintTokens := new(big.Int).Div(deployerBalance, divisor).Uint64()
 
+	// Build a set of supported pool capabilities so we can skip combos where
+	// EVM is the "local" side but doesn't actually support that pool.
+	supported := make(map[string]bool)
+	for _, cap := range m.GetSupportedPools() {
+		supported[cap.PoolType+"\x00"+cap.PoolVersion.String()] = true
+	}
+
 	seen := make(map[string]bool)
 	var configs []tokenscore.TokenExpansionInputPerChain
 
@@ -1199,6 +1206,15 @@ func (m *CCIP17EVMConfig) GetTokenExpansionConfigs(
 		// counterpart chain and must not be deployed here — deploying it would
 		// attempt to fund a lockbox for an unsupported pool version and fail.
 		poolRef := combo.LocalPoolAddressRef()
+
+		// Skip combos where EVM doesn't support the local pool type/version.
+		// ComputeTokenCombinations generates combos in both directions, so we
+		// may receive combos where another chain (e.g. Solana) is meant to be
+		// the local side.
+		if !supported[string(poolRef.Type)+"\x00"+poolRef.Version.String()] {
+			continue
+		}
+
 		key := string(poolRef.Type) + "\x00" + poolRef.Version.String() + "\x00" + poolRef.Qualifier
 		if seen[key] {
 			continue

--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -1195,31 +1195,33 @@ func (m *CCIP17EVMConfig) GetTokenExpansionConfigs(
 	var configs []tokenscore.TokenExpansionInputPerChain
 
 	for _, combo := range combos {
-		for _, poolRef := range []datastore.AddressRef{combo.LocalPoolAddressRef(), combo.RemotePoolAddressRef()} {
-			key := string(poolRef.Type) + "\x00" + poolRef.Version.String() + "\x00" + poolRef.Qualifier
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-
-			configs = append(configs, tokenscore.TokenExpansionInputPerChain{
-				TokenPoolVersion:      poolRef.Version,
-				SkipOwnershipTransfer: true,
-				DeployTokenInput: &tokenscore.DeployTokenInput{
-					Symbol:        poolRef.Qualifier,
-					Name:          poolRef.Qualifier,
-					Decimals:      DefaultDecimals,
-					Type:          bnm_drip_v1_0.ContractType,
-					ExternalAdmin: chain.DeployerKey.From.Hex(),
-					CCIPAdmin:     chain.DeployerKey.From.Hex(),
-					PreMint:       &preMintTokens,
-				},
-				DeployTokenPoolInput: &tokenscore.DeployTokenPoolInput{
-					PoolType:           string(poolRef.Type),
-					TokenPoolQualifier: poolRef.Qualifier,
-				},
-			})
+		// Only deploy the local pool ref. The remote pool ref belongs to the
+		// counterpart chain and must not be deployed here — deploying it would
+		// attempt to fund a lockbox for an unsupported pool version and fail.
+		poolRef := combo.LocalPoolAddressRef()
+		key := string(poolRef.Type) + "\x00" + poolRef.Version.String() + "\x00" + poolRef.Qualifier
+		if seen[key] {
+			continue
 		}
+		seen[key] = true
+
+		configs = append(configs, tokenscore.TokenExpansionInputPerChain{
+			TokenPoolVersion:      poolRef.Version,
+			SkipOwnershipTransfer: true,
+			DeployTokenInput: &tokenscore.DeployTokenInput{
+				Symbol:        poolRef.Qualifier,
+				Name:          poolRef.Qualifier,
+				Decimals:      DefaultDecimals,
+				Type:          bnm_drip_v1_0.ContractType,
+				ExternalAdmin: chain.DeployerKey.From.Hex(),
+				CCIPAdmin:     chain.DeployerKey.From.Hex(),
+				PreMint:       &preMintTokens,
+			},
+			DeployTokenPoolInput: &tokenscore.DeployTokenPoolInput{
+				PoolType:           string(poolRef.Type),
+				TokenPoolQualifier: poolRef.Qualifier,
+			},
+		})
 	}
 
 	return configs, nil

--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -1193,10 +1193,7 @@ func (m *CCIP17EVMConfig) GetTokenExpansionConfigs(
 
 	// Build a set of supported pool capabilities so we can skip combos where
 	// EVM is the "local" side but doesn't actually support that pool.
-	supported := make(map[string]bool)
-	for _, cap := range m.GetSupportedPools() {
-		supported[cap.PoolType+"\x00"+cap.PoolVersion.String()] = true
-	}
+	supported := devenvcommon.BuildSupportedPoolsMap(m.GetSupportedPools())
 
 	seen := make(map[string]bool)
 	var configs []tokenscore.TokenExpansionInputPerChain
@@ -1211,11 +1208,11 @@ func (m *CCIP17EVMConfig) GetTokenExpansionConfigs(
 		// ComputeTokenCombinations generates combos in both directions, so we
 		// may receive combos where another chain (e.g. Solana) is meant to be
 		// the local side.
-		if !supported[string(poolRef.Type)+"\x00"+poolRef.Version.String()] {
+		if !devenvcommon.IsPoolSupported(supported, poolRef) {
 			continue
 		}
 
-		key := string(poolRef.Type) + "\x00" + poolRef.Version.String() + "\x00" + poolRef.Qualifier
+		key := devenvcommon.AddressRefFullKey(poolRef)
 		if seen[key] {
 			continue
 		}


### PR DESCRIPTION
## Description

This PR fixes bugs in `GetTokenExpansionConfigs` and adds support for cross-version token pool combinations (LockRelease 1.6.1 ↔ BurnMint 2.0.0).

**Bug fixes in EVM's `GetTokenExpansionConfigs`:**

1. **Deploy only local pools**: The function previously iterated both `LocalPoolAddressRef()` and `RemotePoolAddressRef()` for each combo, attempting to deploy both pools on EVM. This is incorrect — the remote pool belongs to the counterpart chain (e.g., Solana) and deploying an unsupported pool type (like LockRelease 1.6.1) would fail during lockbox funding.

2. **Filter by supported pools**: `ComputeTokenCombinations()` generates combos for ALL chains in both directions. Without filtering, EVM would receive combos where another chain is meant to be the "local" side and attempt to deploy pools it doesn't support.

**New token combinations:**

Added two entries to `AllTokenCombinations()` to enable cross-chain transfers between EVM BurnMint 2.0.0 and Solana LockRelease 1.6.1:
- `2.0.0 burn <-> 1.6.1 release` (EVM as local)
- `1.6.1 release <-> 2.0.0 burn` (Solana as local)

**Code quality improvements:**

Extracted common helper functions to `devenvcommon` to reduce duplication between EVM and Solana implementations:
- `PoolCapabilityKey()`, `AddressRefPoolKey()`, `AddressRefFullKey()`
- `BuildSupportedPoolsMap()`, `IsPoolSupported()`
- Uses `::` separator instead of null bytes for readability

## Testing

Tested with chainlink-ccip-solana devenv:
- `make start-devenv` — devenv starts successfully with Solana LockRelease 1.6.1 pools
- `go test -timeout 5m -v -count 1 ./devenv/tests/e2e/... -run TestEVM2Solana` — LockRelease test case passes (EVM BurnMint 2.0.0 → Solana LockRelease 1.6.1)
- `go test -timeout 5m -v -count 1 ./devenv/tests/e2e/... -run TestSolana2EVM` — reverse direction passes

## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date