### PR TITLE
dockerfiles: pin alpine to 3.23, introduce nonpriveleged users

### DIFF
--- a/aggregator/Dockerfile
+++ b/aggregator/Dockerfile
@@ -13,10 +13,15 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
     cd aggregator && CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/aggregator cmd/main.go
 
-FROM alpine:latest
+FROM alpine:3.23
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/aggregator /bin/
-COPY --from=builder /app/aggregator/migrations /migrations
+
+# Create a non-root user and group for running the application
+RUN addgroup -S aggregator && adduser -S aggregator -G aggregator
+
+COPY --chown=aggregator:aggregator --from=builder /bin/aggregator /bin/
+COPY --chown=aggregator:aggregator --from=builder /app/aggregator/migrations /migrations
 WORKDIR /app
-RUN ln -s /migrations /app/migrations || true
+RUN chown aggregator:aggregator /app && ln -s /migrations /app/migrations || true
+USER aggregator:aggregator
 CMD ["/bin/aggregator"]

--- a/build/devenv/fakes/Dockerfile
+++ b/build/devenv/fakes/Dockerfile
@@ -14,8 +14,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
     CGO_ENABLED=0 GOOS=linux go build -o /fake cmd/main.go
 
-FROM alpine:latest
+FROM alpine:3.23
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /fake /fake
+
+# Create a non-root user and group for running the application
+RUN addgroup -S fakes && adduser -S fakes -G fakes
+
+COPY --chown=fakes:fakes --from=builder /fake /fake
+USER fakes:fakes
 EXPOSE 9111
 CMD ["/fake"]

--- a/executor/Dockerfile
+++ b/executor/Dockerfile
@@ -14,7 +14,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
     CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/executor main.go
 
-FROM alpine:latest
+FROM alpine:3.23
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/executor /bin/
+
+# Create a non-root user and group for running the application
+RUN addgroup -S executor && adduser -S executor -G executor
+
+COPY --chown=executor:executor --from=builder /bin/executor /bin/
+USER executor:executor
 CMD ["/bin/executor"]

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -14,9 +14,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     cd indexer && CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/indexer cmd/main.go && \
     CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/indexer-replay cmd/replay/main.go
 
-FROM alpine:latest
+FROM alpine:3.23
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/indexer /bin/
-COPY --from=builder /bin/indexer-replay /bin/
-COPY --from=builder /app/indexer/migrations ./migrations
+
+# Create a non-root user and group for running the application
+RUN addgroup -S indexer && adduser -S indexer -G indexer
+
+COPY --chown=indexer:indexer --from=builder /bin/indexer /bin/
+COPY --chown=indexer:indexer --from=builder /bin/indexer-replay /bin/
+COPY --chown=indexer:indexer --from=builder /app/indexer/migrations ./migrations
+USER indexer:indexer
 CMD ["/bin/indexer"]

--- a/pricer/Dockerfile
+++ b/pricer/Dockerfile
@@ -15,7 +15,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-s -w' -o /bin/pricer main.go
 
 # Release on alpine to keep size small
-FROM alpine:latest
+FROM alpine:3.23
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/pricer /bin/
+
+# Create a non-root user and group for running the application
+RUN addgroup -S pricer && adduser -S pricer -G pricer
+
+COPY --chown=pricer:pricer --from=builder /bin/pricer /bin/
+USER pricer:pricer
 ENTRYPOINT ["/bin/pricer"]

--- a/verifier/Dockerfile
+++ b/verifier/Dockerfile
@@ -17,9 +17,15 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=ccv-go-build \
     --mount=type=cache,target=/go/pkg/mod,id=ccv-go-mod \
     CGO_ENABLED=0 go build -ldflags='-s -w' -o /bin/verifier main.go
 
-FROM alpine:latest
+FROM alpine:3.23
 RUN apk --no-cache add ca-certificates tini
-COPY --from=builder /bin/verifier /bin/
+
+# Create a non-root user and group for running the application
+RUN addgroup -S verifier && adduser -S verifier -G verifier
+
+COPY --chown=verifier:verifier --from=builder /bin/verifier /bin/
+USER verifier:verifier
+
 # tini is needed here because the verifier would otherwise run as PID 1
 # and we wouldn't be able to pause it with pkill -STOP.
 # Sometimes that is required because we have to run a CLI command to


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

The dockerfiles we use for production builds currently use `alpine:latest` rather than a semantically versioned build, and all processes are running as the root user.

This PR pins alpine to 3.23 and created unprivileged users instead for added security.


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

Existing regression test suite should not be affected.

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
