### PR TITLE
Support asymetric lanes

### DIFF
--- a/build/devenv/deploy/deploy.go
+++ b/build/devenv/deploy/deploy.go
@@ -676,28 +676,6 @@ func tokenTransferRemoteNodeKey(chainSelector uint64, ref datastore.AddressRef) 
 	}
 }
 
-func tokenTransferRemoteNodeKeyFromConfig(
-	cfg tokenscore.TokenTransferConfig,
-	remoteSelector uint64,
-) (tokenTransferNodeKey, bool) {
-	remoteCfg, ok := cfg.RemoteChains[remoteSelector]
-	if !ok || remoteCfg.RemotePool == nil {
-		return tokenTransferNodeKey{}, false
-	}
-	return tokenTransferRemoteNodeKey(remoteSelector, *remoteCfg.RemotePool), true
-}
-
-func tokenTransferConfigsAreReciprocal(
-	from tokenscore.TokenTransferConfig,
-	to tokenscore.TokenTransferConfig,
-) bool {
-	expectedRemote, ok := tokenTransferRemoteNodeKeyFromConfig(from, to.ChainSelector)
-	if !ok {
-		return false
-	}
-	return expectedRemote == tokenTransferConfigNodeKey(to)
-}
-
 func (k tokenTransferNodeKey) String() string {
 	return fmt.Sprintf("%d/%s", k.chainSelector, k.poolKey)
 }
@@ -758,28 +736,27 @@ func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) ([][]to
 
 func splitTokenTransferBatchBySelector(configs []tokenscore.TokenTransferConfig) [][]tokenscore.TokenTransferConfig {
 	// isBidirectionallyCompatible checks whether placing cfg into batch would
-	// maintain symmetry at pool level: whenever cfg and a batch member reference
-	// one another, the referenced local pool must be the exact counterpart being
-	// batched, not just any config on the same selector.
+	// maintain symmetry: for every remote chain already in the batch, the
+	// counterpart config must reference cfg's chain back and vice-versa.
 	isBidirectionallyCompatible := func(batch []tokenscore.TokenTransferConfig, cfg tokenscore.TokenTransferConfig) bool {
+		batchBySelector := make(map[uint64]tokenscore.TokenTransferConfig, len(batch))
 		for _, b := range batch {
-			candidateRefsBatchMember, candidateHasRemote := tokenTransferRemoteNodeKeyFromConfig(cfg, b.ChainSelector)
-			batchMemberRefsCandidate, batchMemberHasRemote := tokenTransferRemoteNodeKeyFromConfig(b, cfg.ChainSelector)
+			batchBySelector[b.ChainSelector] = b
+		}
 
-			if candidateHasRemote {
-				if candidateRefsBatchMember != tokenTransferConfigNodeKey(b) {
-					return false
-				}
-				if !tokenTransferConfigsAreReciprocal(b, cfg) {
-					return false
-				}
+		for remoteSelector := range cfg.RemoteChains {
+			counterpart, inBatch := batchBySelector[remoteSelector]
+			if !inBatch {
+				continue
 			}
+			if _, ok := counterpart.RemoteChains[cfg.ChainSelector]; !ok {
+				return false
+			}
+		}
 
-			if batchMemberHasRemote {
-				if batchMemberRefsCandidate != tokenTransferConfigNodeKey(cfg) {
-					return false
-				}
-				if !tokenTransferConfigsAreReciprocal(cfg, b) {
+		for _, b := range batch {
+			if _, refsMe := b.RemoteChains[cfg.ChainSelector]; refsMe {
+				if _, ok := cfg.RemoteChains[b.ChainSelector]; !ok {
 					return false
 				}
 			}

--- a/build/devenv/deploy/deploy.go
+++ b/build/devenv/deploy/deploy.go
@@ -676,6 +676,28 @@ func tokenTransferRemoteNodeKey(chainSelector uint64, ref datastore.AddressRef) 
 	}
 }
 
+func tokenTransferRemoteNodeKeyFromConfig(
+	cfg tokenscore.TokenTransferConfig,
+	remoteSelector uint64,
+) (tokenTransferNodeKey, bool) {
+	remoteCfg, ok := cfg.RemoteChains[remoteSelector]
+	if !ok || remoteCfg.RemotePool == nil {
+		return tokenTransferNodeKey{}, false
+	}
+	return tokenTransferRemoteNodeKey(remoteSelector, *remoteCfg.RemotePool), true
+}
+
+func tokenTransferConfigsAreReciprocal(
+	from tokenscore.TokenTransferConfig,
+	to tokenscore.TokenTransferConfig,
+) bool {
+	expectedRemote, ok := tokenTransferRemoteNodeKeyFromConfig(from, to.ChainSelector)
+	if !ok {
+		return false
+	}
+	return expectedRemote == tokenTransferConfigNodeKey(to)
+}
+
 func (k tokenTransferNodeKey) String() string {
 	return fmt.Sprintf("%d/%s", k.chainSelector, k.poolKey)
 }
@@ -735,43 +757,29 @@ func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) ([][]to
 }
 
 func splitTokenTransferBatchBySelector(configs []tokenscore.TokenTransferConfig) [][]tokenscore.TokenTransferConfig {
-	// Build a lookup of all configs by (selector, poolRefKey) so we can check
-	// bidirectional symmetry during placement.
-	type nodeID struct {
-		selector uint64
-		poolKey  string
-	}
-	configByNode := make(map[nodeID]tokenscore.TokenTransferConfig, len(configs))
-	for _, cfg := range configs {
-		configByNode[nodeID{cfg.ChainSelector, tokenTransferRefKey(cfg.TokenPoolRef)}] = cfg
-	}
-
 	// isBidirectionallyCompatible checks whether placing cfg into batch would
-	// maintain symmetry: for every remote chain already in the batch, the
-	// counterpart config must reference cfg's chain back and vice-versa.
+	// maintain symmetry at pool level: whenever cfg and a batch member reference
+	// one another, the referenced local pool must be the exact counterpart being
+	// batched, not just any config on the same selector.
 	isBidirectionallyCompatible := func(batch []tokenscore.TokenTransferConfig, cfg tokenscore.TokenTransferConfig) bool {
-		batchBySelector := make(map[uint64]tokenscore.TokenTransferConfig, len(batch))
 		for _, b := range batch {
-			batchBySelector[b.ChainSelector] = b
-		}
+			candidateRefsBatchMember, candidateHasRemote := tokenTransferRemoteNodeKeyFromConfig(cfg, b.ChainSelector)
+			batchMemberRefsCandidate, batchMemberHasRemote := tokenTransferRemoteNodeKeyFromConfig(b, cfg.ChainSelector)
 
-		// Check: for each remote chain in cfg that is already in the batch,
-		// the batch member must reference cfg's chain back.
-		for remoteSelector := range cfg.RemoteChains {
-			counterpart, inBatch := batchBySelector[remoteSelector]
-			if !inBatch {
-				continue
+			if candidateHasRemote {
+				if candidateRefsBatchMember != tokenTransferConfigNodeKey(b) {
+					return false
+				}
+				if !tokenTransferConfigsAreReciprocal(b, cfg) {
+					return false
+				}
 			}
-			if _, ok := counterpart.RemoteChains[cfg.ChainSelector]; !ok {
-				return false
-			}
-		}
 
-		// Check: for each batch member that references cfg's chain as a remote,
-		// cfg must reference that member's chain back.
-		for _, b := range batch {
-			if _, refsMe := b.RemoteChains[cfg.ChainSelector]; refsMe {
-				if _, ok := cfg.RemoteChains[b.ChainSelector]; !ok {
+			if batchMemberHasRemote {
+				if batchMemberRefsCandidate != tokenTransferConfigNodeKey(cfg) {
+					return false
+				}
+				if !tokenTransferConfigsAreReciprocal(cfg, b) {
 					return false
 				}
 			}

--- a/build/devenv/deploy/deploy.go
+++ b/build/devenv/deploy/deploy.go
@@ -735,12 +735,60 @@ func buildTokenTransferBatches(configs []tokenscore.TokenTransferConfig) ([][]to
 }
 
 func splitTokenTransferBatchBySelector(configs []tokenscore.TokenTransferConfig) [][]tokenscore.TokenTransferConfig {
+	// Build a lookup of all configs by (selector, poolRefKey) so we can check
+	// bidirectional symmetry during placement.
+	type nodeID struct {
+		selector uint64
+		poolKey  string
+	}
+	configByNode := make(map[nodeID]tokenscore.TokenTransferConfig, len(configs))
+	for _, cfg := range configs {
+		configByNode[nodeID{cfg.ChainSelector, tokenTransferRefKey(cfg.TokenPoolRef)}] = cfg
+	}
+
+	// isBidirectionallyCompatible checks whether placing cfg into batch would
+	// maintain symmetry: for every remote chain already in the batch, the
+	// counterpart config must reference cfg's chain back and vice-versa.
+	isBidirectionallyCompatible := func(batch []tokenscore.TokenTransferConfig, cfg tokenscore.TokenTransferConfig) bool {
+		batchBySelector := make(map[uint64]tokenscore.TokenTransferConfig, len(batch))
+		for _, b := range batch {
+			batchBySelector[b.ChainSelector] = b
+		}
+
+		// Check: for each remote chain in cfg that is already in the batch,
+		// the batch member must reference cfg's chain back.
+		for remoteSelector := range cfg.RemoteChains {
+			counterpart, inBatch := batchBySelector[remoteSelector]
+			if !inBatch {
+				continue
+			}
+			if _, ok := counterpart.RemoteChains[cfg.ChainSelector]; !ok {
+				return false
+			}
+		}
+
+		// Check: for each batch member that references cfg's chain as a remote,
+		// cfg must reference that member's chain back.
+		for _, b := range batch {
+			if _, refsMe := b.RemoteChains[cfg.ChainSelector]; refsMe {
+				if _, ok := cfg.RemoteChains[b.ChainSelector]; !ok {
+					return false
+				}
+			}
+		}
+
+		return true
+	}
+
 	batches := make([][]tokenscore.TokenTransferConfig, 0, 1)
 	seenSelectors := make([]map[uint64]bool, 0, 1)
 	for _, cfg := range configs {
 		placed := false
 		for i := range batches {
 			if seenSelectors[i][cfg.ChainSelector] {
+				continue
+			}
+			if !isBidirectionallyCompatible(batches[i], cfg) {
 				continue
 			}
 			batches[i] = append(batches[i], cfg)

--- a/build/devenv/deploy/deploy_test.go
+++ b/build/devenv/deploy/deploy_test.go
@@ -74,18 +74,21 @@ func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByLocalPoolInstance(t *tes
 		testTokenTransferConfig(lock3, burn1, burn2),
 	})
 	require.NoError(t, err)
-	require.Len(t, batches, 2)
-
-	for _, batch := range batches {
-		require.Len(t, batch, 3)
-		requireNoDuplicateTokenTransferSelectors(t, batch)
-		qualifier := batch[0].TokenPoolRef.Qualifier
-		for _, cfg := range batch {
-			require.Equal(t, qualifier, cfg.TokenPoolRef.Qualifier)
-			require.Len(t, cfg.RemoteChains, 2)
-			requireBatchContainsRemoteSelectors(t, batch, cfg)
-		}
-	}
+	require.Len(t, batches, 4)
+	requireTokenTransferBatchNodeKeys(t, batches[0],
+		"1/TokenPool+1.0.0+TEST (burn, lock)::burn",
+		"2/TokenPool+1.0.0+TEST (burn, lock)::lock",
+	)
+	requireTokenTransferBatchNodeKeys(t, batches[1],
+		"1/TokenPool+1.0.0+TEST (burn, lock)::lock",
+		"2/TokenPool+1.0.0+TEST (burn, lock)::burn",
+	)
+	requireTokenTransferBatchNodeKeys(t, batches[2],
+		"3/TokenPool+1.0.0+TEST (burn, lock)::burn",
+	)
+	requireTokenTransferBatchNodeKeys(t, batches[3],
+		"3/TokenPool+1.0.0+TEST (burn, lock)::lock",
+	)
 }
 
 // TestBuildTokenTransferBatchesCrossTypePools verifies that an EVM
@@ -240,13 +243,14 @@ func TestBuildTokenTransferBatchesSameTypeVersionsSplitByLocalVersion(t *testing
 
 // TestBuildTokenTransferBatchesAsymmetricChainSupport verifies correct batching
 // when one chain (e.g. EVM) supports only Burn 2.0.0 while other chains (e.g. Solana)
-// support both Lock 1.6.1 and Burn 2.0.0. The splitter must produce symmetric
-// sub-batches where each config's RemoteChains are reciprocated.
+// support both Lock 1.6.1 and Burn 2.0.0. The splitter must avoid batching a
+// config with a same-selector pool that is not the exact RemotePool it targets.
 //
 // Expected split:
 //
-//	Batch 0: chain1-Burn(→chain2,chain3) + chain2-Lock(→chain1,chain3) + chain3-Lock(→chain1,chain2) — symmetric
-//	Batch 1: chain2-Burn(→chain3) + chain3-Burn(→chain2) — symmetric (no chain1: it lacks Lock)
+	//	Batch 0: chain1-Burn + chain2-Lock
+	//	Batch 1: chain2-Burn + chain3-Lock
+	//	Batch 2: chain3-Burn
 func TestBuildTokenTransferBatchesAsymmetricChainSupport(t *testing.T) {
 	const pairQualifier = "TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])"
 
@@ -297,33 +301,23 @@ func TestBuildTokenTransferBatchesAsymmetricChainSupport(t *testing.T) {
 		testTokenTransferConfig(chain3Burn, chain2Lock),
 	})
 	require.NoError(t, err)
-	require.Len(t, batches, 2, "expected 2 sub-batches for asymmetric chain support")
+	require.Len(t, batches, 3, "expected 3 sub-batches for asymmetric chain support")
 
-	// Verify each batch is symmetric and has no duplicate selectors.
-	for i, batch := range batches {
+	for _, batch := range batches {
 		requireNoDuplicateTokenTransferSelectors(t, batch)
-		for _, cfg := range batch {
-			requireBatchContainsRemoteSelectors(t, batch, cfg)
-		}
-		// Also verify bidirectional symmetry: for every remote chain ref, the
-		// counterpart in the batch must reference back.
-		bySelector := make(map[uint64]tokenscore.TokenTransferConfig, len(batch))
-		for _, cfg := range batch {
-			bySelector[cfg.ChainSelector] = cfg
-		}
-		for _, cfg := range batch {
-			for remoteSelector := range cfg.RemoteChains {
-				counterpart, ok := bySelector[remoteSelector]
-				require.True(t, ok, "batch %d: missing counterpart for selector %d", i, remoteSelector)
-				_, hasBack := counterpart.RemoteChains[cfg.ChainSelector]
-				require.True(t, hasBack, "batch %d: counterpart selector %d does not reference back to %d", i, remoteSelector, cfg.ChainSelector)
-			}
-		}
 	}
 
-	// Verify batch sizes: one batch with 3 configs (chain1+chain2+chain3), one with 2 (chain2+chain3).
-	sizes := []int{len(batches[0]), len(batches[1])}
-	require.ElementsMatch(t, []int{3, 2}, sizes)
+	requireTokenTransferBatchNodeKeys(t, batches[0],
+		"1/BurnMintTokenPool+2.0.0+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::BurnMintTokenPool 2.0.0 [default]",
+		"2/LockReleaseTokenPool+1.6.1+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::LockReleaseTokenPool 1.6.1 []",
+	)
+	requireTokenTransferBatchNodeKeys(t, batches[1],
+		"2/BurnMintTokenPool+2.0.0+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::BurnMintTokenPool 2.0.0 [default]",
+		"3/LockReleaseTokenPool+1.6.1+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::LockReleaseTokenPool 1.6.1 []",
+	)
+	requireTokenTransferBatchNodeKeys(t, batches[2],
+		"3/BurnMintTokenPool+2.0.0+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::BurnMintTokenPool 2.0.0 [default]",
+	)
 }
 
 func testTokenPoolRef(selector uint64, qualifier string) datastore.AddressRef {
@@ -357,6 +351,16 @@ func requireNoDuplicateTokenTransferSelectors(t *testing.T, batch []tokenscore.T
 		require.False(t, seen[cfg.ChainSelector], "duplicate selector %d in token transfer batch", cfg.ChainSelector)
 		seen[cfg.ChainSelector] = true
 	}
+}
+
+func requireTokenTransferBatchNodeKeys(t *testing.T, batch []tokenscore.TokenTransferConfig, expected ...string) {
+	t.Helper()
+
+	actual := make([]string, 0, len(batch))
+	for _, cfg := range batch {
+		actual = append(actual, tokenTransferConfigNodeKey(cfg).String())
+	}
+	require.Equal(t, expected, actual)
 }
 
 func requireReciprocalTokenTransferBatch(t *testing.T, batch []tokenscore.TokenTransferConfig) {

--- a/build/devenv/deploy/deploy_test.go
+++ b/build/devenv/deploy/deploy_test.go
@@ -74,21 +74,18 @@ func TestBuildTokenTransferBatchesAsymmetricPoolsSplitByLocalPoolInstance(t *tes
 		testTokenTransferConfig(lock3, burn1, burn2),
 	})
 	require.NoError(t, err)
-	require.Len(t, batches, 4)
-	requireTokenTransferBatchNodeKeys(t, batches[0],
-		"1/TokenPool+1.0.0+TEST (burn, lock)::burn",
-		"2/TokenPool+1.0.0+TEST (burn, lock)::lock",
-	)
-	requireTokenTransferBatchNodeKeys(t, batches[1],
-		"1/TokenPool+1.0.0+TEST (burn, lock)::lock",
-		"2/TokenPool+1.0.0+TEST (burn, lock)::burn",
-	)
-	requireTokenTransferBatchNodeKeys(t, batches[2],
-		"3/TokenPool+1.0.0+TEST (burn, lock)::burn",
-	)
-	requireTokenTransferBatchNodeKeys(t, batches[3],
-		"3/TokenPool+1.0.0+TEST (burn, lock)::lock",
-	)
+	require.Len(t, batches, 2)
+
+	for _, batch := range batches {
+		require.Len(t, batch, 3)
+		requireNoDuplicateTokenTransferSelectors(t, batch)
+		qualifier := batch[0].TokenPoolRef.Qualifier
+		for _, cfg := range batch {
+			require.Equal(t, qualifier, cfg.TokenPoolRef.Qualifier)
+			require.Len(t, cfg.RemoteChains, 2)
+			requireBatchContainsRemoteSelectors(t, batch, cfg)
+		}
+	}
 }
 
 // TestBuildTokenTransferBatchesCrossTypePools verifies that an EVM
@@ -243,14 +240,13 @@ func TestBuildTokenTransferBatchesSameTypeVersionsSplitByLocalVersion(t *testing
 
 // TestBuildTokenTransferBatchesAsymmetricChainSupport verifies correct batching
 // when one chain (e.g. EVM) supports only Burn 2.0.0 while other chains (e.g. Solana)
-// support both Lock 1.6.1 and Burn 2.0.0. The splitter must avoid batching a
-// config with a same-selector pool that is not the exact RemotePool it targets.
+// support both Lock 1.6.1 and Burn 2.0.0. The splitter must produce symmetric
+// sub-batches where each config's RemoteChains are reciprocated.
 //
 // Expected split:
 //
-	//	Batch 0: chain1-Burn + chain2-Lock
-	//	Batch 1: chain2-Burn + chain3-Lock
-	//	Batch 2: chain3-Burn
+	//	Batch 0: chain1-Burn(→chain2,chain3) + chain2-Lock(→chain1,chain3) + chain3-Lock(→chain1,chain2) — symmetric
+	//	Batch 1: chain2-Burn(→chain3) + chain3-Burn(→chain2) — symmetric (no chain1: it lacks Lock)
 func TestBuildTokenTransferBatchesAsymmetricChainSupport(t *testing.T) {
 	const pairQualifier = "TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])"
 
@@ -301,23 +297,32 @@ func TestBuildTokenTransferBatchesAsymmetricChainSupport(t *testing.T) {
 		testTokenTransferConfig(chain3Burn, chain2Lock),
 	})
 	require.NoError(t, err)
-	require.Len(t, batches, 3, "expected 3 sub-batches for asymmetric chain support")
+	require.Len(t, batches, 2, "expected 2 sub-batches for asymmetric chain support")
 
-	for _, batch := range batches {
+	for i, batch := range batches {
 		requireNoDuplicateTokenTransferSelectors(t, batch)
+		for _, cfg := range batch {
+			requireBatchContainsRemoteSelectors(t, batch, cfg)
+		}
+		// Also verify bidirectional symmetry: for every remote chain ref, the
+		// counterpart in the batch must reference back.
+		bySelector := make(map[uint64]tokenscore.TokenTransferConfig, len(batch))
+		for _, cfg := range batch {
+			bySelector[cfg.ChainSelector] = cfg
+		}
+		for _, cfg := range batch {
+			for remoteSelector := range cfg.RemoteChains {
+				counterpart, ok := bySelector[remoteSelector]
+				require.True(t, ok, "batch %d: missing counterpart for selector %d", i, remoteSelector)
+				_, hasBack := counterpart.RemoteChains[cfg.ChainSelector]
+				require.True(t, hasBack, "batch %d: counterpart selector %d does not reference back to %d", i, remoteSelector, cfg.ChainSelector)
+			}
+		}
 	}
 
-	requireTokenTransferBatchNodeKeys(t, batches[0],
-		"1/BurnMintTokenPool+2.0.0+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::BurnMintTokenPool 2.0.0 [default]",
-		"2/LockReleaseTokenPool+1.6.1+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::LockReleaseTokenPool 1.6.1 []",
-	)
-	requireTokenTransferBatchNodeKeys(t, batches[1],
-		"2/BurnMintTokenPool+2.0.0+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::BurnMintTokenPool 2.0.0 [default]",
-		"3/LockReleaseTokenPool+1.6.1+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::LockReleaseTokenPool 1.6.1 []",
-	)
-	requireTokenTransferBatchNodeKeys(t, batches[2],
-		"3/BurnMintTokenPool+2.0.0+TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])::BurnMintTokenPool 2.0.0 [default]",
-	)
+	// Verify batch sizes: one batch with 3 configs (chain1+chain2+chain3), one with 2 (chain2+chain3).
+	sizes := []int{len(batches[0]), len(batches[1])}
+	require.ElementsMatch(t, []int{3, 2}, sizes)
 }
 
 func testTokenPoolRef(selector uint64, qualifier string) datastore.AddressRef {
@@ -351,16 +356,6 @@ func requireNoDuplicateTokenTransferSelectors(t *testing.T, batch []tokenscore.T
 		require.False(t, seen[cfg.ChainSelector], "duplicate selector %d in token transfer batch", cfg.ChainSelector)
 		seen[cfg.ChainSelector] = true
 	}
-}
-
-func requireTokenTransferBatchNodeKeys(t *testing.T, batch []tokenscore.TokenTransferConfig, expected ...string) {
-	t.Helper()
-
-	actual := make([]string, 0, len(batch))
-	for _, cfg := range batch {
-		actual = append(actual, tokenTransferConfigNodeKey(cfg).String())
-	}
-	require.Equal(t, expected, actual)
 }
 
 func requireReciprocalTokenTransferBatch(t *testing.T, batch []tokenscore.TokenTransferConfig) {

--- a/build/devenv/deploy/deploy_test.go
+++ b/build/devenv/deploy/deploy_test.go
@@ -238,6 +238,94 @@ func TestBuildTokenTransferBatchesSameTypeVersionsSplitByLocalVersion(t *testing
 	}
 }
 
+// TestBuildTokenTransferBatchesAsymmetricChainSupport verifies correct batching
+// when one chain (e.g. EVM) supports only Burn 2.0.0 while other chains (e.g. Solana)
+// support both Lock 1.6.1 and Burn 2.0.0. The splitter must produce symmetric
+// sub-batches where each config's RemoteChains are reciprocated.
+//
+// Expected split:
+//
+//	Batch 0: chain1-Burn(→chain2,chain3) + chain2-Lock(→chain1,chain3) + chain3-Lock(→chain1,chain2) — symmetric
+//	Batch 1: chain2-Burn(→chain3) + chain3-Burn(→chain2) — symmetric (no chain1: it lacks Lock)
+func TestBuildTokenTransferBatchesAsymmetricChainSupport(t *testing.T) {
+	const pairQualifier = "TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])"
+
+	// chain1 (EVM-like): only Burn 2.0.0 (no Lock 1.6.1)
+	chain1Burn := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 2.0.0 [default]",
+	}
+	// chain2 (Solana-like): both Lock 1.6.1 and Burn 2.0.0
+	chain2Lock := datastore.AddressRef{
+		ChainSelector: 2,
+		Type:          datastore.ContractType("LockReleaseTokenPool"),
+		Version:       semver.MustParse("1.6.1"),
+		Qualifier:     pairQualifier + "::LockReleaseTokenPool 1.6.1 []",
+	}
+	chain2Burn := datastore.AddressRef{
+		ChainSelector: 2,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 2.0.0 [default]",
+	}
+	// chain3 (Solana-like): both Lock 1.6.1 and Burn 2.0.0
+	chain3Lock := datastore.AddressRef{
+		ChainSelector: 3,
+		Type:          datastore.ContractType("LockReleaseTokenPool"),
+		Version:       semver.MustParse("1.6.1"),
+		Qualifier:     pairQualifier + "::LockReleaseTokenPool 1.6.1 []",
+	}
+	chain3Burn := datastore.AddressRef{
+		ChainSelector: 3,
+		Type:          datastore.ContractType("BurnMintTokenPool"),
+		Version:       semver.MustParse("2.0.0"),
+		Qualifier:     pairQualifier + "::BurnMintTokenPool 2.0.0 [default]",
+	}
+
+	batches, err := buildTokenTransferBatches([]tokenscore.TokenTransferConfig{
+		// chain1 (EVM): Burn local → references chain2-Lock and chain3-Lock
+		testTokenTransferConfig(chain1Burn, chain2Lock, chain3Lock),
+		// chain2 (Solana): Lock local → references chain1-Burn and chain3-Burn
+		testTokenTransferConfig(chain2Lock, chain1Burn, chain3Burn),
+		// chain2 (Solana): Burn local → references chain3-Lock only (chain1 lacks Lock)
+		testTokenTransferConfig(chain2Burn, chain3Lock),
+		// chain3 (Solana): Lock local → references chain1-Burn and chain2-Burn
+		testTokenTransferConfig(chain3Lock, chain1Burn, chain2Burn),
+		// chain3 (Solana): Burn local → references chain2-Lock only (chain1 lacks Lock)
+		testTokenTransferConfig(chain3Burn, chain2Lock),
+	})
+	require.NoError(t, err)
+	require.Len(t, batches, 2, "expected 2 sub-batches for asymmetric chain support")
+
+	// Verify each batch is symmetric and has no duplicate selectors.
+	for i, batch := range batches {
+		requireNoDuplicateTokenTransferSelectors(t, batch)
+		for _, cfg := range batch {
+			requireBatchContainsRemoteSelectors(t, batch, cfg)
+		}
+		// Also verify bidirectional symmetry: for every remote chain ref, the
+		// counterpart in the batch must reference back.
+		bySelector := make(map[uint64]tokenscore.TokenTransferConfig, len(batch))
+		for _, cfg := range batch {
+			bySelector[cfg.ChainSelector] = cfg
+		}
+		for _, cfg := range batch {
+			for remoteSelector := range cfg.RemoteChains {
+				counterpart, ok := bySelector[remoteSelector]
+				require.True(t, ok, "batch %d: missing counterpart for selector %d", i, remoteSelector)
+				_, hasBack := counterpart.RemoteChains[cfg.ChainSelector]
+				require.True(t, hasBack, "batch %d: counterpart selector %d does not reference back to %d", i, remoteSelector, cfg.ChainSelector)
+			}
+		}
+	}
+
+	// Verify batch sizes: one batch with 3 configs (chain1+chain2+chain3), one with 2 (chain2+chain3).
+	sizes := []int{len(batches[0]), len(batches[1])}
+	require.ElementsMatch(t, []int{3, 2}, sizes)
+}
+
 func testTokenPoolRef(selector uint64, qualifier string) datastore.AddressRef {
 	return datastore.AddressRef{
 		ChainSelector: selector,

--- a/build/devenv/deploy/deploy_test.go
+++ b/build/devenv/deploy/deploy_test.go
@@ -245,8 +245,8 @@ func TestBuildTokenTransferBatchesSameTypeVersionsSplitByLocalVersion(t *testing
 //
 // Expected split:
 //
-	//	Batch 0: chain1-Burn(→chain2,chain3) + chain2-Lock(→chain1,chain3) + chain3-Lock(→chain1,chain2) — symmetric
-	//	Batch 1: chain2-Burn(→chain3) + chain3-Burn(→chain2) — symmetric (no chain1: it lacks Lock)
+//	Batch 0: chain1-Burn(->chain2,chain3) + chain2-Lock(->chain1,chain3) + chain3-Lock(->chain1,chain2) - symmetric
+//	Batch 1: chain2-Burn(->chain3) + chain3-Burn(->chain2) - symmetric (no chain1: it lacks Lock)
 func TestBuildTokenTransferBatchesAsymmetricChainSupport(t *testing.T) {
 	const pairQualifier = "TEST (BurnMintTokenPool 2.0.0 [default], LockReleaseTokenPool 1.6.1 [])"
 


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
Fixes token-transfer batching for asymmetric lane support.

Adds bidirectional selector compatibility checks when placing configs into batches.
Keeps deterministic batching order.
Adds an asymmetric BurnMint/LockRelease regression test.
Verifies expected split (3-config batch + 2-config batch) and reciprocal selector coverage.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
