### PR TITLE
tcapi: use BuildChainMessage/SendChainMessage instead of SendMessage

### DIFF
--- a/build/devenv/tests/e2e/smoke_test.go
+++ b/build/devenv/tests/e2e/smoke_test.go
@@ -12,6 +12,7 @@ import (
 	ccv "github.com/smartcontractkit/chainlink-ccv/build/devenv"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cciptestinterfaces"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/common"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/basic"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/token_transfer"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
@@ -35,8 +36,9 @@ func TestE2ESmoke_Basic(t *testing.T) {
 
 	src, dest := chains[0].CCIP17, chains[1].CCIP17
 
+	sendCfg := tcapi.SendConfig{}
 	t.Run("extra args v3 messaging", func(t *testing.T) {
-		for _, tc := range basic.All(lib, src.ChainSelector(), dest.ChainSelector()) {
+		for _, tc := range basic.All(lib, src.ChainSelector(), dest.ChainSelector(), sendCfg) {
 			if tc.HavePrerequisites(ctx) {
 				t.Run(tc.Name(), func(t *testing.T) {
 					subtestCtx := ccv.Plog.WithContext(t.Context())
@@ -50,7 +52,7 @@ func TestE2ESmoke_Basic(t *testing.T) {
 
 	t.Run("extra args v3 token transfer", func(t *testing.T) {
 		combos := common.AllTokenCombinations()
-		for _, tc := range token_transfer.All(lib, src.ChainSelector(), dest.ChainSelector(), combos) {
+		for _, tc := range token_transfer.All(lib, src.ChainSelector(), dest.ChainSelector(), combos, sendCfg) {
 			if tc.HavePrerequisites(ctx) {
 				t.Run(tc.Name(), func(t *testing.T) {
 					subtestCtx := ccv.Plog.WithContext(t.Context())
@@ -60,7 +62,7 @@ func TestE2ESmoke_Basic(t *testing.T) {
 				t.Logf("Skipping %s because current environment does not have the prerequisites", tc.Name())
 			}
 		}
-		for _, tc := range token_transfer.All17(lib, src.ChainSelector(), dest.ChainSelector(), combos) {
+		for _, tc := range token_transfer.All17(lib, src.ChainSelector(), dest.ChainSelector(), combos, sendCfg) {
 			if tc.HavePrerequisites(ctx) {
 				t.Run(tc.Name(), func(t *testing.T) {
 					subtestCtx := ccv.Plog.WithContext(t.Context())

--- a/build/devenv/tests/e2e/smoke_test.go
+++ b/build/devenv/tests/e2e/smoke_test.go
@@ -36,7 +36,7 @@ func TestE2ESmoke_Basic(t *testing.T) {
 
 	src, dest := chains[0].CCIP17, chains[1].CCIP17
 
-	sendCfg := tcapi.SendConfig{}
+	sendCfg := tcapi.SendArgs{}
 	t.Run("extra args v3 messaging", func(t *testing.T) {
 		for _, tc := range basic.All(lib, src.ChainSelector(), dest.ChainSelector(), sendCfg) {
 			if tc.HavePrerequisites(ctx) {

--- a/build/devenv/tests/e2e/tcapi/basic/v3.go
+++ b/build/devenv/tests/e2e/tcapi/basic/v3.go
@@ -33,6 +33,7 @@ type v3TestCaseBase struct {
 	numExpectedReceipts      int
 	numExpectedVerifications int
 	aggregatorQualifier      string
+	sendConfig               tcapi.SendConfig
 }
 
 // v3TestCase is for tests that use ExtraArgsV3.
@@ -67,16 +68,18 @@ func (tc *v3TestCase) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to get expected next sequence number: %w", err)
 	}
 	l.Info().Uint64("SeqNo", seqNo).Msg("Expecting sequence number")
-	sendMessageResult, err := src.SendMessage(
-		ctx, tc.dst, cciptestinterfaces.MessageFields{
+	sendMessageResult, err := tcapi.SendV3Message(ctx, src, dst, tc.dst,
+		cciptestinterfaces.MessageFields{
 			Receiver: tc.receiver,
 			Data:     tc.msgData,
-		}, cciptestinterfaces.MessageOptions{
-			ExecutionGasLimit: 200_000,
-			FinalityConfig:    tc.finality,
-			Executor:          tc.executor,
-			CCVs:              tc.ccvs,
-		}, 3)
+		},
+		cciptestinterfaces.MessageOptions{
+			FinalityConfig: tc.finality,
+			Executor:       tc.executor,
+			CCVs:           tc.ccvs,
+		},
+		tc.sendConfig,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
@@ -148,11 +151,11 @@ func getCommitteeCCV(ds datastore.DataStore, srcChainSelector uint64, qualifier,
 }
 
 // CustomExecutor returns a test case that uses the custom executor.
-func CustomExecutor(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return customExecutor(lib, src, dest)
+func CustomExecutor(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return customExecutor(lib, src, dest, cfg)
 }
 
-func customExecutor(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func customExecutor(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "custom executor",
@@ -164,6 +167,7 @@ func customExecutor(lib ccv.Lib, src, dest uint64) *v3TestCase {
 			numExpectedReceipts:      3,
 			expectFail:               false,
 			numExpectedVerifications: 1,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -191,11 +195,11 @@ func customExecutor(lib ccv.Lib, src, dest uint64) *v3TestCase {
 }
 
 // EOAReceiverDefaultVerifier returns a test case: EOA receiver and default committee verifier.
-func EOAReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return eoaReceiverDefaultVerifier(lib, src, dest)
+func EOAReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return eoaReceiverDefaultVerifier(lib, src, dest, cfg)
 }
 
-func eoaReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func eoaReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "EOA receiver and default committee verifier",
@@ -206,6 +210,7 @@ func eoaReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64) *v3TestCase {
 			msgData:                  []byte("multi-verifier test"),
 			numExpectedReceipts:      3,
 			numExpectedVerifications: 1,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			chainMap, err := tc.lib.ChainsMap(ctx)
@@ -241,11 +246,11 @@ func eoaReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64) *v3TestCase {
 }
 
 // EOAReceiverSecondaryVerifier returns a test case: EOA receiver and secondary committee verifier.
-func EOAReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return eoaReceiverSecondaryVerifier(lib, src, dest)
+func EOAReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return eoaReceiverSecondaryVerifier(lib, src, dest, cfg)
 }
 
-func eoaReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func eoaReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "EOA receiver and secondary committee verifier",
@@ -256,6 +261,7 @@ func eoaReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64) *v3TestCase {
 			msgData:                  []byte("multi-verifier test"),
 			numExpectedReceipts:      4,
 			numExpectedVerifications: 2,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -295,11 +301,11 @@ func eoaReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64) *v3TestCase {
 }
 
 // ReceiverSecondaryVerifierRequired returns a test case: receiver with secondary verifier required.
-func ReceiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return receiverSecondaryVerifierRequired(lib, src, dest)
+func ReceiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return receiverSecondaryVerifierRequired(lib, src, dest, cfg)
 }
 
-func receiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func receiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ secondary verifier required",
@@ -311,6 +317,7 @@ func receiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64) *v3TestCas
 			numExpectedReceipts:      3,
 			numExpectedVerifications: 1,
 			aggregatorQualifier:      common.SecondaryCommitteeVerifierQualifier,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -338,11 +345,11 @@ func receiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64) *v3TestCas
 }
 
 // ReceiverSecondaryRequiredTertiaryOptionalThreshold1 returns a test case: receiver w/ secondary required and tertiary optional threshold=1.
-func ReceiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return receiverSecondaryRequiredTertiaryOptionalThreshold1(lib, src, dest)
+func ReceiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return receiverSecondaryRequiredTertiaryOptionalThreshold1(lib, src, dest, cfg)
 }
 
-func receiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func receiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ secondary required and tertiary optional threshold=1",
@@ -354,6 +361,7 @@ func receiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest 
 			numExpectedReceipts:      4,
 			numExpectedVerifications: 2,
 			aggregatorQualifier:      common.SecondaryCommitteeVerifierQualifier,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -385,11 +393,11 @@ func receiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest 
 }
 
 // ReceiverQuaternaryAllThreeVerifiers returns a test case: receiver w/ default required, secondary and tertiary optional, message specifies all three.
-func ReceiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return receiverQuaternaryAllThreeVerifiers(lib, src, dest)
+func ReceiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return receiverQuaternaryAllThreeVerifiers(lib, src, dest, cfg)
 }
 
-func receiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func receiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ default required, secondary and tertiary optional, threshold=1, message specifies all three",
@@ -400,6 +408,7 @@ func receiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64) *v3TestC
 			msgData:                  []byte("multi-verifier test"),
 			numExpectedReceipts:      5,
 			numExpectedVerifications: 3,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -435,11 +444,11 @@ func receiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64) *v3TestC
 }
 
 // ReceiverQuaternaryDefaultAndSecondary returns a test case: receiver w/ default and secondary verifiers.
-func ReceiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return receiverQuaternaryDefaultAndSecondary(lib, src, dest)
+func ReceiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return receiverQuaternaryDefaultAndSecondary(lib, src, dest, cfg)
 }
 
-func receiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func receiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ default required, secondary and tertiary optional, threshold=1, message specifies default and secondary",
@@ -450,6 +459,7 @@ func receiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64) *v3Tes
 			msgData:                  []byte("multi-verifier test"),
 			numExpectedReceipts:      4,
 			numExpectedVerifications: 2,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -481,11 +491,11 @@ func receiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64) *v3Tes
 }
 
 // ReceiverQuaternaryDefaultAndTertiary returns a test case: receiver w/ default and tertiary verifiers.
-func ReceiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return receiverQuaternaryDefaultAndTertiary(lib, src, dest)
+func ReceiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return receiverQuaternaryDefaultAndTertiary(lib, src, dest, cfg)
 }
 
-func receiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func receiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ default required, secondary and tertiary optional, threshold=1, message specifies default and tertiary",
@@ -496,6 +506,7 @@ func receiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64) *v3Test
 			msgData:                  []byte("multi-verifier test"),
 			numExpectedReceipts:      4,
 			numExpectedVerifications: 2,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -527,11 +538,11 @@ func receiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64) *v3Test
 }
 
 // MaxDataSize returns a test case that sends the maximum allowed data size.
-func MaxDataSize(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return maxDataSize(lib, src, dest)
+func MaxDataSize(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return maxDataSize(lib, src, dest, cfg)
 }
 
-func maxDataSize(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func maxDataSize(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "max data size",
@@ -542,6 +553,7 @@ func maxDataSize(lib ccv.Lib, src, dest uint64) *v3TestCase {
 			numExpectedReceipts:      3,
 			expectFail:               false,
 			numExpectedVerifications: 1,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -584,11 +596,11 @@ func maxDataSize(lib ccv.Lib, src, dest uint64) *v3TestCase {
 // EOAReceiverDefaultVerifier_SafeTag returns a test case identical to EOAReceiverDefaultVerifier
 // but with the finality field set to FinalityWaitForSafe (0x00010000), exercising the Ethereum
 // `safe` head fast-confirmation path end-to-end.
-func EOAReceiverDefaultVerifier_SafeTag(lib ccv.Lib, src, dest uint64) tcapi.TestCase {
-	return eoaReceiverDefaultVerifierSafeTag(lib, src, dest)
+func EOAReceiverDefaultVerifier_SafeTag(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+	return eoaReceiverDefaultVerifierSafeTag(lib, src, dest, cfg)
 }
 
-func eoaReceiverDefaultVerifierSafeTag(lib ccv.Lib, src, dest uint64) *v3TestCase {
+func eoaReceiverDefaultVerifierSafeTag(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "EOA receiver, default committee verifier, safe-tag finality",
@@ -599,6 +611,7 @@ func eoaReceiverDefaultVerifierSafeTag(lib ccv.Lib, src, dest uint64) *v3TestCas
 			msgData:                  []byte("safe-tag finality test"),
 			numExpectedReceipts:      3,
 			numExpectedVerifications: 1,
+			sendConfig:               cfg,
 		},
 		hydrate: func(ctx context.Context, tc *v3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -634,17 +647,17 @@ func eoaReceiverDefaultVerifierSafeTag(lib ccv.Lib, src, dest uint64) *v3TestCas
 }
 
 // All returns all basic v3 messaging test cases (custom executor, multi-verifier, max data size).
-func All(lib ccv.Lib, src, dest uint64) []tcapi.TestCase {
+func All(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) []tcapi.TestCase {
 	return []tcapi.TestCase{
-		customExecutor(lib, src, dest),
-		eoaReceiverDefaultVerifier(lib, src, dest),
-		eoaReceiverDefaultVerifierSafeTag(lib, src, dest),
-		eoaReceiverSecondaryVerifier(lib, src, dest),
-		receiverSecondaryVerifierRequired(lib, src, dest),
-		receiverSecondaryRequiredTertiaryOptionalThreshold1(lib, src, dest),
-		receiverQuaternaryAllThreeVerifiers(lib, src, dest),
-		receiverQuaternaryDefaultAndSecondary(lib, src, dest),
-		receiverQuaternaryDefaultAndTertiary(lib, src, dest),
-		maxDataSize(lib, src, dest),
+		customExecutor(lib, src, dest, cfg),
+		eoaReceiverDefaultVerifier(lib, src, dest, cfg),
+		eoaReceiverDefaultVerifierSafeTag(lib, src, dest, cfg),
+		eoaReceiverSecondaryVerifier(lib, src, dest, cfg),
+		receiverSecondaryVerifierRequired(lib, src, dest, cfg),
+		receiverSecondaryRequiredTertiaryOptionalThreshold1(lib, src, dest, cfg),
+		receiverQuaternaryAllThreeVerifiers(lib, src, dest, cfg),
+		receiverQuaternaryDefaultAndSecondary(lib, src, dest, cfg),
+		receiverQuaternaryDefaultAndTertiary(lib, src, dest, cfg),
+		maxDataSize(lib, src, dest, cfg),
 	}
 }

--- a/build/devenv/tests/e2e/tcapi/basic/v3.go
+++ b/build/devenv/tests/e2e/tcapi/basic/v3.go
@@ -33,7 +33,7 @@ type v3TestCaseBase struct {
 	numExpectedReceipts      int
 	numExpectedVerifications int
 	aggregatorQualifier      string
-	sendConfig               tcapi.SendConfig
+	sendConfig               tcapi.SendArgs
 }
 
 // v3TestCase is for tests that use ExtraArgsV3.
@@ -63,11 +63,6 @@ func (tc *v3TestCase) Run(ctx context.Context) error {
 		return fmt.Errorf("destination chain not found: %d", tc.dst)
 	}
 	l := zerolog.Ctx(ctx)
-	seqNo, err := src.GetExpectedNextSequenceNumber(ctx, tc.dst)
-	if err != nil {
-		return fmt.Errorf("failed to get expected next sequence number: %w", err)
-	}
-	l.Info().Uint64("SeqNo", seqNo).Msg("Expecting sequence number")
 	sendMessageResult, err := tcapi.SendV3Message(ctx, src, dst, tc.dst,
 		cciptestinterfaces.MessageFields{
 			Receiver: tc.receiver,
@@ -86,11 +81,18 @@ func (tc *v3TestCase) Run(ctx context.Context) error {
 	if len(sendMessageResult.ReceiptIssuers) != tc.numExpectedReceipts {
 		return fmt.Errorf("expected %d receipt issuers, got %d", tc.numExpectedReceipts, len(sendMessageResult.ReceiptIssuers))
 	}
-	sentEvent, err := src.ConfirmSendOnSource(ctx, tc.dst, cciptestinterfaces.MessageEventKey{SeqNum: seqNo}, tcapi.DefaultSentTimeout)
+	if sendMessageResult.MessageID == (protocol.Bytes32{}) {
+		return fmt.Errorf("send returned zero message ID")
+	}
+	messageKey := cciptestinterfaces.MessageEventKey{MessageID: sendMessageResult.MessageID}
+	if sendMessageResult.Message != nil {
+		l.Info().Uint64("SeqNo", uint64(sendMessageResult.Message.SequenceNumber)).Msg("Sent message")
+	}
+	_, err = src.ConfirmSendOnSource(ctx, tc.dst, messageKey, tcapi.DefaultSentTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to wait for sent event: %w", err)
 	}
-	messageID := sentEvent.MessageID
+	messageID := sendMessageResult.MessageID
 
 	aggregatorClients, err := tc.lib.AllAggregators()
 	if err != nil {
@@ -126,7 +128,7 @@ func (tc *v3TestCase) Run(ctx context.Context) error {
 		return fmt.Errorf("expected %d indexed verifications, got %d", tc.numExpectedVerifications, len(result.IndexedVerifications.Results))
 	}
 
-	e, err := dst.ConfirmExecOnDest(ctx, tc.src, cciptestinterfaces.MessageEventKey{SeqNum: seqNo}, tcapi.DefaultExecTimeout)
+	e, err := dst.ConfirmExecOnDest(ctx, tc.src, messageKey, tcapi.DefaultExecTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to wait for exec event: %w", err)
 	}
@@ -151,11 +153,11 @@ func getCommitteeCCV(ds datastore.DataStore, srcChainSelector uint64, qualifier,
 }
 
 // CustomExecutor returns a test case that uses the custom executor.
-func CustomExecutor(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func CustomExecutor(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return customExecutor(lib, src, dest, cfg)
 }
 
-func customExecutor(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func customExecutor(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "custom executor",
@@ -195,11 +197,11 @@ func customExecutor(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3Test
 }
 
 // EOAReceiverDefaultVerifier returns a test case: EOA receiver and default committee verifier.
-func EOAReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func EOAReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return eoaReceiverDefaultVerifier(lib, src, dest, cfg)
 }
 
-func eoaReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func eoaReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "EOA receiver and default committee verifier",
@@ -246,11 +248,11 @@ func eoaReceiverDefaultVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendCon
 }
 
 // EOAReceiverSecondaryVerifier returns a test case: EOA receiver and secondary committee verifier.
-func EOAReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func EOAReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return eoaReceiverSecondaryVerifier(lib, src, dest, cfg)
 }
 
-func eoaReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func eoaReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "EOA receiver and secondary committee verifier",
@@ -301,11 +303,11 @@ func eoaReceiverSecondaryVerifier(lib ccv.Lib, src, dest uint64, cfg tcapi.SendC
 }
 
 // ReceiverSecondaryVerifierRequired returns a test case: receiver with secondary verifier required.
-func ReceiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func ReceiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return receiverSecondaryVerifierRequired(lib, src, dest, cfg)
 }
 
-func receiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func receiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ secondary verifier required",
@@ -345,11 +347,11 @@ func receiverSecondaryVerifierRequired(lib ccv.Lib, src, dest uint64, cfg tcapi.
 }
 
 // ReceiverSecondaryRequiredTertiaryOptionalThreshold1 returns a test case: receiver w/ secondary required and tertiary optional threshold=1.
-func ReceiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func ReceiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return receiverSecondaryRequiredTertiaryOptionalThreshold1(lib, src, dest, cfg)
 }
 
-func receiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func receiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ secondary required and tertiary optional threshold=1",
@@ -393,11 +395,11 @@ func receiverSecondaryRequiredTertiaryOptionalThreshold1(lib ccv.Lib, src, dest 
 }
 
 // ReceiverQuaternaryAllThreeVerifiers returns a test case: receiver w/ default required, secondary and tertiary optional, message specifies all three.
-func ReceiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func ReceiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return receiverQuaternaryAllThreeVerifiers(lib, src, dest, cfg)
 }
 
-func receiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func receiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ default required, secondary and tertiary optional, threshold=1, message specifies all three",
@@ -444,11 +446,11 @@ func receiverQuaternaryAllThreeVerifiers(lib ccv.Lib, src, dest uint64, cfg tcap
 }
 
 // ReceiverQuaternaryDefaultAndSecondary returns a test case: receiver w/ default and secondary verifiers.
-func ReceiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func ReceiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return receiverQuaternaryDefaultAndSecondary(lib, src, dest, cfg)
 }
 
-func receiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func receiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ default required, secondary and tertiary optional, threshold=1, message specifies default and secondary",
@@ -491,11 +493,11 @@ func receiverQuaternaryDefaultAndSecondary(lib ccv.Lib, src, dest uint64, cfg tc
 }
 
 // ReceiverQuaternaryDefaultAndTertiary returns a test case: receiver w/ default and tertiary verifiers.
-func ReceiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func ReceiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return receiverQuaternaryDefaultAndTertiary(lib, src, dest, cfg)
 }
 
-func receiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func receiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "receiver w/ default required, secondary and tertiary optional, threshold=1, message specifies default and tertiary",
@@ -538,11 +540,11 @@ func receiverQuaternaryDefaultAndTertiary(lib ccv.Lib, src, dest uint64, cfg tca
 }
 
 // MaxDataSize returns a test case that sends the maximum allowed data size.
-func MaxDataSize(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func MaxDataSize(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return maxDataSize(lib, src, dest, cfg)
 }
 
-func maxDataSize(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func maxDataSize(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "max data size",
@@ -596,11 +598,11 @@ func maxDataSize(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCas
 // EOAReceiverDefaultVerifier_SafeTag returns a test case identical to EOAReceiverDefaultVerifier
 // but with the finality field set to FinalityWaitForSafe (0x00010000), exercising the Ethereum
 // `safe` head fast-confirmation path end-to-end.
-func EOAReceiverDefaultVerifier_SafeTag(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) tcapi.TestCase {
+func EOAReceiverDefaultVerifier_SafeTag(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) tcapi.TestCase {
 	return eoaReceiverDefaultVerifierSafeTag(lib, src, dest, cfg)
 }
 
-func eoaReceiverDefaultVerifierSafeTag(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) *v3TestCase {
+func eoaReceiverDefaultVerifierSafeTag(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) *v3TestCase {
 	return &v3TestCase{
 		v3TestCaseBase: v3TestCaseBase{
 			name:                     "EOA receiver, default committee verifier, safe-tag finality",
@@ -647,7 +649,7 @@ func eoaReceiverDefaultVerifierSafeTag(lib ccv.Lib, src, dest uint64, cfg tcapi.
 }
 
 // All returns all basic v3 messaging test cases (custom executor, multi-verifier, max data size).
-func All(lib ccv.Lib, src, dest uint64, cfg tcapi.SendConfig) []tcapi.TestCase {
+func All(lib ccv.Lib, src, dest uint64, cfg tcapi.SendArgs) []tcapi.TestCase {
 	return []tcapi.TestCase{
 		customExecutor(lib, src, dest, cfg),
 		eoaReceiverDefaultVerifier(lib, src, dest, cfg),

--- a/build/devenv/tests/e2e/tcapi/token_transfer/v3.go
+++ b/build/devenv/tests/e2e/tcapi/token_transfer/v3.go
@@ -35,6 +35,7 @@ type tokenTransferV3TestCaseBase struct {
 	useEOAReceiver  bool
 	numExpectedRecv int
 	numExpectedVer  int
+	sendConfig      tcapi.SendConfig
 }
 
 type tokenTransferV3TestCase struct {
@@ -83,8 +84,7 @@ func (tc *tokenTransferV3TestCase) Run(ctx context.Context) error {
 	}
 	l.Info().Uint64("SeqNo", seqNo).Str("Token", tc.combo.LocalPoolAddressRef().Qualifier).Msg("expecting sequence number")
 
-	sendRes, err := src.SendMessage(
-		ctx, tc.dst,
+	sendRes, err := tcapi.SendV3Message(ctx, src, dst, tc.dst,
 		cciptestinterfaces.MessageFields{
 			Receiver: tc.receiver,
 			TokenAmount: cciptestinterfaces.TokenAmount{
@@ -93,11 +93,10 @@ func (tc *tokenTransferV3TestCase) Run(ctx context.Context) error {
 			},
 		},
 		cciptestinterfaces.MessageOptions{
-			ExecutionGasLimit: 200_000,
-			FinalityConfig:    tc.finalityConfig,
-			Executor:          tc.executor,
+			FinalityConfig: tc.finalityConfig,
+			Executor:       tc.executor,
 		},
-		3,
+		tc.sendConfig,
 	)
 	if err != nil {
 		return fmt.Errorf("send message: %w", err)
@@ -182,11 +181,11 @@ func getTokenAddress(ds datastore.DataStore, chainSelector uint64, qualifier str
 }
 
 // TokenTransfer returns a single token transfer test case for the given combo, finality, receiver type, and name.
-func TokenTransfer(lib ccv.Lib, src, dest uint64, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string) tcapi.TestCase {
-	return tokenTransferCase(lib, src, dest, combo, finalityConfig, useEOAReceiver, name)
+func TokenTransfer(lib ccv.Lib, src, dest uint64, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string, cfg tcapi.SendConfig) tcapi.TestCase {
+	return tokenTransferCase(lib, src, dest, combo, finalityConfig, useEOAReceiver, name, cfg)
 }
 
-func tokenTransferCase(lib ccv.Lib, src, dest uint64, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string) *tokenTransferV3TestCase {
+func tokenTransferCase(lib ccv.Lib, src, dest uint64, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string, cfg tcapi.SendConfig) *tokenTransferV3TestCase {
 	return &tokenTransferV3TestCase{
 		tokenTransferV3TestCaseBase: tokenTransferV3TestCaseBase{
 			name:            name,
@@ -198,6 +197,7 @@ func tokenTransferCase(lib ccv.Lib, src, dest uint64, combo common.TokenCombinat
 			useEOAReceiver:  useEOAReceiver,
 			numExpectedRecv: combo.ExpectedReceiptIssuers(),
 			numExpectedVer:  combo.ExpectedVerifierResults(),
+			sendConfig:      cfg,
 		},
 		hydrate: func(ctx context.Context, tc *tokenTransferV3TestCase) bool {
 			ds, err := tc.lib.DataStore()
@@ -249,17 +249,17 @@ func tokenTransferCase(lib ccv.Lib, src, dest uint64, combo common.TokenCombinat
 }
 
 // All returns test cases for the given token combinations with EOA receiver and combo finality.
-func All(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination) []tcapi.TestCase {
+func All(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination, cfg tcapi.SendConfig) []tcapi.TestCase {
 	out := make([]tcapi.TestCase, 0, len(combos))
 	for _, combo := range combos {
 		name := fmt.Sprintf("token transfer EOA (%s)", combo.LocalPoolAddressRef().Qualifier)
-		out = append(out, tokenTransferCase(lib, src, dest, combo, combo.FinalityConfig(), true, name))
+		out = append(out, tokenTransferCase(lib, src, dest, combo, combo.FinalityConfig(), true, name, cfg))
 	}
 	return out
 }
 
 // All17 returns test cases for 2.0.0-only token combinations: EOA and mock receiver with default finality (0).
-func All17(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination) []tcapi.TestCase {
+func All17(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination, cfg tcapi.SendConfig) []tcapi.TestCase {
 	var filtered []common.TokenCombination
 	for _, tc := range combos {
 		if common.Is17Combination(tc) {
@@ -270,8 +270,8 @@ func All17(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination) []tc
 	for _, combo := range filtered {
 		qual := combo.LocalPoolAddressRef().Qualifier
 		out = append(out,
-			tokenTransferCase(lib, src, dest, combo, 0, true, fmt.Sprintf("token transfer 1.7.0 EOA default finality (%s)", qual)),
-			tokenTransferCase(lib, src, dest, combo, 0, false, fmt.Sprintf("token transfer 1.7.0 mock receiver default finality (%s)", qual)),
+			tokenTransferCase(lib, src, dest, combo, 0, true, fmt.Sprintf("token transfer 1.7.0 EOA default finality (%s)", qual), cfg),
+			tokenTransferCase(lib, src, dest, combo, 0, false, fmt.Sprintf("token transfer 1.7.0 mock receiver default finality (%s)", qual), cfg),
 		)
 	}
 	return out

--- a/build/devenv/tests/e2e/tcapi/token_transfer/v3.go
+++ b/build/devenv/tests/e2e/tcapi/token_transfer/v3.go
@@ -35,7 +35,7 @@ type tokenTransferV3TestCaseBase struct {
 	useEOAReceiver  bool
 	numExpectedRecv int
 	numExpectedVer  int
-	sendConfig      tcapi.SendConfig
+	sendConfig      tcapi.SendArgs
 }
 
 type tokenTransferV3TestCase struct {
@@ -78,12 +78,6 @@ func (tc *tokenTransferV3TestCase) Run(ctx context.Context) error {
 	}
 	l.Info().Str("Sender", tc.sender.String()).Uint64("SrcStartBalance", srcStartBal.Uint64()).Str("Token", tc.combo.LocalPoolAddressRef().Qualifier).Msg("sender start balance")
 
-	seqNo, err := src.GetExpectedNextSequenceNumber(ctx, tc.dst)
-	if err != nil {
-		return fmt.Errorf("get expected next sequence number: %w", err)
-	}
-	l.Info().Uint64("SeqNo", seqNo).Str("Token", tc.combo.LocalPoolAddressRef().Qualifier).Msg("expecting sequence number")
-
 	sendRes, err := tcapi.SendV3Message(ctx, src, dst, tc.dst,
 		cciptestinterfaces.MessageFields{
 			Receiver: tc.receiver,
@@ -104,12 +98,18 @@ func (tc *tokenTransferV3TestCase) Run(ctx context.Context) error {
 	if len(sendRes.ReceiptIssuers) != tc.numExpectedRecv {
 		return fmt.Errorf("expected %d receipt issuers, got %d", tc.numExpectedRecv, len(sendRes.ReceiptIssuers))
 	}
-
-	sentEvt, err := src.ConfirmSendOnSource(ctx, tc.dst, cciptestinterfaces.MessageEventKey{SeqNum: seqNo}, tcapi.DefaultSentTimeout)
+	if sendRes.MessageID == (protocol.Bytes32{}) {
+		return fmt.Errorf("send returned zero message ID")
+	}
+	messageKey := cciptestinterfaces.MessageEventKey{MessageID: sendRes.MessageID}
+	if sendRes.Message != nil {
+		l.Info().Uint64("SeqNo", uint64(sendRes.Message.SequenceNumber)).Str("Token", tc.combo.LocalPoolAddressRef().Qualifier).Msg("sent message")
+	}
+	_, err = src.ConfirmSendOnSource(ctx, tc.dst, messageKey, tcapi.DefaultSentTimeout)
 	if err != nil {
 		return fmt.Errorf("wait for sent event: %w", err)
 	}
-	msgID := sentEvt.MessageID
+	msgID := sendRes.MessageID
 
 	aggregatorClients, err := tc.lib.AllAggregators()
 	if err != nil {
@@ -137,7 +137,7 @@ func (tc *tokenTransferV3TestCase) Run(ctx context.Context) error {
 		return fmt.Errorf("aggregated result is nil")
 	}
 
-	execEvt, err := dst.ConfirmExecOnDest(ctx, tc.src, cciptestinterfaces.MessageEventKey{SeqNum: seqNo}, tokenTransferExecTimeout)
+	execEvt, err := dst.ConfirmExecOnDest(ctx, tc.src, messageKey, tokenTransferExecTimeout)
 	if err != nil {
 		return fmt.Errorf("wait for exec event: %w", err)
 	}
@@ -181,11 +181,11 @@ func getTokenAddress(ds datastore.DataStore, chainSelector uint64, qualifier str
 }
 
 // TokenTransfer returns a single token transfer test case for the given combo, finality, receiver type, and name.
-func TokenTransfer(lib ccv.Lib, src, dest uint64, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string, cfg tcapi.SendConfig) tcapi.TestCase {
+func TokenTransfer(lib ccv.Lib, src, dest uint64, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string, cfg tcapi.SendArgs) tcapi.TestCase {
 	return tokenTransferCase(lib, src, dest, combo, finalityConfig, useEOAReceiver, name, cfg)
 }
 
-func tokenTransferCase(lib ccv.Lib, src, dest uint64, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string, cfg tcapi.SendConfig) *tokenTransferV3TestCase {
+func tokenTransferCase(lib ccv.Lib, src, dest uint64, combo common.TokenCombination, finalityConfig protocol.Finality, useEOAReceiver bool, name string, cfg tcapi.SendArgs) *tokenTransferV3TestCase {
 	return &tokenTransferV3TestCase{
 		tokenTransferV3TestCaseBase: tokenTransferV3TestCaseBase{
 			name:            name,
@@ -249,7 +249,7 @@ func tokenTransferCase(lib ccv.Lib, src, dest uint64, combo common.TokenCombinat
 }
 
 // All returns test cases for the given token combinations with EOA receiver and combo finality.
-func All(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination, cfg tcapi.SendConfig) []tcapi.TestCase {
+func All(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination, cfg tcapi.SendArgs) []tcapi.TestCase {
 	out := make([]tcapi.TestCase, 0, len(combos))
 	for _, combo := range combos {
 		name := fmt.Sprintf("token transfer EOA (%s)", combo.LocalPoolAddressRef().Qualifier)
@@ -259,7 +259,7 @@ func All(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination, cfg tc
 }
 
 // All17 returns test cases for 2.0.0-only token combinations: EOA and mock receiver with default finality (0).
-func All17(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination, cfg tcapi.SendConfig) []tcapi.TestCase {
+func All17(lib ccv.Lib, src, dest uint64, combos []common.TokenCombination, cfg tcapi.SendArgs) []tcapi.TestCase {
 	var filtered []common.TokenCombination
 	for _, tc := range combos {
 		if common.Is17Combination(tc) {

--- a/build/devenv/tests/e2e/tcapi/types.go
+++ b/build/devenv/tests/e2e/tcapi/types.go
@@ -39,8 +39,8 @@ type TestCase interface {
 // DefaultV3ExecutionGasLimit is the execution gas limit used when SendConfig and MessageOptions omit it.
 const DefaultV3ExecutionGasLimit uint32 = 200_000
 
-// SendConfig holds pair-level settings for building and sending V3 CCIP messages in tcapi tests.
-type SendConfig struct {
+// SendArgs holds pair-level settings for building and sending ExtraArgsV3 CCIP messages in tcapi tests.
+type SendArgs struct {
 	ExecutionGasLimit   uint32 // 0: use opts if set, else DefaultV3ExecutionGasLimit
 	ExtraArgsParams     any    // passed to dest MessageV3Destination.GetExecutorArgs
 	TokenArgsParams     any    // passed to dest GetTokenArgs
@@ -55,7 +55,7 @@ func SendV3Message(
 	destSelector uint64,
 	fields cciptestinterfaces.MessageFields,
 	opts cciptestinterfaces.MessageOptions,
-	cfg SendConfig,
+	sendArgs SendArgs,
 ) (cciptestinterfaces.MessageSentEvent, error) {
 	chainAsSource, ok := src.(cciptestinterfaces.ChainAsSource)
 	if !ok {
@@ -70,13 +70,13 @@ func SendV3Message(
 		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("dest chain does not support V3 message")
 	}
 
-	if cfg.ExecutionGasLimit != 0 {
-		opts.ExecutionGasLimit = cfg.ExecutionGasLimit
+	if sendArgs.ExecutionGasLimit != 0 {
+		opts.ExecutionGasLimit = sendArgs.ExecutionGasLimit
 	} else if opts.ExecutionGasLimit == 0 {
 		opts.ExecutionGasLimit = DefaultV3ExecutionGasLimit
 	}
 
-	extraArgs, err := v3Source.BuildV3ExtraArgs(opts, v3Dest, cfg.ExtraArgsParams, cfg.TokenReceiverParams, cfg.TokenArgsParams)
+	extraArgs, err := v3Source.BuildV3ExtraArgs(opts, v3Dest, sendArgs.ExtraArgsParams, sendArgs.TokenReceiverParams, sendArgs.TokenArgsParams)
 	if err != nil {
 		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("failed to encode V3 extra args: %w", err)
 	}
@@ -86,7 +86,7 @@ func SendV3Message(
 		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("failed to build chain message: %w", err)
 	}
 
-	sent, _, err := chainAsSource.SendChainMessage(ctx, destSelector, msg, cfg.SendOption)
+	sent, _, err := chainAsSource.SendChainMessage(ctx, destSelector, msg, sendArgs.SendOption)
 	if err != nil {
 		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("failed to send chain message: %w", err)
 	}

--- a/build/devenv/tests/e2e/tcapi/types.go
+++ b/build/devenv/tests/e2e/tcapi/types.go
@@ -36,6 +36,63 @@ type TestCase interface {
 	HavePrerequisites(ctx context.Context) bool
 }
 
+// DefaultV3ExecutionGasLimit is the execution gas limit used when SendConfig and MessageOptions omit it.
+const DefaultV3ExecutionGasLimit uint32 = 200_000
+
+// SendConfig holds pair-level settings for building and sending V3 CCIP messages in tcapi tests.
+type SendConfig struct {
+	ExecutionGasLimit   uint32 // 0: use opts if set, else DefaultV3ExecutionGasLimit
+	ExtraArgsParams     any    // passed to dest MessageV3Destination.GetExecutorArgs
+	TokenArgsParams     any    // passed to dest GetTokenArgs
+	TokenReceiverParams any    // passed to dest GetTokenReceiver
+	SendOption          cciptestinterfaces.ChainSendOption
+}
+
+// SendV3Message builds and sends a V3 message using BuildV3ExtraArgs, BuildChainMessage, and SendChainMessage.
+func SendV3Message(
+	ctx context.Context,
+	src, dst cciptestinterfaces.CCIP17,
+	destSelector uint64,
+	fields cciptestinterfaces.MessageFields,
+	opts cciptestinterfaces.MessageOptions,
+	cfg SendConfig,
+) (cciptestinterfaces.MessageSentEvent, error) {
+	chainAsSource, ok := src.(cciptestinterfaces.ChainAsSource)
+	if !ok {
+		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("source chain does not implement ChainAsSource")
+	}
+	v3Source, ok := src.(cciptestinterfaces.MessageV3Source)
+	if !ok {
+		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("source chain does not support V3 message")
+	}
+	v3Dest, ok := dst.(cciptestinterfaces.MessageV3Destination)
+	if !ok {
+		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("dest chain does not support V3 message")
+	}
+
+	if cfg.ExecutionGasLimit != 0 {
+		opts.ExecutionGasLimit = cfg.ExecutionGasLimit
+	} else if opts.ExecutionGasLimit == 0 {
+		opts.ExecutionGasLimit = DefaultV3ExecutionGasLimit
+	}
+
+	extraArgs, err := v3Source.BuildV3ExtraArgs(opts, v3Dest, cfg.ExtraArgsParams, cfg.TokenReceiverParams, cfg.TokenArgsParams)
+	if err != nil {
+		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("failed to encode V3 extra args: %w", err)
+	}
+
+	msg, err := chainAsSource.BuildChainMessage(ctx, fields, extraArgs)
+	if err != nil {
+		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("failed to build chain message: %w", err)
+	}
+
+	sent, _, err := chainAsSource.SendChainMessage(ctx, destSelector, msg, cfg.SendOption)
+	if err != nil {
+		return cciptestinterfaces.MessageSentEvent{}, fmt.Errorf("failed to send chain message: %w", err)
+	}
+	return sent, nil
+}
+
 type TestingContext struct {
 	Ctx              context.Context
 	Impl             map[uint64]cciptestinterfaces.CCIP17

--- a/changelog/2026-06-02_tcapi_v3_send_config.md
+++ b/changelog/2026-06-02_tcapi_v3_send_config.md
@@ -6,6 +6,7 @@
 - Introduces `tcapi.SendConfig` so callers supply pair-level execution gas, destination-shaped extra-args parameters (`any`), and optional `ChainSendOption` without importing chain-family types into generic test code.
 - Affects `build/devenv/tests/e2e/tcapi`, `tcapi/basic`, `tcapi/token_transfer`, and in-repo smoke tests that call `basic.All` / `token_transfer.All` / `All17`.
 - Breaking: `basic.All`, all exported `basic.*` case constructors, `token_transfer.All`, `token_transfer.All17`, and `token_transfer.TokenTransfer` gain a final `tcapi.SendConfig` parameter. `tcapi.TestCase` (`Run` / `HavePrerequisites`) is unchanged.
+- Behavior: TCAPI `Run` no longer calls `GetExpectedNextSequenceNumber`; `ConfirmSendOnSource` / `ConfirmExecOnDest` use `MessageEventKey{MessageID: ...}` from `SendV3Message` (aligns with `MessageV3TestScenario`).
 
 ## AI Adapter Index
 
@@ -37,6 +38,7 @@ The expected consumer of this changelog is an AI adapting a downstream repo. Thi
 | `tcapi.SendV3Message` | added | `\btcapi\.SendV3Message\(` | `build/devenv/tests/e2e/tcapi/types.go:52` | [#sendconfig-and-sendv3message](#sendconfig-and-sendv3message) |
 | `tcapi.TestCase.Run` | unchanged | — | `build/devenv/tests/e2e/tcapi/types.go:29` | — |
 | `tcapi.TestCase.HavePrerequisites` | unchanged | — | `build/devenv/tests/e2e/tcapi/types.go:36` | — |
+| TCAPI `Run` confirm path (`GetExpectedNextSequenceNumber` removed) | behavior-changed | `GetExpectedNextSequenceNumber` in `tcapi/` | `build/devenv/tests/e2e/tcapi/basic/v3.go:52` | [#tcapi-confirm-by-message-id](#tcapi-confirm-by-message-id) |
 
 ## Breaking Changes
 
@@ -68,6 +70,14 @@ The expected consumer of this changelog is an AI adapting a downstream repo. Thi
 - **After:** Both call `tcapi.SendV3Message`, which type-asserts `MessageV3Source` / `MessageV3Destination` / `ChainAsSource` and runs `BuildV3ExtraArgs` → `BuildChainMessage` → `SendChainMessage`.
 - **Why:** Aligns importable tests with composable chain interfaces and removes dependence on deprecated `SendMessage` for the tcapi packages.
 - **Who is affected:** Consumers relying on side effects of `SendMessage` inside TCAPI cases only; external callers of `TestCase.Run` see the same success/failure semantics for EVM→EVM with empty `SendConfig`.
+
+### TCAPI confirm by message ID
+
+- **What changed:** `v3TestCase.Run` and `tokenTransferV3TestCase.Run` no longer call `GetExpectedNextSequenceNumber` before send. After `tcapi.SendV3Message`, both `ConfirmSendOnSource` and `ConfirmExecOnDest` use `cciptestinterfaces.MessageEventKey{MessageID: sendResult.MessageID}` (same pattern as `messaging.MessageV3TestScenario`).
+- **Before:** Pre-read expected sequence number; confirm send/exec with `MessageEventKey{SeqNum: seqNo}`; take `messageID` from `ConfirmSendOnSource` for aggregator asserts.
+- **After:** `messageID` comes from `SendV3Message` / `SendChainMessage`; confirms key off that ID. Optional seq logging uses `sendResult.Message.SequenceNumber` when present.
+- **Why:** Reduces required chain API surface for importable tests (`GetExpectedNextSequenceNumber` is on full `CCIP17` / `Chain`, not `ChainAsSource`). Avoids seq races when another message lands on the lane between pre-read and send. Matches composable messaging tests.
+- **Who is affected:** Downstream code that assumed TCAPI cases depended on `GetExpectedNextSequenceNumber` (they no longer do). Other e2e tests outside `tcapi/basic` and `tcapi/token_transfer` are unchanged.
 
 ## Migration Guide
 
@@ -125,6 +135,12 @@ The expected consumer of this changelog is an AI adapting a downstream repo. Thi
 - **`tcapi.SendV3Message`** — shared helper: assert composable interfaces, merge gas from `SendConfig` / `MessageOptions`, `BuildV3ExtraArgs`, `BuildChainMessage`, `SendChainMessage`. See `build/devenv/tests/e2e/tcapi/types.go:52`.
   - Usage: optional direct use in custom test drivers; TCAPI `basic` and `token_transfer` already call it from `Run`.
 
+## Compatibility & Requirements
+
+- **Non-zero `MessageID` on send:** `MessageEventKey` requires either a non-zero `MessageID` or non-zero `SeqNum` (`cciptestinterfaces` validation in `ConfirmSendOnSource` / `ConfirmExecOnDest`). Every `ChainAsSource.SendChainMessage` implementation used with TCAPI must populate `MessageSentEvent.MessageID` on success. TCAPI `Run` returns an error if send succeeds but `MessageID` is zero. EVM does this from the tx receipt; verify Solana/Canton (and any new source) before running cross-family TCAPI suites.
+- **`GetExpectedNextSequenceNumber`:** Still exists on `cciptestinterfaces.Chain` / `CCIP17` for other e2e tests; TCAPI importable cases no longer call it.
+- **Confirm after send:** TCAPI still calls `ConfirmSendOnSource` after `SendV3Message` so log polling can observe the on-chain sent event (same as `MessageV3TestScenario`), even when the send path already returns `MessageID`.
+
 ## Examples
 
 ```go
@@ -146,4 +162,4 @@ require.NoError(t, tc.Run(ctx))
 ## References
 
 - Prior changelog entries: `changelog/2026-04-27_extra_args_data_provider.md`, `changelog/2026-05-18_simplify_tcapi.md`
-- Composable send reference: `build/devenv/tests/composable/messaging/agnostic_chain_test.go` (`MessageV3TestScenario`)
+- Composable send/confirm reference: `build/devenv/tests/composable/messaging/agnostic_chain_test.go` (`MessageV3TestScenario` uses `MessageEventKey{MessageID: sentEvent.MessageID}`)

--- a/changelog/2026-06-02_tcapi_v3_send_config.md
+++ b/changelog/2026-06-02_tcapi_v3_send_config.md
@@ -1,0 +1,149 @@
+# TCAPI V3 send path: `SendConfig` and composable send APIs
+
+## Executive Summary
+
+- Migrates importable TCAPI test cases in `basic` and `token_transfer` from deprecated `Chain.SendMessage` to `BuildV3ExtraArgs` + `BuildChainMessage` + `SendChainMessage` via a shared `tcapi.SendV3Message` helper.
+- Introduces `tcapi.SendConfig` so callers supply pair-level execution gas, destination-shaped extra-args parameters (`any`), and optional `ChainSendOption` without importing chain-family types into generic test code.
+- Affects `build/devenv/tests/e2e/tcapi`, `tcapi/basic`, `tcapi/token_transfer`, and in-repo smoke tests that call `basic.All` / `token_transfer.All` / `All17`.
+- Breaking: `basic.All`, all exported `basic.*` case constructors, `token_transfer.All`, `token_transfer.All17`, and `token_transfer.TokenTransfer` gain a final `tcapi.SendConfig` parameter. `tcapi.TestCase` (`Run` / `HavePrerequisites`) is unchanged.
+
+## AI Adapter Index
+
+The expected consumer of this changelog is an AI adapting a downstream repo. This table is its entry point: every symbol or behavior touched gets one row, with a grep pattern for finding consumer call sites and an anchor into the rest of this file for migration detail. The AI is expected to:
+
+1. Read this table.
+2. Run each `Search` pattern against the consumer repo.
+3. For rows that produce hits, read **only** the linked `Section`. Skip rows with zero hits.
+4. Treat any symbol *not* listed here as unchanged — do not load source for it.
+
+| Symbol | Kind | Search | Location | Section |
+|---|---|---|---|---|
+| `basic.All` | signature-changed | `basic\.All\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:650` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.CustomExecutor` | signature-changed | `basic\.CustomExecutor\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:154` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.EOAReceiverDefaultVerifier` | signature-changed | `basic\.EOAReceiverDefaultVerifier\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:198` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.EOAReceiverSecondaryVerifier` | signature-changed | `basic\.EOAReceiverSecondaryVerifier\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:249` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.ReceiverSecondaryVerifierRequired` | signature-changed | `basic\.ReceiverSecondaryVerifierRequired\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:304` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.ReceiverSecondaryRequiredTertiaryOptionalThreshold1` | signature-changed | `basic\.ReceiverSecondaryRequiredTertiaryOptionalThreshold1\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:348` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.ReceiverQuaternaryAllThreeVerifiers` | signature-changed | `basic\.ReceiverQuaternaryAllThreeVerifiers\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:396` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.ReceiverQuaternaryDefaultAndSecondary` | signature-changed | `basic\.ReceiverQuaternaryDefaultAndSecondary\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:447` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.ReceiverQuaternaryDefaultAndTertiary` | signature-changed | `basic\.ReceiverQuaternaryDefaultAndTertiary\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:494` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.MaxDataSize` | signature-changed | `basic\.MaxDataSize\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:541` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `basic.EOAReceiverDefaultVerifier_SafeTag` | signature-changed | `basic\.EOAReceiverDefaultVerifier_SafeTag\(` | `build/devenv/tests/e2e/tcapi/basic/v3.go:599` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `token_transfer.All` | signature-changed | `token_transfer\.All\(` | `build/devenv/tests/e2e/tcapi/token_transfer/v3.go:252` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `token_transfer.All17` | signature-changed | `token_transfer\.All17\(` | `build/devenv/tests/e2e/tcapi/token_transfer/v3.go:262` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `token_transfer.TokenTransfer` | signature-changed | `token_transfer\.TokenTransfer\(` | `build/devenv/tests/e2e/tcapi/token_transfer/v3.go:184` | [#basic-and-token-transfer-constructors](#basic-and-token-transfer-constructors) |
+| `tcapi.SendConfig` | added | `\btcapi\.SendConfig\b` | `build/devenv/tests/e2e/tcapi/types.go:44` | [#sendconfig-and-sendv3message](#sendconfig-and-sendv3message) |
+| `tcapi.DefaultV3ExecutionGasLimit` | added | `\bDefaultV3ExecutionGasLimit\b` | `build/devenv/tests/e2e/tcapi/types.go:40` | [#sendconfig-and-sendv3message](#sendconfig-and-sendv3message) |
+| `tcapi.SendV3Message` | added | `\btcapi\.SendV3Message\(` | `build/devenv/tests/e2e/tcapi/types.go:52` | [#sendconfig-and-sendv3message](#sendconfig-and-sendv3message) |
+| `tcapi.TestCase.Run` | unchanged | — | `build/devenv/tests/e2e/tcapi/types.go:29` | — |
+| `tcapi.TestCase.HavePrerequisites` | unchanged | — | `build/devenv/tests/e2e/tcapi/types.go:36` | — |
+
+## Breaking Changes
+
+### Basic and token-transfer constructors
+
+- **What changed:** Every `basic` case factory and `token_transfer` suite entry point now takes `cfg tcapi.SendConfig` as the last argument.
+- **Before:**
+  ```go
+  basic.All(lib, srcSelector, destSelector)
+  basic.EOAReceiverDefaultVerifier(lib, srcSelector, destSelector)
+  token_transfer.All(lib, srcSelector, destSelector, combos)
+  token_transfer.All17(lib, srcSelector, destSelector, combos)
+  token_transfer.TokenTransfer(lib, src, dest, combo, finality, useEOA, name)
+  ```
+- **After:**
+  ```go
+  basic.All(lib, srcSelector, destSelector, cfg)
+  basic.EOAReceiverDefaultVerifier(lib, srcSelector, destSelector, cfg)
+  token_transfer.All(lib, srcSelector, destSelector, combos, cfg)
+  token_transfer.All17(lib, srcSelector, destSelector, combos, cfg)
+  token_transfer.TokenTransfer(lib, src, dest, combo, finality, useEOA, name, cfg)
+  ```
+- **Why:** Pair-specific V3 extra-args construction (gas limit, destination `GetExecutorArgs` / `GetTokenArgs` / `GetTokenReceiver` inputs) must be supplied by the test driver without embedding chain-family types inside generic TCAPI `Run` logic. `SendConfig` is threaded from `All()` or single-case constructors into each test case struct and consumed at send time after `hydrate` fills `MessageOptions` (executor, CCVs, etc.).
+- **Who is affected:** Any downstream repo that imports `github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi/basic` or `.../token_transfer` and calls the listed constructors. In-repo smoke tests updated at `build/devenv/tests/e2e/smoke_test.go`.
+
+### TCAPI case send implementation (behavior, not public API)
+
+- **What changed:** `v3TestCase.Run` and `tokenTransferV3TestCase.Run` no longer call `src.SendMessage(..., messageVersion 3)`.
+- **After:** Both call `tcapi.SendV3Message`, which type-asserts `MessageV3Source` / `MessageV3Destination` / `ChainAsSource` and runs `BuildV3ExtraArgs` → `BuildChainMessage` → `SendChainMessage`.
+- **Why:** Aligns importable tests with composable chain interfaces and removes dependence on deprecated `SendMessage` for the tcapi packages.
+- **Who is affected:** Consumers relying on side effects of `SendMessage` inside TCAPI cases only; external callers of `TestCase.Run` see the same success/failure semantics for EVM→EVM with empty `SendConfig`.
+
+## Migration Guide
+
+1. Add `tcapi` import if not already present:
+   ```go
+   "github.com/smartcontractkit/chainlink-ccv/build/devenv/tests/e2e/tcapi"
+   ```
+
+2. Define pair-level send settings once per `(src, dest)` lane (or per test binary):
+   ```go
+   sendCfg := tcapi.SendConfig{} // EVM→EVM: default 200k gas, nil dest extra-args params
+   ```
+
+3. Pass `sendCfg` into suite constructors:
+   ```go
+   // Before
+   cases := basic.All(lib, srcSel, destSel)
+
+   // After
+   cases := basic.All(lib, srcSel, destSel, sendCfg)
+   ```
+
+4. Update single-case constructors the same way:
+   ```go
+   // Before
+   tc := basic.MaxDataSize(lib, srcSel, destSel)
+
+   // After
+   tc := basic.MaxDataSize(lib, srcSel, destSel, sendCfg)
+   ```
+
+5. For cross-family lanes (e.g. EVM source → Solana destination), populate `SendConfig` at the driver — not inside `basic` / `token_transfer` packages:
+   ```go
+   sendCfg := tcapi.SendConfig{
+       ExecutionGasLimit: 500_000,
+       ExtraArgsParams:     svmExecutorArgs, // type expected by dest GetExecutorArgs
+   }
+   cases := basic.All(lib, evmSel, solSel, sendCfg)
+   ```
+   Product repos own the concrete `ExtraArgsParams` / `TokenArgsParams` / `TokenReceiverParams` values; TCAPI `hydrate` remains EVM-centric for prerequisites until a separate change lands.
+
+6. `Run` and `HavePrerequisites` are unchanged — no updates to subtest loops beyond constructor calls:
+   ```go
+   if tc.HavePrerequisites(ctx) {
+       require.NoError(t, tc.Run(ctx))
+   }
+   ```
+
+## New Features / Additions
+
+### `SendConfig` and `SendV3Message`
+
+- **`tcapi.SendConfig`** — pair-level settings for V3 sends in TCAPI tests. Fields: `ExecutionGasLimit` (0 → use `MessageOptions` if set, else `DefaultV3ExecutionGasLimit`), `ExtraArgsParams`, `TokenArgsParams`, `TokenReceiverParams` (passed through to `MessageV3Source.BuildV3ExtraArgs` and destination `Get*` methods), `SendOption` (`cciptestinterfaces.ChainSendOption` for `SendChainMessage`). See `build/devenv/tests/e2e/tcapi/types.go:44`.
+- **`tcapi.DefaultV3ExecutionGasLimit`** — `200_000`; matches prior hardcoded gas in TCAPI `Run` methods. See `build/devenv/tests/e2e/tcapi/types.go:40`.
+- **`tcapi.SendV3Message`** — shared helper: assert composable interfaces, merge gas from `SendConfig` / `MessageOptions`, `BuildV3ExtraArgs`, `BuildChainMessage`, `SendChainMessage`. See `build/devenv/tests/e2e/tcapi/types.go:52`.
+  - Usage: optional direct use in custom test drivers; TCAPI `basic` and `token_transfer` already call it from `Run`.
+
+## Examples
+
+```go
+// EVM→EVM smoke (behavior-neutral vs prior SendMessage path)
+sendCfg := tcapi.SendConfig{}
+for _, tc := range basic.All(lib, src.ChainSelector(), dest.ChainSelector(), sendCfg) {
+    if tc.HavePrerequisites(ctx) {
+        require.NoError(t, tc.Run(ctx))
+    }
+}
+```
+
+```go
+// Single imported case with default pair config
+tc := basic.EOAReceiverDefaultVerifier(lib, srcSel, destSel, tcapi.SendConfig{})
+require.NoError(t, tc.Run(ctx))
+```
+
+## References
+
+- Prior changelog entries: `changelog/2026-04-27_extra_args_data_provider.md`, `changelog/2026-05-18_simplify_tcapi.md`
+- Composable send reference: `build/devenv/tests/composable/messaging/agnostic_chain_test.go` (`MessageV3TestScenario`)


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

The `SendMessage` API is now deprecated in favor of BuildChainMessage and SendChainMessage, so that extra arg construction is properly cross-family.

In order for the standard test cases in tcapi to be used for AltVMs they need to use this newer API.


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

The TestE2ESmoke_Basic test now uses these new primitives instead of SendMessage, through its usage of tcapi.


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
