### PR TITLE
build/devenv: ignore --build when --profile is absent in ccv test

### DIFF
--- a/build/devenv/cli/ccv.go
+++ b/build/devenv/cli/ccv.go
@@ -478,10 +478,7 @@ Examples:
 		if len(args) > 0 && patternFlag != "" {
 			return fmt.Errorf("cannot combine a suite name with --pattern")
 		}
-		buildEnabled := buildTarget != "" && buildTarget != "false"
-		if buildEnabled && profileName == "" {
-			return fmt.Errorf("--build requires --profile")
-		}
+		buildEnabled := buildTarget != "" && buildTarget != "false" && profileName != ""
 
 		// Resolve the Go test pattern and target directory.
 		var testPattern, testDir string
@@ -914,7 +911,7 @@ func init() {
 	testCmd.Flags().StringP("profile", "p", "", "Profile to start before running tests (also sets per-run output file)")
 	testCmd.Flags().StringP("pattern", "r", "", "Raw Go test pattern (alternative to a named suite positional arg)")
 	testCmd.Flags().Duration("timeout", 0, "Test timeout (0 = unlimited)")
-	testCmd.Flags().String("build", "build-docker", "Just target to build Docker images before starting (e.g. build-docker, build-docker-ci); pass 'false' to skip (requires --profile)")
+	testCmd.Flags().String("build", "build-docker", "Just target to build Docker images before starting (e.g. build-docker, build-docker-ci); pass 'false' to skip; silently ignored when --profile is absent")
 	testCmd.Flags().String("log", "", "Write verbose output (build, env, test) to this file; only progress lines appear on the terminal")
 	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(indexerDBShellCmd)

--- a/changelog/2026-06-03_ccv_profiles_and_test.md
+++ b/changelog/2026-06-03_ccv_profiles_and_test.md
@@ -117,7 +117,7 @@ Named suite aliases (positional arg): `smoke`, `smoke-v2`, `smoke-v3`, `load`,
 |------|---------|-------|
 | `--profile` / `-p` | — | Profile to start before running; sets per-run output file |
 | `--pattern` / `-r` | — | Raw Go `-run` pattern; mutually exclusive with suite name |
-| `--build` | `true` | Build Docker images first (requires `--profile`); pass `--build=false` to skip |
+| `--build` | `build-docker` | Build Docker images first; silently ignored when `--profile` is absent; pass `--build=false` to skip |
 | `--timeout` | `0` (unlimited) | Passed to `go test -timeout` |
 | `--log <path>` | — | Write all output to file; terminal shows only progress lines |
 


### PR DESCRIPTION


<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
Fold the profile guard into the buildEnabled expression so that passing --build without --profile silently skips the build step instead of returning an error. This lets users run ccv test without --profile and without having to explicitly pass --build=false.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing
n/a

<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
