### PR TITLE
fix: Increase fee limit to compensate for EIP-150 gas attenuation

### DIFF
--- a/integration/pkg/contracttransmitter/txm_evm_contract_transmitter.go
+++ b/integration/pkg/contracttransmitter/txm_evm_contract_transmitter.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	// Numerator for EIP-150 compensation across two CALL boundaries: 64^2.
-	eip150ForwardingNumerator   = 64 * 64
-	// Denominator for EIP-150 compensation across two CALL boundaries: 63^2.
-	eip150ForwardingDenominator = 63 * 63
+	// Numerator for EIP-150 gas buffer across two CALL boundaries: 64^2 - 63^2.
+	eip150ForwardingBufferNumerator = 64*64 - 63*63
+	// Denominator for EIP-150 gas buffer across two CALL boundaries: 63^2.
+	eip150ForwardingBufferDenominator = 63 * 63
 )
 
 var (
@@ -77,7 +77,8 @@ func (ct *TXMEVMContractTransmitter) ConvertAndWriteMessageToChain(ctx context.C
 		return fmt.Errorf("skipping transmit, error getting round-robin from address: %w", err)
 	}
 	messageID, _ := report.Message.MessageID()
-	feeLimit := eip150ForwardingFeeLimit(report.Message.ExecutionGasLimit)
+	feeLimit := uint64(report.Message.ExecutionGasLimit) +
+		eip150ForwardingGasBuffer(report.Message.CcipReceiveGasLimit)
 
 	// we don't want to use an idempotency key based on messageid in case the CCV Data changes in between resubmissions
 	tx, err := ct.TxmClient.CreateTransaction(ctx, txmgr.TxRequest{
@@ -96,9 +97,10 @@ func (ct *TXMEVMContractTransmitter) ConvertAndWriteMessageToChain(ctx context.C
 	return nil
 }
 
-// eip150ForwardingFeeLimit compensates for EIP-150 gas attenuation across the
-// OffRamp -> Router -> Receiver call path so ccipReceive receives the intended
-// gas limit. It computes ceil(4096/3969 * L) using integer-ceiling arithmetic.
-func eip150ForwardingFeeLimit(executionGasLimit uint32) uint64 {
-	return (uint64(executionGasLimit)*eip150ForwardingNumerator + eip150ForwardingDenominator - 1) / eip150ForwardingDenominator
+// eip150ForwardingGasBuffer returns the extra gas needed to compensate for EIP-150
+// gas attenuation across the OffRamp -> Router -> Receiver call path.
+// It computes ceil(((64^2 - 63^2) / 63^2) * L), where L is the ccipReceive gas limit.
+func eip150ForwardingGasBuffer(ccipReceiveGasLimit uint32) uint64 {
+	return (uint64(ccipReceiveGasLimit)*eip150ForwardingBufferNumerator +
+		eip150ForwardingBufferDenominator - 1) / eip150ForwardingBufferDenominator
 }

--- a/integration/pkg/contracttransmitter/txm_evm_contract_transmitter.go
+++ b/integration/pkg/contracttransmitter/txm_evm_contract_transmitter.go
@@ -20,10 +20,9 @@ import (
 )
 
 const (
-	// Numerator for EIP-150 gas buffer across two CALL boundaries: 64^2 - 63^2.
-	eip150ForwardingBufferNumerator = 64*64 - 63*63
-	// Denominator for EIP-150 gas buffer across two CALL boundaries: 63^2.
-	eip150ForwardingBufferDenominator = 63 * 63
+	// Numerator and Denominator to compensate for EIP-150 forwarding.
+	eip150ForwardingNumerator   = 64
+	eip150ForwardingDenominator = 63
 )
 
 var (
@@ -99,8 +98,15 @@ func (ct *TXMEVMContractTransmitter) ConvertAndWriteMessageToChain(ctx context.C
 
 // eip150ForwardingGasBuffer returns the extra gas needed to compensate for EIP-150
 // gas attenuation across the OffRamp -> Router -> Receiver call path.
-// It computes ceil(((64^2 - 63^2) / 63^2) * L), where L is the ccipReceive gas limit.
+// It computes ceil(64/63 * ceil(64/63 * L)) - L, where L is the ccipReceive gas limit.
 func eip150ForwardingGasBuffer(ccipReceiveGasLimit uint32) uint64 {
-	return (uint64(ccipReceiveGasLimit)*eip150ForwardingBufferNumerator +
-		eip150ForwardingBufferDenominator - 1) / eip150ForwardingBufferDenominator
+	gasLimit := uint64(ccipReceiveGasLimit)
+	// Gas required at Router for Receiver to get L: ceil(64/63 * L)
+	atRouter := (eip150ForwardingNumerator*gasLimit +
+		eip150ForwardingDenominator - 1) / eip150ForwardingDenominator
+	// Gas required at OffRamp for Router to get atRouter: ceil(64/63 * atRouter)
+	atOffRamp := (eip150ForwardingNumerator*atRouter +
+		eip150ForwardingDenominator - 1) / eip150ForwardingDenominator
+	// Buffer is the extra gas on top of L
+	return atOffRamp - gasLimit
 }

--- a/integration/pkg/contracttransmitter/txm_evm_contract_transmitter.go
+++ b/integration/pkg/contracttransmitter/txm_evm_contract_transmitter.go
@@ -19,6 +19,13 @@ import (
 	txmgrcommon "github.com/smartcontractkit/chainlink-framework/chains/txmgr"
 )
 
+const (
+	// Numerator for EIP-150 compensation across two CALL boundaries: 64^2.
+	eip150ForwardingNumerator   = 64 * 64
+	// Denominator for EIP-150 compensation across two CALL boundaries: 63^2.
+	eip150ForwardingDenominator = 63 * 63
+)
+
 var (
 	_          chainaccess.ContractTransmitter = &TXMEVMContractTransmitter{}
 	offrampABI                                 = evmtypes.MustGetABI(offramp.OffRampABI)
@@ -70,13 +77,14 @@ func (ct *TXMEVMContractTransmitter) ConvertAndWriteMessageToChain(ctx context.C
 		return fmt.Errorf("skipping transmit, error getting round-robin from address: %w", err)
 	}
 	messageID, _ := report.Message.MessageID()
+	feeLimit := eip150ForwardingFeeLimit(report.Message.ExecutionGasLimit)
 
 	// we don't want to use an idempotency key based on messageid in case the CCV Data changes in between resubmissions
 	tx, err := ct.TxmClient.CreateTransaction(ctx, txmgr.TxRequest{
 		FromAddress:    roundRobinFromAddress,
 		ToAddress:      ct.OffRampAddress,
 		EncodedPayload: payload,
-		FeeLimit:       uint64(report.Message.ExecutionGasLimit),
+		FeeLimit:       feeLimit,
 		Strategy:       txmgrcommon.NewSendEveryStrategy(),
 	})
 	if err != nil {
@@ -86,4 +94,11 @@ func (ct *TXMEVMContractTransmitter) ConvertAndWriteMessageToChain(ctx context.C
 
 	ct.lggr.Infow("submitted tx to txm", "messageID", messageID, "txm key", tx.IdempotencyKey)
 	return nil
+}
+
+// eip150ForwardingFeeLimit compensates for EIP-150 gas attenuation across the
+// OffRamp -> Router -> Receiver call path so ccipReceive receives the intended
+// gas limit. It computes ceil(4096/3969 * L) using integer-ceiling arithmetic.
+func eip150ForwardingFeeLimit(executionGasLimit uint32) uint64 {
+	return (uint64(executionGasLimit)*eip150ForwardingNumerator + eip150ForwardingDenominator - 1) / eip150ForwardingDenominator
 }

--- a/integration/pkg/contracttransmitter/txm_evm_contract_transmitter_test.go
+++ b/integration/pkg/contracttransmitter/txm_evm_contract_transmitter_test.go
@@ -399,11 +399,11 @@ func TestEIP150ForwardingGasBuffer(t *testing.T) {
 			gasLimit := uint64(tc.ccipReceiveGasLimit)
 			buffer := eip150ForwardingGasBuffer(tc.ccipReceiveGasLimit)
 
-			// Min gas received after an EIP-150 CALL boundary
-			eip150MinCallGas := func(gas uint64) uint64 { return gas - gas/64 }
+			// Gas received after an EIP-150 CALL boundary
+			eip150ForwardedGas := func(gas uint64) uint64 { return gas - gas/64 }
 
-			assert.GreaterOrEqual(t, eip150MinCallGas(eip150MinCallGas(gasLimit+buffer)), gasLimit, "buffer too small")
-			assert.LessOrEqual(t, eip150MinCallGas(eip150MinCallGas(gasLimit+buffer)), gasLimit+2, "buffer larger than necessary")
+			assert.GreaterOrEqual(t, eip150ForwardedGas(eip150ForwardedGas(gasLimit+buffer)), gasLimit, "buffer too small")
+			assert.LessOrEqual(t, eip150ForwardedGas(eip150ForwardedGas(gasLimit+buffer)), gasLimit+2, "buffer larger than necessary")
 		})
 	}
 }

--- a/integration/pkg/contracttransmitter/txm_evm_contract_transmitter_test.go
+++ b/integration/pkg/contracttransmitter/txm_evm_contract_transmitter_test.go
@@ -64,7 +64,7 @@ func TestTXMEVMContractTransmitter_ConvertAndWriteMessageToChain(t *testing.T) {
 					[]byte("ccv_data_1"),
 					[]byte("ccv_data_2"),
 				},
-				Message: mustCreateMessage(t, 1, 2, 100, 1000000),
+				Message: mustCreateMessage(t, 1, 2, 100, 2000000, 1000000),
 			},
 			setupMocks: func(txm *mockTxManager, rr *mockRoundRobin) {
 				fromAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
@@ -76,7 +76,8 @@ func TestTXMEVMContractTransmitter_ConvertAndWriteMessageToChain(t *testing.T) {
 
 				txm.On("CreateTransaction", mock.Anything, mock.MatchedBy(func(req txmgr.TxRequest) bool {
 					return req.FromAddress == fromAddr &&
-						req.FeeLimit == uint64(1000000) &&
+						req.FeeLimit == uint64(2000000)+
+							eip150ForwardingGasBuffer(1000000) &&
 						len(req.EncodedPayload) > 0
 				})).Return(expectedTx, nil)
 			},
@@ -103,7 +104,7 @@ func TestTXMEVMContractTransmitter_ConvertAndWriteMessageToChain(t *testing.T) {
 				CCVData: [][]byte{
 					[]byte("ccv_data_1"),
 				},
-				Message: mustCreateMessage(t, 1, 2, 100, 1000000),
+				Message: mustCreateMessage(t, 1, 2, 100, 1000000, 1000000),
 			},
 			setupMocks: func(txm *mockTxManager, rr *mockRoundRobin) {
 				rr.On("GetNextAddress", mock.Anything, mock.Anything).Return(common.Address{}, errors.New("no available keys"))
@@ -119,7 +120,7 @@ func TestTXMEVMContractTransmitter_ConvertAndWriteMessageToChain(t *testing.T) {
 				CCVData: [][]byte{
 					[]byte("ccv_data_1"),
 				},
-				Message: mustCreateMessage(t, 1, 2, 100, 1000000),
+				Message: mustCreateMessage(t, 1, 2, 100, 1000000, 1000000),
 			},
 			setupMocks: func(txm *mockTxManager, rr *mockRoundRobin) {
 				fromAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
@@ -137,7 +138,7 @@ func TestTXMEVMContractTransmitter_ConvertAndWriteMessageToChain(t *testing.T) {
 			report: protocol.AbstractAggregatedReport{
 				CCVS:    []protocol.UnknownAddress{},
 				CCVData: [][]byte{},
-				Message: mustCreateMessage(t, 1, 2, 100, 1000000),
+				Message: mustCreateMessage(t, 1, 2, 100, 1000000, 1000000),
 			},
 			setupMocks: func(txm *mockTxManager, rr *mockRoundRobin) {
 				fromAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
@@ -149,7 +150,7 @@ func TestTXMEVMContractTransmitter_ConvertAndWriteMessageToChain(t *testing.T) {
 
 				txm.On("CreateTransaction", mock.Anything, mock.MatchedBy(func(req txmgr.TxRequest) bool {
 					return req.FromAddress == fromAddr &&
-						req.FeeLimit == uint64(1000000) &&
+						req.FeeLimit == uint64(1000000)+eip150ForwardingGasBuffer(1000000) &&
 						len(req.EncodedPayload) > 0
 				})).Return(expectedTx, nil)
 			},
@@ -168,7 +169,7 @@ func TestTXMEVMContractTransmitter_ConvertAndWriteMessageToChain(t *testing.T) {
 					[]byte("ccv_data_2"),
 					[]byte("ccv_data_3"),
 				},
-				Message: mustCreateMessage(t, 1, 2, 100, 5000000),
+				Message: mustCreateMessage(t, 1, 2, 100, 5000000, 5000000),
 			},
 			setupMocks: func(txm *mockTxManager, rr *mockRoundRobin) {
 				fromAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
@@ -180,7 +181,7 @@ func TestTXMEVMContractTransmitter_ConvertAndWriteMessageToChain(t *testing.T) {
 
 				txm.On("CreateTransaction", mock.Anything, mock.MatchedBy(func(req txmgr.TxRequest) bool {
 					return req.FromAddress == fromAddr &&
-						req.FeeLimit == uint64(5000000) &&
+						req.FeeLimit == uint64(5000000)+eip150ForwardingGasBuffer(5000000) &&
 						len(req.EncodedPayload) > 0
 				})).Return(expectedTx, nil)
 			},
@@ -313,7 +314,7 @@ func TestTXMEVMContractTransmitter_ABIEncoding(t *testing.T) {
 				CCVData: [][]byte{
 					[]byte("test_data"),
 				},
-				Message: mustCreateMessage(t, 1, 2, 100, 1000000),
+				Message: mustCreateMessage(t, 1, 2, 100, 1000000, 1000000),
 			},
 			validateError: func(t *testing.T, err error) {
 				assert.NoError(t, err)
@@ -378,7 +379,7 @@ func TestTXMEVMContractTransmitter_ABIEncoding(t *testing.T) {
 }
 
 // mustCreateMessage creates a test message or fails the test.
-func mustCreateMessage(t *testing.T, sourceChain, destChain, nonce uint64, gasLimit uint32) protocol.Message {
+func mustCreateMessage(t *testing.T, sourceChain, destChain, nonce uint64, executionGasLimit, ccipReceiveGasLimit uint32) protocol.Message {
 	msg, err := protocol.NewMessage(
 		protocol.ChainSelector(sourceChain),
 		protocol.ChainSelector(destChain),
@@ -386,8 +387,8 @@ func mustCreateMessage(t *testing.T, sourceChain, destChain, nonce uint64, gasLi
 		protocol.UnknownAddress(common.HexToAddress("0x1111111111111111111111111111111111111111").Bytes()),
 		protocol.UnknownAddress(common.HexToAddress("0x2222222222222222222222222222222222222222").Bytes()),
 		1,
-		gasLimit,
-		gasLimit,           // ccipReceiveGasLimit
+		executionGasLimit,
+		ccipReceiveGasLimit,
 		protocol.Bytes32{}, // ccvAndExecutorHash
 		protocol.UnknownAddress(common.HexToAddress("0x3333333333333333333333333333333333333333").Bytes()),
 		protocol.UnknownAddress(common.HexToAddress("0x4444444444444444444444444444444444444444").Bytes()),

--- a/integration/pkg/contracttransmitter/txm_evm_contract_transmitter_test.go
+++ b/integration/pkg/contracttransmitter/txm_evm_contract_transmitter_test.go
@@ -3,6 +3,7 @@ package contracttransmitter
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -374,6 +375,35 @@ func TestTXMEVMContractTransmitter_ABIEncoding(t *testing.T) {
 				// Compare the payloads for byte-level equality
 				assert.Equal(t, expectedPayload, capturedPayload)
 			}
+		})
+	}
+}
+
+func TestEIP150ForwardingGasBuffer(t *testing.T) {
+	testCases := []struct {
+		name                string
+		ccipReceiveGasLimit uint32
+	}{
+		{name: "zero", ccipReceiveGasLimit: 0},
+		{name: "one", ccipReceiveGasLimit: 1},
+		{name: "one below denominator boundary", ccipReceiveGasLimit: eip150ForwardingDenominator - 1},
+		{name: "exact denominator boundary", ccipReceiveGasLimit: eip150ForwardingDenominator},
+		{name: "exact numerator boundary", ccipReceiveGasLimit: eip150ForwardingNumerator},
+		{name: "typical gas limit", ccipReceiveGasLimit: 200000},
+		{name: "large gas limit", ccipReceiveGasLimit: 5000000},
+		{name: "max uint32", ccipReceiveGasLimit: math.MaxUint32},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gasLimit := uint64(tc.ccipReceiveGasLimit)
+			buffer := eip150ForwardingGasBuffer(tc.ccipReceiveGasLimit)
+
+			// Min gas received after an EIP-150 CALL boundary
+			eip150MinCallGas := func(gas uint64) uint64 { return gas - gas/64 }
+
+			assert.GreaterOrEqual(t, eip150MinCallGas(eip150MinCallGas(gasLimit+buffer)), gasLimit, "buffer too small")
+			assert.LessOrEqual(t, eip150MinCallGas(eip150MinCallGas(gasLimit+buffer)), gasLimit+2, "buffer larger than necessary")
 		})
 	}
 }


### PR DESCRIPTION
## Description

The `executionGasLimit` is currently used as the destination transaction fee limit. However, it does not account for EIP-150 forwarding at most ~63/64 gas with each external call. 

This PR compensates for this attenuation by adding a buffer ($`\left\lceil{\frac{64}{63} \left\lceil{\frac{64}{63}L}\right\rceil}\right\rceil - L`$, where $`L`$ is the `ccipReceiveGasLimit`) to account for the two external calls made by the OffRamp (Router -> Receiver).

## Testing

- Updated contract transmitter tests to verify fee limit includes this new buffer
- Added coverage where `executionGasLimit` and `ccipReceiveGasLimit` differ