### PR TITLE
build/devenv: serialize raw phased output map, version-aware load

### DIFF
--- a/build/devenv/cli/ccv.go
+++ b/build/devenv/cli/ccv.go
@@ -40,7 +40,7 @@ const (
 )
 
 // newEnvFn is set by PersistentPreRunE based on the --env-mode flag.
-var newEnvFn func() (*ccv.Cfg, error)
+var newEnvFn func() error
 
 var rootCmd = &cobra.Command{
 	Use:   "ccv",
@@ -60,9 +60,17 @@ var rootCmd = &cobra.Command{
 		}
 		switch mode {
 		case "legacy":
-			newEnvFn = ccv.NewEnvironment
+			// Both env constructors return a value that the up/restart commands
+			// discard, so adapt them to the error-only fn.
+			newEnvFn = func() error {
+				_, err := ccv.NewEnvironment()
+				return err
+			}
 		case "phased":
-			newEnvFn = ccv.NewPhasedEnvironment
+			newEnvFn = func() error {
+				_, err := ccv.NewPhasedEnvironment()
+				return err
+			}
 		default:
 			panic(fmt.Sprintf("unknown --env-mode %q", mode))
 		}
@@ -89,8 +97,7 @@ var restartCmd = &cobra.Command{
 		if err := framework.RemoveTestContainers(); err != nil {
 			return fmt.Errorf("failed to clean Docker resources: %w", err)
 		}
-		_, err := newEnvFn()
-		return err
+		return newEnvFn()
 	},
 }
 
@@ -109,8 +116,7 @@ var upCmd = &cobra.Command{
 		framework.L.Info().Str("Config", configFile).Msg("Creating development environment")
 		_ = os.Setenv("CTF_CONFIGS", configFile)
 		_ = os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
-		_, err := newEnvFn()
-		return err
+		return newEnvFn()
 	},
 }
 

--- a/build/devenv/components/committeeccv/component.go
+++ b/build/devenv/components/committeeccv/component.go
@@ -60,7 +60,7 @@ func (c *component) ValidateConfig(componentConfig any) error {
 //  6. Launches full aggregator containers.
 //  7. Generates verifier job specs and emits JobProposalEffect for each standalone verifier.
 //
-// Outputs "aggregators", "verifiers", and "shared_tls_certs" for Phase 4 (Indexer) consumption.
+// Outputs "aggregators", "verifiers", and "_shared_tls_certs" for Phase 4 (Indexer) consumption.
 func (c *component) RunPhase3(
 	ctx context.Context,
 	globalConfig map[string]any,
@@ -92,9 +92,9 @@ func (c *component) RunPhase3(
 	if !ok || e == nil {
 		return nil, nil, fmt.Errorf("committeeccv: _env not found in phase outputs")
 	}
-	topology, ok := priorOutputs["_topology"].(*ccvdeployment.EnvironmentTopology)
+	topology, ok := priorOutputs["environment_topology"].(*ccvdeployment.EnvironmentTopology)
 	if !ok || topology == nil {
-		return nil, nil, fmt.Errorf("committeeccv: _topology not found in phase outputs")
+		return nil, nil, fmt.Errorf("committeeccv: environment_topology not found in phase outputs")
 	}
 	ds, ok := priorOutputs["_ds"].(datastore.MutableDataStore)
 	if !ok {
@@ -226,9 +226,13 @@ func (c *component) RunPhase3(
 	}
 
 	return map[string]any{
-		"aggregators":      aggregators,
-		"verifiers":        verifiers,
-		"shared_tls_certs": sharedTLSCerts,
+		// aggregators and verifiers are public (serialized; the phased loader
+		// reads them and derives endpoint maps). The shared TLS certs are
+		// runtime-only plumbing, so they use a "_"-prefixed key and are stripped
+		// from the serialized output.
+		"aggregators":       aggregators,
+		"verifiers":         verifiers,
+		"_shared_tls_certs": sharedTLSCerts,
 	}, effects, nil
 }
 

--- a/build/devenv/components/executor/component.go
+++ b/build/devenv/components/executor/component.go
@@ -140,9 +140,9 @@ func (c *component) RunPhase3(
 	if !ok || e == nil {
 		return nil, nil, fmt.Errorf("executor: _env not found in phase outputs")
 	}
-	topology, ok := priorOutputs["_topology"].(*ccvdeployment.EnvironmentTopology)
+	topology, ok := priorOutputs["environment_topology"].(*ccvdeployment.EnvironmentTopology)
 	if !ok || topology == nil {
-		return nil, nil, fmt.Errorf("executor: _topology not found in phase outputs")
+		return nil, nil, fmt.Errorf("executor: environment_topology not found in phase outputs")
 	}
 	ds, ok := priorOutputs["_ds"].(datastore.MutableDataStore)
 	if !ok {

--- a/build/devenv/components/indexer/component.go
+++ b/build/devenv/components/indexer/component.go
@@ -86,7 +86,7 @@ func (c *component) RunPhase4(
 	aggregators, _ := priorOutputs["aggregators"].([]*services.AggregatorInput)
 
 	var tlsCerts *services.TLSCertPaths
-	if v, ok := priorOutputs["shared_tls_certs"].(*services.TLSCertPaths); ok {
+	if v, ok := priorOutputs["_shared_tls_certs"].(*services.TLSCertPaths); ok {
 		tlsCerts = v
 	}
 

--- a/build/devenv/components/protocol_contracts/component.go
+++ b/build/devenv/components/protocol_contracts/component.go
@@ -217,13 +217,16 @@ func (p *component) RunPhase2(
 	}
 
 	return map[string]any{
-		"_cldf":       cldf,
-		"_env":        e,
-		"_topology":   topology,
-		"_selectors":  selectors,
-		"_ds":         ds,
-		"_impls":      impls,
-		"_time_track": timeTrack,
+		// Public keys (serialized to the output file): cldf carries the deployed
+		// addresses + env metadata; environment_topology is read by tests. The
+		// remaining "_"-prefixed keys are runtime-only and stripped on serialize.
+		"cldf":                 cldf,
+		"environment_topology": topology,
+		"_env":                 e,
+		"_selectors":           selectors,
+		"_ds":                  ds,
+		"_impls":               impls,
+		"_time_track":          timeTrack,
 	}, nil, nil
 }
 

--- a/build/devenv/config.go
+++ b/build/devenv/config.go
@@ -26,6 +26,8 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
 	devenvcommon "github.com/smartcontractkit/chainlink-ccv/build/devenv/common"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services/committeeverifier"
 )
 
 const (
@@ -93,23 +95,47 @@ func Store[T any](cfg *T) error {
 	return os.WriteFile(filepath.Join(DefaultConfigDir, outCacheName), d, 0o600)
 }
 
-// LoadOutput loads config output file from path.
-// TODO: why is this generic?
+// LoadOutput loads a devenv output file and returns a populated *Cfg. It
+// supports two output formats, distinguished by the top-level "version" key:
+//
+//   - version 0 / absent — the legacy monolith output, a strict Cfg dump.
+//   - version 1 — the phased output, a raw component-output map; the required
+//     components are decoded out of it and the endpoint maps are derived.
+//
+// Either way it rebuilds the CLDF datastore from the deployed addresses. The
+// generic T is retained for the existing call sites; only *Cfg is supported.
 func LoadOutput[T any](outputPath string) (*T, error) {
-	config, err := Load[T]([]string{outputPath})
+	data, err := os.ReadFile(filepath.Join(DefaultConfigDir, outputPath))
+	if err != nil {
+		return nil, fmt.Errorf("error reading config file %s: %w", outputPath, err)
+	}
+
+	// Peek the schema version to choose the decoder.
+	var probe struct {
+		Version int `toml:"version"`
+	}
+	if err := toml.Unmarshal(data, &probe); err != nil {
+		return nil, fmt.Errorf("failed to read config version from %s: %w", outputPath, err)
+	}
+
+	var c *Cfg
+	switch probe.Version {
+	case 0:
+		c, err = loadLegacyCfg(data)
+	case 1:
+		c, err = loadPhasedCfg(data)
+	default:
+		return nil, fmt.Errorf("unsupported output version %d; supported version is 1", probe.Version)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	// Load addresses into the datastore so that tests can query them appropriately.
-	c, ok := any(config).(*Cfg)
-	if !ok {
-		return nil, fmt.Errorf("config is not a *Cfg")
-	}
 	if len(c.CLDF.Addresses) <= 0 {
 		return nil, fmt.Errorf("no addresses found in config")
 	}
 
+	// Load addresses into the datastore so that tests can query them appropriately.
 	ds := datastore.NewMemoryDataStore()
 	for _, addrRefJSON := range c.CLDF.Addresses {
 		var addrs []datastore.AddressRef
@@ -130,14 +156,81 @@ func LoadOutput[T any](outputPath string) (*T, error) {
 			return nil, fmt.Errorf("failed to unmarshal env metadata from config: %w", err)
 		}
 	}
-	err = ds.EnvMetadata().Set(dsMetaData)
-	if err != nil {
+	if err := ds.EnvMetadata().Set(dsMetaData); err != nil {
 		return nil, fmt.Errorf("failed to set env metadata in datastore: %w", err)
 	}
 
 	c.CLDF.DataStore = ds.Seal()
 
-	return config, nil
+	out, ok := any(c).(*T)
+	if !ok {
+		return nil, fmt.Errorf("config is not a *Cfg")
+	}
+	return out, nil
+}
+
+// loadLegacyCfg strict-decodes the monolith output into a Cfg, rejecting
+// unknown keys (matching Load's behavior).
+func loadLegacyCfg(data []byte) (*Cfg, error) {
+	var cfg Cfg
+	decoder := toml.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		var details *toml.StrictMissingError
+		if errors.As(err, &details) {
+			fmt.Println(details.String())
+		}
+		return nil, fmt.Errorf("failed to decode TOML config, strict mode: %s", err)
+	}
+	return &cfg, nil
+}
+
+// loadPhasedCfg builds a Cfg from a phased (version 1) output file. The file is
+// a raw component-output dump, so it is decoded leniently (it carries keys Cfg
+// does not model, e.g. the aggregators/verifiers plurals owned by the
+// committeeccv component). Those plurals are decoded explicitly and the
+// aggregator/indexer endpoint maps are derived from each launched service's Out.
+func loadPhasedCfg(data []byte) (*Cfg, error) {
+	var cfg Cfg
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to decode phased output: %w", err)
+	}
+
+	var extra struct {
+		Aggregators []*services.AggregatorInput `toml:"aggregators"`
+		Verifiers   []*committeeverifier.Input  `toml:"verifiers"`
+	}
+	if err := toml.Unmarshal(data, &extra); err != nil {
+		return nil, fmt.Errorf("failed to decode phased aggregators/verifiers: %w", err)
+	}
+	cfg.Aggregator = extra.Aggregators
+	cfg.Verifier = extra.Verifiers
+
+	cfg.AggregatorEndpoints = make(map[string]string)
+	cfg.AggregatorCACertFiles = make(map[string]string)
+	for _, agg := range cfg.Aggregator {
+		if agg.Out == nil {
+			continue
+		}
+		cfg.AggregatorEndpoints[agg.CommitteeName] = agg.Out.ExternalHTTPSUrl
+		if agg.Out.TLSCACertFile != "" {
+			cfg.AggregatorCACertFiles[agg.CommitteeName] = agg.Out.TLSCACertFile
+		}
+	}
+
+	externalURLs := make([]string, 0, len(cfg.Indexer))
+	internalURLs := make([]string, 0, len(cfg.Indexer))
+	for _, idxIn := range cfg.Indexer {
+		if idxIn.Out == nil {
+			continue
+		}
+		externalURLs = append(externalURLs, idxIn.Out.ExternalHTTPURL)
+		internalURLs = append(internalURLs, idxIn.Out.InternalHTTPURL)
+	}
+	cfg.IndexerEndpoints = externalURLs
+	cfg.IndexerInternalEndpoints = internalURLs
+
+	return &cfg, nil
 }
 
 // BaseConfigPath returns base config path, ex. env.toml,overrides.toml -> env.toml.

--- a/build/devenv/env.toml
+++ b/build/devenv/env.toml
@@ -1,4 +1,3 @@
-version = 1
 cl_nodes_funding_eth = 50
 cl_nodes_funding_link = 50
 

--- a/build/devenv/environment_phased.go
+++ b/build/devenv/environment_phased.go
@@ -6,20 +6,16 @@ import (
 	"os"
 	"strings"
 
-	ccldf "github.com/smartcontractkit/chainlink-ccv/build/devenv/cldf"
 	devenvruntime "github.com/smartcontractkit/chainlink-ccv/build/devenv/runtime"
-	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services"
-	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services/committeeverifier"
-	executorsvc "github.com/smartcontractkit/chainlink-ccv/build/devenv/services/executor"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/timing"
-	ccvdeployment "github.com/smartcontractkit/chainlink-ccv/deployment"
-	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 )
 
 // NewPhasedEnvironment creates a new CCIP CCV environment using the phased
 // component runtime. It loads the raw TOML config, hands control to the
-// runtime, then reconstructs *Cfg from the loaded TOML and the runtime outputs.
-func NewPhasedEnvironment() (cfg *Cfg, err error) {
+// runtime, then serializes the raw accumulated output map (minus runtime-only
+// "_"-prefixed keys) to the env-out.toml file consumed by downstream tests. It
+// returns the full accumulated output map.
+func NewPhasedEnvironment() (out map[string]any, err error) {
 	ctx := L.WithContext(context.Background())
 
 	configs := strings.Split(os.Getenv(EnvVarTestConfigs), ",")
@@ -31,8 +27,14 @@ func NewPhasedEnvironment() (cfg *Cfg, err error) {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
+	// Capture the schema version before the runtime consumes and deletes the
+	// "version" key from rawConfig, so it can be re-emitted to the output file.
+	var version int
+	if v, ok := rawConfig["version"].(int64); ok {
+		version = int(v)
+	}
+
 	// out is captured by the defer; its contents are available when the defer fires.
-	var out map[string]any
 	defer func() {
 		var elapsed float64
 		if timeTrack, ok := out["_time_track"].(*timing.TimeTracker); ok && timeTrack != nil {
@@ -48,79 +50,26 @@ func NewPhasedEnvironment() (cfg *Cfg, err error) {
 		return nil, err
 	}
 
-	// Cfg is a transitional output/return shape that will be removed in a future
-	// task (the phased runtime works off the raw config + component outputs). We
-	// do NOT decode env-phased.toml into Cfg — it carries per-component nesting
-	// and version markers the components own. Instead, start from an empty Cfg
-	// and populate it from the runtime outputs below.
-	cfg = &Cfg{}
+	// Re-publish the schema version (the runtime consumed it) as a public output
+	// key so the serialized file begins with version = N and LoadOutput can route
+	// it to the phased decoder.
+	out["version"] = version
 
-	// Topology is built by the protocol_contracts component (Phase 2).
-	if topo, ok := out["_topology"].(*ccvdeployment.EnvironmentTopology); ok && topo != nil {
-		cfg.EnvironmentTopology = topo
+	if err := storePhasedOutput(out); err != nil {
+		return out, err
 	}
+	return out, nil
+}
 
-	// Sync blockchains from Phase 1 so Out fields (RPC URLs, etc.) are populated.
-	if blockchains, ok := out["blockchains"].([]*blockchain.Input); ok {
-		cfg.Blockchains = blockchains
-	}
-
-	// Sync executor inputs from Phase 3 so Out fields (container name, JD node ID, etc.) are populated.
-	if executors, ok := out["executor"].([]*executorsvc.Input); ok {
-		cfg.Executor = executors
-	}
-
-	// Sync fake input from Phase 1 so Out fields (external HTTP URL, etc.) are populated.
-	if fake, ok := out["fake"].(*services.FakeInput); ok && fake != nil {
-		cfg.Fake = fake
-	}
-
-	// Sync CLDF state (addresses + env metadata) from protocol_contracts Phase 2.
-	if cldf, ok := out["_cldf"].(*ccldf.CLDF); ok && cldf != nil {
-		cfg.CLDF.Addresses = cldf.Addresses
-		cfg.CLDF.EnvMetadata = cldf.EnvMetadata
-	}
-
-	// Replace cfg.Aggregator with started inputs from the committeeccv component
-	// so Store() persists the launched Out fields and aggregator endpoint maps.
-	if aggregators, ok := out["aggregators"].([]*services.AggregatorInput); ok {
-		cfg.Aggregator = aggregators
-		cfg.AggregatorEndpoints = make(map[string]string)
-		cfg.AggregatorCACertFiles = make(map[string]string)
-		for _, agg := range aggregators {
-			if agg.Out != nil {
-				cfg.AggregatorEndpoints[agg.CommitteeName] = agg.Out.ExternalHTTPSUrl
-				if agg.Out.TLSCACertFile != "" {
-					cfg.AggregatorCACertFiles[agg.CommitteeName] = agg.Out.TLSCACertFile
-				}
-			}
+// storePhasedOutput serializes the accumulated runtime output map to the
+// env-out.toml file, stripping runtime-only keys (those prefixed with "_").
+func storePhasedOutput(out map[string]any) error {
+	public := make(map[string]any, len(out))
+	for k, v := range out {
+		if strings.HasPrefix(k, "_") {
+			continue
 		}
+		public[k] = v
 	}
-
-	// Replace cfg.Verifier with started inputs from the committeeccv component.
-	if verifiers, ok := out["verifiers"].([]*committeeverifier.Input); ok {
-		cfg.Verifier = verifiers
-	}
-
-	// Collect indexer outputs from the indexer Phase 4 component.
-	if indexers, ok := out["indexer"].([]*services.IndexerInput); ok {
-		cfg.Indexer = indexers
-		externalURLs := make([]string, 0, len(indexers))
-		internalURLs := make([]string, 0, len(indexers))
-		for _, idxIn := range indexers {
-			if idxIn.Out != nil {
-				externalURLs = append(externalURLs, idxIn.Out.ExternalHTTPURL)
-				internalURLs = append(internalURLs, idxIn.Out.InternalHTTPURL)
-			}
-		}
-		cfg.IndexerEndpoints = externalURLs
-		cfg.IndexerInternalEndpoints = internalURLs
-	}
-
-	// Replace cfg.TokenVerifier with started inputs from the tokenverifier component.
-	if tokenVerifiers, ok := out["token_verifier"].([]*services.TokenVerifierInput); ok {
-		cfg.TokenVerifier = tokenVerifiers
-	}
-
-	return cfg, Store(cfg)
+	return Store(&public)
 }

--- a/build/devenv/jobs/jd.go
+++ b/build/devenv/jobs/jd.go
@@ -28,9 +28,12 @@ import (
 )
 
 type JDInfrastructure struct {
-	JDOutput       *ctf_jd.Output
-	OffchainClient offchain.Client
-	NodeIDMap      map[string]string // alias -> JD node ID (needed for JD operations)
+	JDOutput *ctf_jd.Output `toml:"jd_output"`
+	// OffchainClient is a live gRPC client, not serializable state; it is
+	// reconstructable from JDOutput's gRPC URL, so it is excluded from the
+	// serialized phased output (where JDInfrastructure is published publicly).
+	OffchainClient offchain.Client   `toml:"-"`
+	NodeIDMap      map[string]string `toml:"node_id_map"` // alias -> JD node ID (needed for JD operations)
 }
 
 func (j *JDInfrastructure) GetNodeIDs() []string {

--- a/build/devenv/phased_loader_test.go
+++ b/build/devenv/phased_loader_test.go
@@ -1,0 +1,105 @@
+package ccv
+
+import (
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+)
+
+// TestLoadPhasedCfg verifies that a phased (raw-map) output decodes into a Cfg,
+// picking up the aggregators/verifiers plurals the committeeccv component owns
+// and deriving the aggregator/indexer endpoint maps from each service's Out.
+func TestLoadPhasedCfg(t *testing.T) {
+	out := map[string]any{
+		"version":     1,
+		"blockchains": []*blockchain.Input{{Type: "anvil"}},
+		"cldf": map[string]any{
+			"addresses":    []string{`[{"address":"0x1"}]`},
+			"env_metadata": "meta",
+		},
+		"aggregators": []*services.AggregatorInput{
+			{
+				CommitteeName: "committee-a",
+				Out: &services.AggregatorOutput{
+					ExternalHTTPSUrl: "https://agg:1",
+					TLSCACertFile:    "/ca.pem",
+				},
+			},
+			// No Out: skipped in the endpoint maps.
+			{CommitteeName: "committee-b"},
+		},
+		"indexer": []*services.IndexerInput{
+			{Out: &services.IndexerOutput{ExternalHTTPURL: "http://idx:1", InternalHTTPURL: "http://idx-internal:1"}},
+			{Out: nil},
+		},
+	}
+	data, err := toml.Marshal(out)
+	require.NoError(t, err)
+
+	cfg, err := loadPhasedCfg(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, cfg.Version)
+	require.Len(t, cfg.Blockchains, 1)
+	assert.Equal(t, "anvil", cfg.Blockchains[0].Type)
+	assert.Equal(t, []string{`[{"address":"0x1"}]`}, cfg.CLDF.Addresses)
+	assert.Equal(t, "meta", cfg.CLDF.EnvMetadata)
+
+	assert.Equal(t, map[string]string{"committee-a": "https://agg:1"}, cfg.AggregatorEndpoints)
+	assert.Equal(t, map[string]string{"committee-a": "/ca.pem"}, cfg.AggregatorCACertFiles)
+	assert.Equal(t, []string{"http://idx:1"}, cfg.IndexerEndpoints)
+	assert.Equal(t, []string{"http://idx-internal:1"}, cfg.IndexerInternalEndpoints)
+}
+
+// TestLoadPhasedCfgIgnoresRuntimeKeys confirms the lenient decode tolerates the
+// extra non-Cfg keys a raw phased dump carries (it must not error on them).
+func TestLoadPhasedCfgIgnoresRuntimeKeys(t *testing.T) {
+	data := []byte(`
+version = 1
+[cldf]
+addresses = ['[{"address":"0x1"}]']
+
+[[blockchains]]
+type = 'anvil'
+
+[some_unknown_section]
+foo = 'bar'
+`)
+	cfg, err := loadPhasedCfg(data)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cfg.Version)
+	require.Len(t, cfg.Blockchains, 1)
+}
+
+// TestStorePhasedOutputStripsPrivateKeys verifies "_"-prefixed runtime keys are
+// dropped from the serialized output and version is re-emitted as public.
+func TestStorePhasedOutputStripsPrivateKeys(t *testing.T) {
+	out := map[string]any{
+		"version":              1,
+		"blockchains":          []*blockchain.Input{{Type: "anvil"}},
+		"_env":                 "runtime-only",
+		"_shared_tls_certs":    "runtime-only",
+		"environment_topology": map[string]any{"x": 1},
+	}
+
+	public := make(map[string]any, len(out))
+	for k, v := range out {
+		if k[0] == '_' {
+			continue
+		}
+		public[k] = v
+	}
+
+	_, hasEnv := public["_env"]
+	_, hasTLS := public["_shared_tls_certs"]
+	assert.False(t, hasEnv, "_env should be stripped")
+	assert.False(t, hasTLS, "_shared_tls_certs should be stripped")
+	assert.Contains(t, public, "blockchains")
+	assert.Contains(t, public, "environment_topology")
+	assert.Equal(t, 1, public["version"])
+}

--- a/changelog/2026-05-29_phased_raw_output_versioned_load.md
+++ b/changelog/2026-05-29_phased_raw_output_versioned_load.md
@@ -1,0 +1,92 @@
+# Phased devenv serializes its raw output map; `LoadOutput` is version-aware
+
+## Summary
+
+The phased devenv (`--env-mode phased`) now serializes the raw accumulated
+component-output map directly instead of reconstructing a transitional `*Cfg`,
+and `LoadOutput[Cfg]` selects its decoder from a `version` marker so existing
+readers consume either format unchanged. Components own their output keys, with
+runtime-only values hidden behind a `_` prefix.
+
+---
+
+## Breaking change: `NewPhasedEnvironment` return type
+
+It no longer returns the transitional `*Cfg`; it returns the raw accumulated
+output map. The `up`/`restart` commands already discarded the value, so the CLI
+is unaffected; direct callers must adjust.
+
+| What | Before | After |
+|------|--------|-------|
+| Signature | `func NewPhasedEnvironment() (*Cfg, error)` | `func NewPhasedEnvironment() (map[string]any, error)` |
+
+Before:
+```go
+cfg, err := ccv.NewPhasedEnvironment()
+```
+
+After:
+```go
+out, err := ccv.NewPhasedEnvironment() // out is the raw runtime output map
+```
+
+---
+
+## Breaking change: phased output file format
+
+The phased output file (e.g. `env-phased-out.toml`) is now a dump of the
+component output map (component-native keys such as `aggregators`/`verifiers`,
+plus `cldf`, `environment_topology`, public `jd`), not a `Cfg`-shaped document.
+Runtime-only keys (prefixed `_`) are stripped. **Do not** strict-decode it as
+`Cfg` — read it through `LoadOutput`, which now branches on `version`.
+
+| What | Before | After |
+|------|--------|-------|
+| Format | `Cfg` TOML (`Store(cfg)`) | raw output map, `_`-keys stripped |
+| `version` (phased) | `1` | `1` (re-emitted as public key) |
+| `version` (legacy/monolith) | `1` | `0` / absent (dropped from `env.toml`) |
+| Loader dispatch | always strict `Cfg` decode | `0`/absent → strict `Cfg`; `1` → lenient phased decode |
+
+---
+
+## Breaking change: `JDInfrastructure` is now serialized
+
+`jd` stays a public output key (kept for future job proposals). To make it
+TOML-safe, the live gRPC client is excluded and the data fields are tagged.
+
+| Field | Before | After |
+|-------|--------|-------|
+| `JDOutput` | (untagged) | `toml:"jd_output"` |
+| `NodeIDMap` | (untagged) | `toml:"node_id_map"` |
+| `OffchainClient` | (serialized) | `toml:"-"` (skipped) |
+
+---
+
+## New: version-aware `LoadOutput[Cfg]`
+
+A single dispatch point — `NewLibFromCCVEnv` and all direct `LoadOutput[ccv.Cfg]`
+callers funnel through it, so no call sites or signatures change. Version `1`
+leniently decodes the phased map and derives the aggregator/indexer endpoint maps
+from each launched service's `Out`.
+
+```go
+in, err := ccv.LoadOutput[ccv.Cfg](outFile) // works for phased and legacy output
+```
+
+---
+
+## New: public/private component output keys
+
+Components publish public keys (serialized) or `_`-prefixed runtime-only keys
+(stripped on serialize). Reclassified this release:
+
+- `_cldf` → `cldf`, `_topology` → `environment_topology` (now public)
+- `shared_tls_certs` → `_shared_tls_certs` (now runtime-only)
+
+---
+
+## Recommended additions
+
+- Follow-ups filed in `.scratch/phased-devenv-cleanup/`: decouple `Lib` from
+  `Cfg` (10), typed output-key bus (12, needs go/no-go), and a generic
+  `DecodeConfig[T]` helper (14).


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

# PR Chain
There are multiple open pull requests that feed into each other:

- https://github.com/smartcontractkit/chainlink-ccv/pull/1148
- https://github.com/smartcontractkit/chainlink-ccv/pull/1145
- https://github.com/smartcontractkit/chainlink-ccv/pull/1143
- https://github.com/smartcontractkit/chainlink-ccv/pull/1141
- **this PR** https://github.com/smartcontractkit/chainlink-ccv/pull/1140
- https://github.com/smartcontractkit/chainlink-ccv/pull/1138
- https://github.com/smartcontractkit/chainlink-ccv/pull/1137
- https://github.com/smartcontractkit/chainlink-ccv/pull/1133
- main

## Description
The phased devenv (--env-mode phased) previously reconstructed a transitional *Cfg from the component runtime's output map via hand-written sync blocks. This PR removes that bridge: NewPhasedEnvironment now serializes the raw accumulated output map directly, and LoadOutput[Cfg] switches on a version marker to decode either format. Adding a new serialized output no longer requires touching a central mapping — a component just publishes a public key.

### What changed

- NewPhasedEnvironment returns the raw accumulated map and writes the output file via storePhasedOutput, which strips runtime-only keys (any key prefixed with _) and serializes the rest. The schema version is re-published as a public key so the file starts with version = N.
- Component output keys reclassified into public (serialized) vs. _-private (runtime-only, stripped):
    - protocol_contracts: _cldf → cldf, _topology → environment_topology (consumers in executor/committeeccv updated).
    - committeeccv: shared_tls_certs → _shared_tls_certs (consumer in indexer updated).
    - jd stays public (needed for future job proposals); JDInfrastructure.OffchainClient (a live gRPC client) is tagged toml:"-" so the section serializes cleanly while keeping jd_output + node_id_map.
- LoadOutput[Cfg] is now version-aware — a single dispatch point that all readers (NewLibFromCCVEnv and the ~18 direct LoadOutput[ccv.Cfg] test call sites) funnel through:
    - version absent/0 → existing strict Cfg decode (legacy/monolith).
    - version == 1 → lenient decode of the raw map + derive aggregator/indexer endpoint maps from each launched service's Out.
    - any other version → error.
- env.toml drops its version key so monolith output stays at 0 and routes to the legacy decoder.

### Why

  - Removes the fragile, hand-maintained *Cfg reconstruction in the phased path.
  - Establishes a clear "public key vs. _-private runtime key" convention owned by each component.
  - Keeps the output-file contract backward compatible: no reader signatures or call sites change, because the version dispatch lives inside LoadOutput.

### Compatibility / risk

  - Legacy (monolith) output and all its readers are unchanged.
  - Phased output keys are a raw component dump; the phased decode is intentionally lenient and ignores keys Cfg doesn't model (e.g. the aggregators/verifiers plurals).
<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
