### PR TITLE
build/devenv: remove fallback, scope lane flag, merge executor phases.

### DIFF
--- a/build/devenv/components/committeeccv/component.go
+++ b/build/devenv/components/committeeccv/component.go
@@ -94,7 +94,10 @@ func (c *component) RunPhase3(
 	}
 	impls, _ := priorOutputs["_impls"].([]cciptestinterfaces.CCIP17Configuration)
 	blockchains, _ := priorOutputs["blockchains"].([]*ctfblockchain.Input)
-	useLegacyConfigureLane, _ := priorOutputs["_use_legacy_configure_lane"].(bool)
+	var useLegacyConfigureLane bool
+	if pcMap, ok := globalConfig["protocol_contracts"].(map[string]any); ok {
+		useLegacyConfigureLane, _ = pcMap["use_legacy_configure_lane"].(bool)
+	}
 
 	// Step 1: Generate HMAC client credentials for all aggregators before launching verifiers.
 	for _, agg := range aggregators {

--- a/build/devenv/components/executor/component.go
+++ b/build/devenv/components/executor/component.go
@@ -48,9 +48,8 @@ func (c *component) ValidateConfig(componentConfig any) error {
 }
 
 // RunPhase3 launches standalone executor containers, registers them with JD,
-// and emits FundingEffect requests for transmitter addresses. Job spec
-// generation and proposal are deferred to Phase 4 because they require
-// deployed contract addresses.
+// emits FundingEffect requests for transmitter addresses, generates job specs,
+// and emits JobProposalEffect for each standalone executor.
 func (c *component) RunPhase3(
 	ctx context.Context,
 	_ map[string]any,
@@ -133,6 +132,57 @@ func (c *component) RunPhase3(
 		}
 	}
 
+	e, ok := priorOutputs["_env"].(*deployment.Environment)
+	if !ok || e == nil {
+		return nil, nil, fmt.Errorf("executor: _env not found in phase outputs")
+	}
+	topology, ok := priorOutputs["_topology"].(*ccvdeployment.EnvironmentTopology)
+	if !ok || topology == nil {
+		return nil, nil, fmt.Errorf("executor: _topology not found in phase outputs")
+	}
+	ds, ok := priorOutputs["_ds"].(datastore.MutableDataStore)
+	if !ok {
+		return nil, nil, fmt.Errorf("executor: _ds not found in phase outputs")
+	}
+
+	jobSpecs, err := buildExecutorJobSpecs(e, executors, topology, ds)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, exec := range executors {
+		if exec == nil || exec.Mode != services.Standalone {
+			continue
+		}
+		if exec.Out == nil || exec.Out.JDNodeID == "" {
+			continue
+		}
+		reg, loaderErr := chainreg.GetRegistry().Get(exec.ChainFamily)
+		if loaderErr != nil {
+			return nil, nil, fmt.Errorf("executor: chain registration for %s: %w", exec.ContainerName, loaderErr)
+		}
+		if reg.ChainConfigLoader == nil {
+			return nil, nil, fmt.Errorf("executor: chain config loader for family %s not found", exec.ChainFamily)
+		}
+		blockchainInfos, loaderErr := reg.ChainConfigLoader(blockchainOutputs)
+		if loaderErr != nil {
+			return nil, nil, fmt.Errorf("executor: loading chain config for %s: %w", exec.ContainerName, loaderErr)
+		}
+		baseSpec, ok := jobSpecs[exec.ContainerName]
+		if !ok {
+			return nil, nil, fmt.Errorf("executor: no job spec found for %s", exec.ContainerName)
+		}
+		jobSpec, specErr := executorsvc.RebuildExecutorJobSpecWithBlockchainInfos(baseSpec, blockchainInfos)
+		if specErr != nil {
+			return nil, nil, fmt.Errorf("executor: building job spec for %s: %w", exec.ContainerName, specErr)
+		}
+		effects = append(effects, devenvruntime.JobProposalEffect{
+			NOPAlias: exec.NOPAlias,
+			NodeID:   exec.Out.JDNodeID,
+			JobSpec:  jobSpec,
+		})
+	}
+
 	return map[string]any{configKey: executors}, effects, nil
 }
 
@@ -174,77 +224,6 @@ func registerWithJD(ctx context.Context, executors []*executorsvc.Input, jdInfra
 		})
 	}
 	return g.Wait()
-}
-
-// RunPhase4 generates executor job specs using deployed contract addresses from
-// Phase 3 and emits JobProposalEffect for each standalone executor.
-func (c *component) RunPhase4(
-	_ context.Context,
-	_ map[string]any,
-	_ any,
-	priorOutputs map[string]any,
-) (map[string]any, []devenvruntime.Effect, error) {
-	executors, ok := priorOutputs[configKey].([]*executorsvc.Input)
-	if !ok || len(executors) == 0 {
-		return map[string]any{}, nil, nil
-	}
-	e, ok := priorOutputs["_env"].(*deployment.Environment)
-	if !ok || e == nil {
-		return nil, nil, fmt.Errorf("executor: _env not found in phase outputs")
-	}
-	topology, ok := priorOutputs["_topology"].(*ccvdeployment.EnvironmentTopology)
-	if !ok || topology == nil {
-		return nil, nil, fmt.Errorf("executor: _topology not found in phase outputs")
-	}
-	ds, ok := priorOutputs["_ds"].(datastore.MutableDataStore)
-	if !ok {
-		return nil, nil, fmt.Errorf("executor: _ds not found in phase outputs")
-	}
-	blockchainOutputs, ok := priorOutputs["blockchainOutputs"].([]*ctfblockchain.Output)
-	if !ok {
-		return nil, nil, fmt.Errorf("executor: blockchainOutputs not found in phase outputs")
-	}
-
-	jobSpecs, err := buildExecutorJobSpecs(e, executors, topology, ds)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var effects []devenvruntime.Effect
-	for _, exec := range executors {
-		if exec == nil || exec.Mode != services.Standalone {
-			continue
-		}
-		if exec.Out == nil || exec.Out.JDNodeID == "" {
-			continue
-		}
-		reg, loaderErr := chainreg.GetRegistry().Get(exec.ChainFamily)
-		if loaderErr != nil {
-			return nil, nil, fmt.Errorf("executor: chain registration for %s: %w", exec.ContainerName, loaderErr)
-		}
-		if reg.ChainConfigLoader == nil {
-			return nil, nil, fmt.Errorf("executor: chain config loader for family %s not found", exec.ChainFamily)
-		}
-		blockchainInfos, loaderErr := reg.ChainConfigLoader(blockchainOutputs)
-		if loaderErr != nil {
-			return nil, nil, fmt.Errorf("executor: loading chain config for %s: %w", exec.ContainerName, loaderErr)
-		}
-		baseSpec, ok := jobSpecs[exec.ContainerName]
-		if !ok {
-			return nil, nil, fmt.Errorf("executor: no job spec found for %s", exec.ContainerName)
-		}
-		jobSpec, specErr := executorsvc.RebuildExecutorJobSpecWithBlockchainInfos(baseSpec, blockchainInfos)
-		if specErr != nil {
-			return nil, nil, fmt.Errorf("executor: building job spec for %s: %w", exec.ContainerName, specErr)
-		}
-		effects = append(effects, devenvruntime.JobProposalEffect{
-			NOPAlias: exec.NOPAlias,
-			NodeID:   exec.Out.JDNodeID,
-			JobSpec:  jobSpec,
-		})
-	}
-
-	return map[string]any{}, effects, nil
 }
 
 type executorJobSpec struct {

--- a/build/devenv/components/protocol_contracts/component.go
+++ b/build/devenv/components/protocol_contracts/component.go
@@ -77,12 +77,6 @@ func (p *component) RunPhase2(
 	if envTopology == nil {
 		return nil, nil, fmt.Errorf("environment_topology is required but not found in config")
 	}
-	var useLegacyConfigureLane bool
-	if m, ok := componentConfig.(map[string]any); ok {
-		if v, ok := m["use_legacy_configure_lane"].(bool); ok {
-			useLegacyConfigureLane = v
-		}
-	}
 	timeTrack := timing.New(p.lggr)
 	ctx = p.lggr.WithContext(ctx)
 
@@ -213,14 +207,13 @@ func (p *component) RunPhase2(
 	}
 
 	return map[string]any{
-		"_cldf":                      cldf,
-		"_env":                       e,
-		"_topology":                  topology,
-		"_selectors":                 selectors,
-		"_ds":                        ds,
-		"_impls":                     impls,
-		"_time_track":                timeTrack,
-		"_use_legacy_configure_lane": useLegacyConfigureLane,
+		"_cldf":       cldf,
+		"_env":        e,
+		"_topology":   topology,
+		"_selectors":  selectors,
+		"_ds":         ds,
+		"_impls":      impls,
+		"_time_track": timeTrack,
 	}, nil, nil
 }
 

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -119,7 +119,7 @@ type Cfg struct {
 	Aggregator         []*services.AggregatorInput    `toml:"aggregator"            validate:"required"`
 	JD                 *jd.Input                      `toml:"jd"                    validate:"required"`
 	Blockchains        []*blockchain.Input            `toml:"blockchains"           validate:"required"`
-	NodeSets           []*ns.Input                    `toml:"nodesets"              validate:"required"`
+	NodeSets           []*ns.Input                    `toml:"nodesets"              validate:"omitempty"`
 	CLNodesFundingETH  float64                        `toml:"cl_nodes_funding_eth"`
 	CLNodesFundingLink float64                        `toml:"cl_nodes_funding_link"`
 	// HighAvailability enables devenv-level service redundancy. When true,

--- a/build/devenv/runtime/environment.go
+++ b/build/devenv/runtime/environment.go
@@ -37,11 +37,11 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 	if effectExecutor == nil {
 		effectExecutor = noopEffectExecutor{}
 	}
-	specific, fallback, err := r.instantiate(nil)
+	specific, err := r.instantiate(nil)
 	if err != nil {
 		return nil, err
 	}
-	if err := r.validate(rawConfig, specific, fallback); err != nil {
+	if err := r.validate(rawConfig, specific); err != nil {
 		return nil, err
 	}
 
@@ -51,23 +51,15 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 			ls.SetLogger(logger)
 		}
 	}
-	if fallback != nil {
-		if ls, ok := fallback.(LogSetter); ok {
-			ls.SetLogger(logger)
-		}
-	}
 
-	// The fallback component receives all config keys not claimed by a specific
-	// registered component, rather than a single top-level key slice.
 	unclaimed := unclaimedKeys(rawConfig, r.factories)
-	if len(unclaimed) > 0 && fallback == nil {
+	if len(unclaimed) > 0 {
 		keys := make([]string, 0, len(unclaimed))
 		for k := range unclaimed {
 			keys = append(keys, k)
 		}
 		// TODO: Make this an error.
-		// logger.Error().Strs("keys", keys).Msg("unclaimed config keys with no fallback component registered")
-		logger.Warn().Strs("keys", keys).Msg("unclaimed config keys with no fallback component registered")
+		logger.Warn().Strs("keys", keys).Msg("unclaimed config keys")
 	}
 	accumulated := map[string]any{}
 
@@ -90,16 +82,6 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 				}
 				phaseEffects = append(phaseEffects, effects...)
 			}
-		}
-		if p1, ok := fallback.(Phase1Component); ok {
-			out, effects, err := p1.RunPhase1(ctx, rawConfig, unclaimed)
-			if err != nil {
-				return nil, fmt.Errorf("phase1 fallback: %w", err)
-			}
-			if err := mergeNoOverwrite(accumulated, out, phase, fallbackOwner); err != nil {
-				return nil, err
-			}
-			phaseEffects = append(phaseEffects, effects...)
 		}
 		if err := effectExecutor.Execute(ctx, phaseEffects, accumulated); err != nil {
 			return nil, fmt.Errorf("phase1 effects: %w", err)
@@ -127,16 +109,6 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 				phaseEffects = append(phaseEffects, effects...)
 			}
 		}
-		if p2, ok := fallback.(Phase2Component); ok {
-			out, effects, err := p2.RunPhase2(ctx, rawConfig, unclaimed, maps.Clone(phaseSnapshot))
-			if err != nil {
-				return nil, fmt.Errorf("phase2 fallback: %w", err)
-			}
-			if err := mergeNoOverwrite(accumulated, out, phase, fallbackOwner); err != nil {
-				return nil, err
-			}
-			phaseEffects = append(phaseEffects, effects...)
-		}
 		if err := effectExecutor.Execute(ctx, phaseEffects, accumulated); err != nil {
 			return nil, fmt.Errorf("phase2 effects: %w", err)
 		}
@@ -162,16 +134,6 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 				}
 				phaseEffects = append(phaseEffects, effects...)
 			}
-		}
-		if p3, ok := fallback.(Phase3Component); ok {
-			out, effects, err := p3.RunPhase3(ctx, rawConfig, unclaimed, maps.Clone(phaseSnapshot))
-			if err != nil {
-				return nil, fmt.Errorf("phase3 fallback: %w", err)
-			}
-			if err := mergeNoOverwrite(accumulated, out, phase, fallbackOwner); err != nil {
-				return nil, err
-			}
-			phaseEffects = append(phaseEffects, effects...)
 		}
 		if err := effectExecutor.Execute(ctx, phaseEffects, accumulated); err != nil {
 			return nil, fmt.Errorf("phase3 effects: %w", err)
@@ -199,16 +161,6 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 				phaseEffects = append(phaseEffects, effects...)
 			}
 		}
-		if p4, ok := fallback.(Phase4Component); ok {
-			out, effects, err := p4.RunPhase4(ctx, rawConfig, unclaimed, maps.Clone(phaseSnapshot))
-			if err != nil {
-				return nil, fmt.Errorf("phase4 fallback: %w", err)
-			}
-			if err := mergeNoOverwrite(accumulated, out, phase, fallbackOwner); err != nil {
-				return nil, err
-			}
-			phaseEffects = append(phaseEffects, effects...)
-		}
 		if err := effectExecutor.Execute(ctx, phaseEffects, accumulated); err != nil {
 			return nil, fmt.Errorf("phase4 effects: %w", err)
 		}
@@ -216,8 +168,6 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 
 	return accumulated, nil
 }
-
-const fallbackOwner = "<fallback>"
 
 // mergeNoOverwrite copies src into dst, returning an error if any key in src
 // already exists in dst. The phase number and owner identify the offending

--- a/build/devenv/runtime/environment_test.go
+++ b/build/devenv/runtime/environment_test.go
@@ -232,37 +232,3 @@ func TestPhase1_OverwriteDetection(t *testing.T) {
 	require.Contains(t, err.Error(), `"B"`)
 	require.Contains(t, err.Error(), `"shared"`)
 }
-
-func TestFallbackHonorsSnapshot(t *testing.T) {
-	specific := newP2Comp(t, map[string]any{"from-specific": 1}, nil)
-
-	var fallbackPrior map[string]any
-	fb := newP2Comp(t, map[string]any{"from-fallback": 2}, func(p map[string]any) { fallbackPrior = p })
-
-	r := devenvruntime.NewRegistry()
-	require.NoError(t, r.Register("Specific", compFactory(specific)))
-	r.SetFallback(compFactory(fb))
-
-	out, err := runEnv(t, r, map[string]any{"Specific": nil, "Other": nil})
-	require.NoError(t, err)
-
-	require.NotContains(t, fallbackPrior, "from-specific",
-		"fallback must see the phase-start snapshot, not the post-Specific state")
-	require.Equal(t, 1, out["from-specific"])
-	require.Equal(t, 2, out["from-fallback"])
-}
-
-func TestFallbackOverwriteDetection(t *testing.T) {
-	specific := newP2Comp(t, map[string]any{"shared": "specific"}, nil)
-	fb := newP2Comp(t, map[string]any{"shared": "fallback"}, nil)
-
-	r := devenvruntime.NewRegistry()
-	require.NoError(t, r.Register("Specific", compFactory(specific)))
-	r.SetFallback(compFactory(fb))
-
-	_, err := runEnv(t, r, map[string]any{"Specific": nil})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "phase 2")
-	require.Contains(t, err.Error(), `"<fallback>"`)
-	require.Contains(t, err.Error(), `"shared"`)
-}

--- a/build/devenv/runtime/registry.go
+++ b/build/devenv/runtime/registry.go
@@ -8,7 +8,6 @@ import (
 // Registry maps top-level config keys to component factories.
 type Registry struct {
 	factories map[string]ComponentFactory
-	fallback  ComponentFactory
 }
 
 // NewRegistry creates an empty Registry.
@@ -26,53 +25,30 @@ func (r *Registry) Register(configKey string, fac ComponentFactory) error {
 	return nil
 }
 
-// SetFallback registers a catch-all factory for config keys not claimed by any registered component.
-// The fallback component receives only unclaimed keys as its componentConfig.
-func (r *Registry) SetFallback(fac ComponentFactory) {
-	r.fallback = fac
-}
-
 // instantiate creates all components for the given raw config.
-// Returns specific components (keyed by config key) and the fallback component (nil if none registered).
-func (r *Registry) instantiate(previousOutput map[string]any) (map[string]Component, Component, error) {
+func (r *Registry) instantiate(previousOutput map[string]any) (map[string]Component, error) {
 	specific := make(map[string]Component, len(r.factories))
 	for key, fac := range r.factories {
 		comp, err := fac(previousOutput)
 		if err != nil {
-			return nil, nil, fmt.Errorf("creating component %q: %w", key, err)
+			return nil, fmt.Errorf("creating component %q: %w", key, err)
 		}
 		specific[key] = comp
 	}
-
-	var fallbackComp Component
-	if r.fallback != nil {
-		comp, err := r.fallback(previousOutput)
-		if err != nil {
-			return nil, nil, fmt.Errorf("creating fallback component: %w", err)
-		}
-		fallbackComp = comp
-	}
-
-	return specific, fallbackComp, nil
+	return specific, nil
 }
 
 // validate calls ValidateConfig on all instantiated components whose
 // top-level config key is present in rawConfig. Components whose key is
 // unset are dormant — neither validated nor phase-executed — so registered
 // components can sit out runs that don't configure them.
-func (r *Registry) validate(rawConfig map[string]any, specific map[string]Component, fallback Component) error {
+func (r *Registry) validate(rawConfig map[string]any, specific map[string]Component) error {
 	for key, comp := range specific {
 		if _, ok := rawConfig[key]; !ok {
 			continue
 		}
 		if err := comp.ValidateConfig(rawConfig[key]); err != nil {
 			return fmt.Errorf("component %q config invalid: %w", key, err)
-		}
-	}
-	if fallback != nil {
-		unclaimed := unclaimedKeys(rawConfig, r.factories)
-		if err := fallback.ValidateConfig(unclaimed); err != nil {
-			return fmt.Errorf("fallback component config invalid: %w", err)
 		}
 	}
 	return nil
@@ -93,11 +69,6 @@ var global = NewRegistry()
 // Register adds a component to the global registry.
 func Register(configKey string, fac ComponentFactory) error {
 	return global.Register(configKey, fac)
-}
-
-// SetFallback sets the fallback component on the global registry.
-func SetFallback(fac ComponentFactory) {
-	global.SetFallback(fac)
 }
 
 // GlobalRegistry returns the package-level registry populated by component init() calls.


### PR DESCRIPTION
# PR Chain
There are multiple open pull requests that feed into each other:

- https://github.com/smartcontractkit/chainlink-ccv/pull/1148
- https://github.com/smartcontractkit/chainlink-ccv/pull/1145
- https://github.com/smartcontractkit/chainlink-ccv/pull/1143
- https://github.com/smartcontractkit/chainlink-ccv/pull/1141
- https://github.com/smartcontractkit/chainlink-ccv/pull/1140
- https://github.com/smartcontractkit/chainlink-ccv/pull/1138
- **this PR** https://github.com/smartcontractkit/chainlink-ccv/pull/1137
- https://github.com/smartcontractkit/chainlink-ccv/pull/1133
- main


<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
Phased devenv cleanup: Four independent follow-up cleanups now that the legacy fallback component has been fully eliminated from the phased devenv runtime.

### Remove `SetFallback` from the runtime registry

  `SetFallback` / `r.fallback` is dead code — nothing registers a
  fallback component any more. This removes the field from `Registry`,
  both `SetFallback` functions (instance + package-level), the
  `fallbackOwner` constant, and all four per-phase fallback execution
  branches in `environment.go`. The two fallback-specific unit tests are
  also deleted.

### Stop routing `use_legacy_configure_lane` through an inter-phase key

  `protocol_contracts` previously read the flag from its component config
  and re-exported it as `"_use_legacy_configure_lane"` so that
  `committeeccv` could consume it one phase later. Now that both
  components share `globalConfig`, `committeeccv` reads the value
  directly from `globalConfig["protocol_contracts"]`. The `protocol_contracts`
  component no longer touches the flag at all. No TOML changes — the
  field stays at `[protocol_contracts].use_legacy_configure_lane`.

### Relax `NodeSets` validation tag

  `Cfg.NodeSets` had `validate:"required"`, which fails for phased
  configs that have no `[[nodeset]]` sections. Changed to
  `validate:"omitempty"`. Monolith configs always pass `env-cl.toml`
  which supplies `NodeSets`, so the monolith path is unaffected.

### Merge executor into a single Phase 3 component

  Executor was split across Phase 3 (launch + JD registration) and Phase
  4 (job spec generation). The split was necessary when
  `protocol_contracts` ran in Phase 3 — job specs needed `_env`,
  `_topology`, and `_ds` which weren't available until Phase 3 completed.
  Now that `protocol_contracts` is Phase 2, all executor dependencies are
  in `priorOutputs` by Phase 3. `RunPhase4` is deleted; its logic is
  folded into `RunPhase3`. CLAUDE.md phase layout updated to reflect the
  current state.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
