### PR TITLE
build/devenv: add per-component timing metrics to phased runtime

### DIFF
--- a/build/devenv/environment_phased.go
+++ b/build/devenv/environment_phased.go
@@ -36,6 +36,10 @@ func NewPhasedEnvironment() (out map[string]any, err error) {
 
 	// out is captured by the defer; its contents are available when the defer fires.
 	defer func() {
+		if ct, ok := out["_component_timings"].(*timing.ComponentTimeTracker); ok && ct != nil {
+			// TODO: report component timings via DX tracker
+			ct.Print(L)
+		}
 		var elapsed float64
 		if timeTrack, ok := out["_time_track"].(*timing.TimeTracker); ok && timeTrack != nil {
 			timeTrack.Print()

--- a/build/devenv/runtime/environment.go
+++ b/build/devenv/runtime/environment.go
@@ -6,8 +6,11 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/timing"
 )
 
 // NewEnvironment runs the environment startup using the global registry.
@@ -74,6 +77,7 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 		return nil, fmt.Errorf("unclaimed config keys: %v", keys)
 	}
 	accumulated := map[string]any{}
+	compTimings := timing.NewComponentTimeTracker()
 
 	// Phase 1 (no priorOutputs by interface; merge rules still apply).
 	{
@@ -85,7 +89,9 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 			}
 			comp := specific[key]
 			if p1, ok := comp.(Phase1Component); ok {
+				start := time.Now()
 				out, effects, err := p1.RunPhase1(ctx, rawConfig, rawConfig[key])
+				compTimings.Record(phase, key, start, time.Now())
 				if err != nil {
 					return nil, fmt.Errorf("phase1 %s: %w", key, err)
 				}
@@ -111,7 +117,9 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 			}
 			comp := specific[key]
 			if p2, ok := comp.(Phase2Component); ok {
+				start := time.Now()
 				out, effects, err := p2.RunPhase2(ctx, rawConfig, rawConfig[key], maps.Clone(phaseSnapshot))
+				compTimings.Record(phase, key, start, time.Now())
 				if err != nil {
 					return nil, fmt.Errorf("phase2 %s: %w", key, err)
 				}
@@ -137,7 +145,9 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 			}
 			comp := specific[key]
 			if p3, ok := comp.(Phase3Component); ok {
+				start := time.Now()
 				out, effects, err := p3.RunPhase3(ctx, rawConfig, rawConfig[key], maps.Clone(phaseSnapshot))
+				compTimings.Record(phase, key, start, time.Now())
 				if err != nil {
 					return nil, fmt.Errorf("phase3 %s: %w", key, err)
 				}
@@ -163,7 +173,9 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 			}
 			comp := specific[key]
 			if p4, ok := comp.(Phase4Component); ok {
+				start := time.Now()
 				out, effects, err := p4.RunPhase4(ctx, rawConfig, rawConfig[key], maps.Clone(phaseSnapshot))
+				compTimings.Record(phase, key, start, time.Now())
 				if err != nil {
 					return nil, fmt.Errorf("phase4 %s: %w", key, err)
 				}
@@ -178,6 +190,8 @@ func NewEnvironmentWithRegistry(ctx context.Context, rawConfig map[string]any, r
 		}
 	}
 
+	// TODO: add per-phase effect executor timing
+	accumulated["_component_timings"] = compTimings
 	return accumulated, nil
 }
 

--- a/build/devenv/timing/timing.go
+++ b/build/devenv/timing/timing.go
@@ -1,7 +1,6 @@
-// Package timing provides a simple wall-clock interval tracker used to
-// profile devenv startup phases. It is isolated from the root ccv package
-// so that components can import it without pulling in the full devenv
-// dependency graph.
+// Package timing provides wall-clock trackers used to profile devenv startup.
+// It is isolated from the root ccv package so that components can import it
+// without pulling in the full devenv dependency graph.
 package timing
 
 import (
@@ -61,4 +60,45 @@ func (t *TimeTracker) Print() {
 
 func (t *TimeTracker) SinceStart() time.Duration {
 	return time.Since(t.start)
+}
+
+// ComponentTiming records the wall-clock span of a single component's phase run.
+type ComponentTiming struct {
+	Phase int
+	Key   string
+	Start time.Time
+	End   time.Time
+}
+
+// ComponentTimeTracker collects per-component timing entries for the phased runtime.
+//
+// TODO: consider merging ComponentTimeTracker with TimeTracker.
+type ComponentTimeTracker struct {
+	entries []ComponentTiming
+}
+
+// NewComponentTimeTracker creates an empty ComponentTimeTracker.
+func NewComponentTimeTracker() *ComponentTimeTracker {
+	return &ComponentTimeTracker{}
+}
+
+// Record appends a timing entry for the given phase and component key.
+func (t *ComponentTimeTracker) Record(phase int, key string, start, end time.Time) {
+	t.entries = append(t.entries, ComponentTiming{
+		Phase: phase,
+		Key:   key,
+		Start: start,
+		End:   end,
+	})
+}
+
+// Print logs one Info line per recorded component showing phase, key, and duration.
+func (t *ComponentTimeTracker) Print(logger zerolog.Logger) {
+	for _, e := range t.entries {
+		logger.Info().
+			Int("phase", e.Phase).
+			Str("component", e.Key).
+			Str("duration", e.End.Sub(e.Start).String()).
+			Msg("component timing")
+	}
 }


### PR DESCRIPTION


<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
Introduces `ComponentTimeTracker` in the `timing` package and wraps each `RunPhaseN` call in `NewEnvironmentWithRegistry` to record wall-clock start/end per component, stored as `_component_timings` in the output. Prints one Info log line per component at the end of `NewPhasedEnvironment` so slow components are immediately visible without enabling debug logging.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
