### PR TITLE
aggregator, indexer: reduce steady-state log verbosity and add quorum progress logs

### DIFF
--- a/aggregator/pkg/aggregation/aggregator.go
+++ b/aggregator/pkg/aggregation/aggregator.go
@@ -110,11 +110,11 @@ func (c *CommitReportAggregator) shouldSkipAggregationDueToExistingQuorum(ctx co
 	}
 
 	if quorumMet {
-		lggr.Infow("Skipping aggregation: existing report already meets quorum", "verificationCount", len(existingReport.Verifications))
+		lggr.Debugw("Skipping aggregation: existing report already meets quorum", "verificationCount", len(existingReport.Verifications))
 		return true
 	}
 
-	lggr.Infow("Existing report no longer meets quorum, proceeding with new aggregation", "verificationCount", len(existingReport.Verifications))
+	lggr.Debugw("Existing report no longer meets quorum, proceeding with new aggregation", "verificationCount", len(existingReport.Verifications))
 	return false
 }
 
@@ -126,7 +126,7 @@ func (c *CommitReportAggregator) checkAggregationAndSubmitComplete(ctx context.C
 	}
 
 	lggr := c.logger(ctx)
-	lggr.Info("Checking aggregation for message")
+	lggr.Debug("Checking aggregation for message")
 
 	shouldSkip := c.shouldSkipAggregationDueToExistingQuorum(ctx, request.MessageID, request.AggregationKey)
 	if shouldSkip {
@@ -175,7 +175,7 @@ func (c *CommitReportAggregator) checkAggregationAndSubmitComplete(ctx context.C
 		c.metrics(ctx).IncrementCompletedAggregations(ctx)
 		c.metrics(ctx).RecordTimeToAggregation(ctx, timeToAggregation)
 	} else {
-		lggr.Infow("Quorum not met, not submitting report", "verifications", len(verifications))
+		lggr.Debugw("Quorum not met, not submitting report", "verifications", len(verifications))
 	}
 
 	return nil

--- a/aggregator/pkg/aggregation/aggregator.go
+++ b/aggregator/pkg/aggregation/aggregator.go
@@ -171,7 +171,9 @@ func (c *CommitReportAggregator) checkAggregationAndSubmitComplete(ctx context.C
 			return err
 		}
 		timeToAggregation := aggregatedReport.CalculateTimeToAggregation(time.Now())
-		lggr.Infow("Report submitted successfully", "verifications", len(verifications), "timeToAggregation", timeToAggregation)
+		// PER-MESSAGE SUCCESS LOG: the one Info line emitted when a message reaches
+		// quorum and its aggregated report is submitted.
+		lggr.Infow("Report submitted successfully", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, "verifications", len(verifications), "timeToAggregation", timeToAggregation)
 		c.metrics(ctx).IncrementCompletedAggregations(ctx)
 		c.metrics(ctx).RecordTimeToAggregation(ctx, timeToAggregation)
 	} else {

--- a/aggregator/pkg/aggregation/aggregator.go
+++ b/aggregator/pkg/aggregation/aggregator.go
@@ -171,8 +171,7 @@ func (c *CommitReportAggregator) checkAggregationAndSubmitComplete(ctx context.C
 			return err
 		}
 		timeToAggregation := aggregatedReport.CalculateTimeToAggregation(time.Now())
-		// PER-MESSAGE SUCCESS LOG: the one Info line emitted when a message reaches
-		// quorum and its aggregated report is submitted.
+		// PER-MESSAGE LOG (success): one line per message, on quorum.
 		lggr.Infow("Report submitted successfully", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, "verifications", len(verifications), "timeToAggregation", timeToAggregation)
 		c.metrics(ctx).IncrementCompletedAggregations(ctx)
 		c.metrics(ctx).RecordTimeToAggregation(ctx, timeToAggregation)

--- a/aggregator/pkg/handlers/heartbeat.go
+++ b/aggregator/pkg/handlers/heartbeat.go
@@ -38,7 +38,7 @@ func (h *HeartbeatHandler) Handle(ctx context.Context, req *heartbeatpb.Heartbea
 	}
 
 	callerID := identity.CallerID
-	h.logger(ctx).Infof("Received HeartbeatRequest from caller: %s", callerID)
+	h.logger(ctx).Debugf("Received HeartbeatRequest from caller: %s", callerID)
 
 	// get Allowed chains from committee config
 	allowedChains := make([]uint64, 0, len(h.committee.QuorumConfigs))
@@ -80,7 +80,7 @@ func (h *HeartbeatHandler) Handle(ctx context.Context, req *heartbeatpb.Heartbea
 	}
 
 	maxBlockHeights, err := h.storage.GetMaxBlockHeights(ctx, chainSelectors)
-	h.logger(ctx).Infof("Max block heights across all callers: %+v", maxBlockHeights)
+	h.logger(ctx).Debugf("Max block heights across all callers: %+v", maxBlockHeights)
 	if err != nil {
 		h.logger(ctx).Errorf("Failed to get max block heights: %v", err)
 		maxBlockHeights = make(map[uint64]uint64)

--- a/aggregator/pkg/handlers/write_commit_verifier_node_result.go
+++ b/aggregator/pkg/handlers/write_commit_verifier_node_result.go
@@ -110,8 +110,7 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 			Status: committeepb.WriteStatus_FAILED,
 		}, status.Error(codes.Internal, "failed to save verification record")
 	}
-	// MAIN STATUS LOG: a verification was received and persisted; emitted once per
-	// verifier node per message (not a success log — quorum may not yet be met).
+	// PER-MESSAGE LOG (status): one per verifier node; quorum may not be met yet.
 	h.logger(signerCtx).Infow("Verification received", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "callerID", identity.CallerID)
 
 	metrics := h.m.Metrics().With(

--- a/aggregator/pkg/handlers/write_commit_verifier_node_result.go
+++ b/aggregator/pkg/handlers/write_commit_verifier_node_result.go
@@ -87,7 +87,7 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 		}, status.Error(codes.InvalidArgument, "signature validation failed")
 	}
 
-	reqLogger.Infof("Signature validated successfully")
+	reqLogger.Debugf("Signature validated successfully")
 
 	aggregationKey, err := h.signatureValidator.DeriveAggregationKey(ctx, record)
 	if err != nil {
@@ -109,7 +109,7 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 			Status: committeepb.WriteStatus_FAILED,
 		}, status.Error(codes.Internal, "failed to save verification record")
 	}
-	h.logger(signerCtx).Infof("Successfully saved commit verification record")
+	h.logger(signerCtx).Debugf("Successfully saved commit verification record")
 
 	metrics := h.m.Metrics().With(
 		"caller_id", identity.CallerID,
@@ -131,7 +131,7 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 			Status: committeepb.WriteStatus_FAILED,
 		}, status.Error(codes.Internal, "failed to trigger aggregation")
 	}
-	reqLogger.Infof("Triggered aggregation check")
+	reqLogger.Debugf("Triggered aggregation check")
 
 	return &committeepb.WriteCommitteeVerifierNodeResultResponse{
 		Status: committeepb.WriteStatus_SUCCESS,

--- a/aggregator/pkg/handlers/write_commit_verifier_node_result.go
+++ b/aggregator/pkg/handlers/write_commit_verifier_node_result.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/model"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/scope"
 	messagerules "github.com/smartcontractkit/chainlink-ccv/common/messagerules"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	committeepb "github.com/smartcontractkit/chainlink-protos/chainlink-ccv/committee-verifier/v1"
@@ -109,7 +110,9 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 			Status: committeepb.WriteStatus_FAILED,
 		}, status.Error(codes.Internal, "failed to save verification record")
 	}
-	h.logger(signerCtx).Infow("Verification received", "callerID", identity.CallerID)
+	// MAIN STATUS LOG: a verification was received and persisted; emitted once per
+	// verifier node per message (not a success log — quorum may not yet be met).
+	h.logger(signerCtx).Infow("Verification received", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "callerID", identity.CallerID)
 
 	metrics := h.m.Metrics().With(
 		"caller_id", identity.CallerID,

--- a/aggregator/pkg/handlers/write_commit_verifier_node_result.go
+++ b/aggregator/pkg/handlers/write_commit_verifier_node_result.go
@@ -109,7 +109,7 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 			Status: committeepb.WriteStatus_FAILED,
 		}, status.Error(codes.Internal, "failed to save verification record")
 	}
-	h.logger(signerCtx).Debugf("Successfully saved commit verification record")
+	h.logger(signerCtx).Infow("Verification received", "callerID", identity.CallerID)
 
 	metrics := h.m.Metrics().With(
 		"caller_id", identity.CallerID,

--- a/aggregator/pkg/health/manager.go
+++ b/aggregator/pkg/health/manager.go
@@ -71,8 +71,7 @@ func (m *Manager) StartPeriodicHealthLogging(ctx context.Context, l logger.Sugar
 				componentStatus[svc.Name] = status
 			}
 
-			// MAIN STATUS LOG: periodic service health summary; emitted once per
-			// interval regardless of message activity (the only steady-state Info line).
+			// SERVICE LOG (status): periodic health summary; only steady-state Info line.
 			l.Infow("Service health summary",
 				protocol.LogTypeKey, protocol.LogTypeServiceStatus,
 				"overall_status", response.Status,

--- a/aggregator/pkg/health/manager.go
+++ b/aggregator/pkg/health/manager.go
@@ -71,7 +71,10 @@ func (m *Manager) StartPeriodicHealthLogging(ctx context.Context, l logger.Sugar
 				componentStatus[svc.Name] = status
 			}
 
+			// MAIN STATUS LOG: periodic service health summary; emitted once per
+			// interval regardless of message activity (the only steady-state Info line).
 			l.Infow("Service health summary",
+				protocol.LogTypeKey, protocol.LogTypeServiceStatus,
 				"overall_status", response.Status,
 				"components", componentStatus,
 			)

--- a/aggregator/pkg/messagerules/registry.go
+++ b/aggregator/pkg/messagerules/registry.go
@@ -92,7 +92,7 @@ func (r *Registry) Refresh(ctx context.Context) error {
 
 	r.metrics.SetMessageDisablementRulesRefreshFailure(ctx, 0)
 	r.emitActiveRuleMetrics(ctx, previousMetricLabels, metricLabels)
-	r.lggr.Infow("Refreshed message disablement rules registry",
+	r.lggr.Debugw("Refreshed message disablement rules registry",
 		"rule_count", compiled.ActiveRuleCount(),
 	)
 

--- a/aggregator/pkg/middlewares/logging_middleware.go
+++ b/aggregator/pkg/middlewares/logging_middleware.go
@@ -19,7 +19,7 @@ func (m *LoggingMiddleware) Intercept(ctx context.Context, req any, info *grpc.U
 	startTime := time.Now()
 	reqLogger := scope.AugmentLogger(ctx, m.l)
 
-	reqLogger.Infof("Request received")
+	reqLogger.Debugf("Request received")
 	reqLogger.Debugw("Request payload received", "payload", req)
 
 	resp, err = handler(ctx, req)
@@ -30,7 +30,7 @@ func (m *LoggingMiddleware) Intercept(ctx context.Context, req any, info *grpc.U
 	if err != nil {
 		reqLogger.Errorw("Request failed", "duration_ms", duration.Milliseconds(), "status", statusCode.String())
 	} else {
-		reqLogger.Infow("Request completed", "duration_ms", duration.Milliseconds(), "status", statusCode.String())
+		reqLogger.Debugw("Request completed", "duration_ms", duration.Milliseconds(), "status", statusCode.String())
 	}
 	reqLogger.Debugw("Response sent", "payload", resp)
 

--- a/aggregator/pkg/orphan_recoverer.go
+++ b/aggregator/pkg/orphan_recoverer.go
@@ -51,7 +51,7 @@ func (o *OrphanRecoverer) Start(ctx context.Context) error {
 
 	for {
 		now := time.Now()
-		o.logger.Info("Initiating orphan recovery scan")
+		o.logger.Debug("Initiating orphan recovery scan")
 
 		err := func() (err error) {
 			defer func() {
@@ -75,12 +75,10 @@ func (o *OrphanRecoverer) Start(ctx context.Context) error {
 
 		duration := time.Since(now)
 		o.metrics(ctx).RecordOrphanRecoveryDuration(ctx, duration)
-		o.logger.Infow("Orphan recovery scan finished",
+		o.logger.Debugw("Orphan recovery scan finished",
 			"duration", duration)
 		if duration < orphanRecoveryConfig.Interval {
 			sleepDuration := orphanRecoveryConfig.Interval - duration
-			o.logger.Infow("Sleeping until next orphan recovery scan",
-				"sleepDuration", sleepDuration)
 			select {
 			case <-time.After(sleepDuration):
 			case <-ctx.Done():
@@ -111,7 +109,7 @@ func (o *OrphanRecoverer) RecoverOrphans(ctx context.Context) error {
 	} else {
 		o.metrics(ctx).SetOrphanBacklog(ctx, stats.NonExpiredCount)
 		o.metrics(ctx).SetOrphanExpiredBacklog(ctx, stats.ExpiredCount)
-		o.logger.Infow("Orphan stats",
+		o.logger.Debugw("Orphan stats",
 			"nonExpired", stats.NonExpiredCount,
 			"expired", stats.ExpiredCount,
 			"total", stats.TotalCount)
@@ -126,7 +124,7 @@ func (o *OrphanRecoverer) RecoverOrphans(ctx context.Context) error {
 		select {
 		case orphanRecord, ok := <-orphansChan:
 			if !ok {
-				o.logger.Infow("Orphan recovery completed",
+				o.logger.Debugw("Orphan recovery completed",
 					"processed", processedCount,
 					"errors", errorCount)
 				return nil
@@ -156,7 +154,7 @@ func (o *OrphanRecoverer) RecoverOrphans(ctx context.Context) error {
 
 		case err, ok := <-errorChan:
 			if !ok {
-				o.logger.Infow("Orphan recovery completed",
+				o.logger.Debugw("Orphan recovery completed",
 					"processed", processedCount,
 					"errors", errorCount)
 				return nil

--- a/aggregator/pkg/orphan_recoverer.go
+++ b/aggregator/pkg/orphan_recoverer.go
@@ -130,6 +130,10 @@ func (o *OrphanRecoverer) RecoverOrphans(ctx context.Context) error {
 				return nil
 			}
 
+			o.logger.Infow("Message pending quorum",
+				"messageID", fmt.Sprintf("%x", orphanRecord.MessageID),
+				"aggregationKey", orphanRecord.AggregationKey)
+
 			err := o.processOrphanedRecord(ctx, orphanRecord)
 			if err != nil {
 				o.logger.Errorw("Failed to process orphaned record",

--- a/aggregator/pkg/orphan_recoverer.go
+++ b/aggregator/pkg/orphan_recoverer.go
@@ -130,8 +130,7 @@ func (o *OrphanRecoverer) RecoverOrphans(ctx context.Context) error {
 				return nil
 			}
 
-			// MAIN STATUS LOG: a message is still awaiting quorum; emitted per
-			// orphan-recovery scan interval (timer-based), not per verification.
+			// PER-MESSAGE LOG (status): timer-based, emitted per orphan scan while pending.
 			o.logger.Infow("Message pending quorum",
 				protocol.LogTypeKey, protocol.LogTypeMessageStatus,
 				"messageID", fmt.Sprintf("%x", orphanRecord.MessageID),

--- a/aggregator/pkg/orphan_recoverer.go
+++ b/aggregator/pkg/orphan_recoverer.go
@@ -130,7 +130,10 @@ func (o *OrphanRecoverer) RecoverOrphans(ctx context.Context) error {
 				return nil
 			}
 
+			// MAIN STATUS LOG: a message is still awaiting quorum; emitted per
+			// orphan-recovery scan interval (timer-based), not per verification.
 			o.logger.Infow("Message pending quorum",
+				protocol.LogTypeKey, protocol.LogTypeMessageStatus,
 				"messageID", fmt.Sprintf("%x", orphanRecord.MessageID),
 				"aggregationKey", orphanRecord.AggregationKey)
 

--- a/aggregator/pkg/quorum/evm_quorum_validator.go
+++ b/aggregator/pkg/quorum/evm_quorum_validator.go
@@ -154,7 +154,7 @@ func (q *EVMQuorumValidator) ValidateSignature(ctx context.Context, record *mode
 		candidateSignerAddress := common.HexToAddress(candidateSigner.Address)
 
 		if candidateSignerAddress == recoveredAddress {
-			q.logger(ctx).Infow("Recovered address from signature", "address", recoveredAddress.Hex())
+			q.logger(ctx).Debugw("Recovered address from signature", "address", recoveredAddress.Hex())
 			return &model.SignatureValidationResult{
 				Signer: &model.SignerIdentifier{
 					Identifier: candidateSignerAddress.Bytes(),

--- a/indexer/pkg/discovery/message_discovery.go
+++ b/indexer/pkg/discovery/message_discovery.go
@@ -330,7 +330,7 @@ func (a *AggregatorMessageDiscovery) callReader(ctx context.Context) (bool, erro
 
 	ingestionTimestamp := a.timeProvider.GetTime()
 	for _, response := range queryResponse {
-		a.logger.Infow("Found Message", "messageID", response.Data.MessageID, "verifierSourceAddress", response.Data.VerifierSourceAddress)
+		a.logger.Debugw("Found Message", "messageID", response.Data.MessageID, "verifierSourceAddress", response.Data.VerifierSourceAddress)
 	}
 	messages, persistedVerifications, allVerifications := common.ConvertDiscoveryResponses(queryResponse, ingestionTimestamp, a.registry)
 

--- a/indexer/pkg/discovery/message_discovery.go
+++ b/indexer/pkg/discovery/message_discovery.go
@@ -269,7 +269,7 @@ func (a *AggregatorMessageDiscovery) consumeReader(ctx context.Context) {
 
 	for {
 		if ctx.Err() != nil {
-			a.logger.Infof("Aggregator timed out, cancelling consumeReader")
+			a.logger.Debugf("Aggregator timed out, cancelling consumeReader")
 			return
 		}
 		found, err := a.callReader(ctx)

--- a/indexer/pkg/worker/worker.go
+++ b/indexer/pkg/worker/worker.go
@@ -1,6 +1,10 @@
 package worker
 
-import "context"
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
 
 // Execute processes a task by finding missing verifiers, loading verifier readers,
 // enqueueing verifier calls, and storing the results.
@@ -33,8 +37,10 @@ func Execute(ctx context.Context, task *Task) (*TaskResult, error) {
 	// Collects the results from the channels and returns any successful verifications.
 	results := task.collectVerifierResults(ctx, verifierReaders)
 
-	// One structured line per attempt summarizing the whole run.
+	// MAIN STATUS LOG: one structured line per processing attempt summarizing the
+	// run; emitted per task execution pass (re-fires on each retry).
 	task.logger.Infow("Processed verification attempt",
+		protocol.LogTypeKey, protocol.LogTypeMessageStatus,
 		"messageID", task.messageID.String(),
 		"total", len(totalVerifiers),
 		"existing", len(existingVerifiers),

--- a/indexer/pkg/worker/worker.go
+++ b/indexer/pkg/worker/worker.go
@@ -20,31 +20,31 @@ func Execute(ctx context.Context, task *Task) (*TaskResult, error) {
 		return nil, err
 	}
 
-	task.logger.Infof("Attempting to retrieve %d verifications for the message. Total Verifiers: %d", len(missing), len(totalVerifiers))
-
 	// Load all missing verifier readers from the registry
 	//
 	// Verifiers the indexer does not have context of are returned in unknownCCVs
 	// These can then be handled by discovery hooks to acquire the readers
 	// for further tasks. However for this task they will be excluded.
 	verifierReaders, attemptingToRetrieve, unknownCCVs := task.loadVerifierReaders(missing)
-	if len(unknownCCVs) != 0 {
-		task.logger.Infof("Detected %d unknown verifiers within the message, ignoring them for this run.", len(unknownCCVs))
-	}
-
-	// Log out useful information about this run
-	task.logger.Infof("Source Specified CCVs %s", totalVerifiers)
-	task.logger.Infof("Exisiting Verifications %s", existingVerifiers)
-	task.logger.Infof("Attempting to Retrieve %s", attemptingToRetrieve)
-	task.logger.Infof("Unknown CCVs %s", unknownCCVs)
 
 	// Process all verifier calls concurrently and collect successful results.
 	// Each verifier reader returns a channel that will emit one result when ready.
 	//
 	// Collects the results from the channels and returns any successful verifications.
 	results := task.collectVerifierResults(ctx, verifierReaders)
+
+	// One structured line per attempt summarizing the whole run.
+	task.logger.Infow("Processed verification attempt",
+		"messageID", task.messageID.String(),
+		"total", len(totalVerifiers),
+		"existing", len(existingVerifiers),
+		"missing", len(missing),
+		"attempting", len(attemptingToRetrieve),
+		"unknown", len(unknownCCVs),
+		"collected", len(results),
+	)
+
 	if len(results) > 0 {
-		task.logger.Infof("Collected %d new verifications for the message", len(results))
 		err = task.storage.InsertVerifierResults(ctx, results)
 		if err != nil {
 			return nil, err

--- a/indexer/pkg/worker/worker.go
+++ b/indexer/pkg/worker/worker.go
@@ -37,11 +37,16 @@ func Execute(ctx context.Context, task *Task) (*TaskResult, error) {
 	// Collects the results from the channels and returns any successful verifications.
 	results := task.collectVerifierResults(ctx, verifierReaders)
 
-	// MAIN STATUS LOG: one structured line per processing attempt summarizing the
-	// run; emitted per task execution pass (re-fires on each retry).
-	task.logger.Infow("Processed verification attempt",
+	// PER-MESSAGE LOG (status): Info on the first attempt, Debug on retries to keep
+	// per-message Info volume bounded; terminal outcome is logged separately.
+	logAttempt := task.logger.Infow
+	if task.attempt > 1 {
+		logAttempt = task.logger.Debugw
+	}
+	logAttempt("Processed verification attempt",
 		protocol.LogTypeKey, protocol.LogTypeMessageStatus,
 		"messageID", task.messageID.String(),
+		"attempt", task.attempt,
 		"total", len(totalVerifiers),
 		"existing", len(existingVerifiers),
 		"missing", len(missing),

--- a/indexer/pkg/worker/worker_pool.go
+++ b/indexer/pkg/worker/worker_pool.go
@@ -112,11 +112,13 @@ func (p *Pool) run(ctx context.Context) {
 					if err := task.SetMessageStatus(ctx, common.MessageSuccessful, ""); err != nil {
 						p.logger.Errorf("Unable to update Message Status for MessageID %s", task.messageID.String())
 					} else if result.SuccessfulVerifications > 0 {
-						// PER-MESSAGE SUCCESS LOG: this attempt collected the final missing
-						// verification(s) and the message is now fully verified. Gated on
-						// SuccessfulVerifications so the no-op tasks that merely observe an
-						// already-complete message stay silent (one success line per message).
-						p.logger.Infow("Message fully verified", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, "messageID", task.messageID.String())
+						// PER-MESSAGE LOG (success): gated on SuccessfulVerifications so it
+						// fires once per message; shares its message string with the DLQ path.
+						p.logger.Infow("Message processing finished",
+							protocol.LogTypeKey, protocol.LogTypeMessageSuccess,
+							"messageID", task.messageID.String(),
+							"status", "verified",
+						)
 					}
 				}
 
@@ -148,8 +150,7 @@ func (p *Pool) enqueueMessages(ctx context.Context) {
 				p.logger.Error("Discovery channel closed; exiting enqueueMessages")
 				return
 			}
-			// MAIN STATUS LOG: a discovered verification is entering the worker pool;
-			// emitted once per verification (keyed per verification, not per message).
+			// PER-MESSAGE LOG (status): once per verification (not per message).
 			p.logger.Infow("Enqueueing verification", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "messageID", message.VerifierResult.MessageID.String(), "verifierSourceAddress", message.VerifierResult.VerifierSourceAddress)
 			task, err := NewTask(p.logger, message.VerifierResult, p.registry, p.storage, p.scheduler.VerificationVisibilityWindow())
 			// This shouldn't happen, it can only be caused by an invalid hex conversion.
@@ -190,7 +191,14 @@ func (p *Pool) handleDLQ(ctx context.Context) {
 				p.logger.Errorf("Unable to update message status to timeout for message %s", task.messageID.String())
 			}
 
-			p.logger.Warnf("Message %s entered DLQ. Partial verifications may have been received", task.messageID.String())
+			// PER-MESSAGE LOG (failure): timed out into the DLQ; shares its message
+			// string with the success path (distinguish by status / log_type).
+			p.logger.Warnw("Message processing finished",
+				protocol.LogTypeKey, protocol.LogTypeMessageFailure,
+				"messageID", task.messageID.String(),
+				"status", "timeout",
+				"error", lastErrStr,
+			)
 		}
 	}
 }

--- a/indexer/pkg/worker/worker_pool.go
+++ b/indexer/pkg/worker/worker_pool.go
@@ -141,7 +141,7 @@ func (p *Pool) enqueueMessages(ctx context.Context) {
 				p.logger.Error("Discovery channel closed; exiting enqueueMessages")
 				return
 			}
-			p.logger.Infow("Enqueueing new Message", "messageID", message.VerifierResult.MessageID.String())
+			p.logger.Infow("Enqueueing verification", "messageID", message.VerifierResult.MessageID.String(), "verifierSourceAddress", message.VerifierResult.VerifierSourceAddress)
 			task, err := NewTask(p.logger, message.VerifierResult, p.registry, p.storage, p.scheduler.VerificationVisibilityWindow())
 			// This shouldn't happen, it can only be caused by an invalid hex conversion.
 			// We're unable to retry the message or send it to the DLQ.

--- a/indexer/pkg/worker/worker_pool.go
+++ b/indexer/pkg/worker/worker_pool.go
@@ -100,7 +100,7 @@ func (p *Pool) run(ctx context.Context) {
 			}
 
 			workerCtx, cancel := context.WithTimeout(ctx, time.Duration(p.config.WorkerTimeout)*time.Second)
-			p.logger.Infof("Starting Worker for %s", task.messageID.String())
+			p.logger.Debugf("Starting Worker for %s", task.messageID.String())
 
 			p.pool.Go(func() {
 				defer cancel()

--- a/indexer/pkg/worker/worker_pool.go
+++ b/indexer/pkg/worker/worker_pool.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/common"
 	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/config"
 	"github.com/smartcontractkit/chainlink-ccv/indexer/pkg/registry"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
@@ -110,6 +111,12 @@ func (p *Pool) run(ctx context.Context) {
 				if err == nil && result != nil && result.UnavailableCCVs == 0 {
 					if err := task.SetMessageStatus(ctx, common.MessageSuccessful, ""); err != nil {
 						p.logger.Errorf("Unable to update Message Status for MessageID %s", task.messageID.String())
+					} else if result.SuccessfulVerifications > 0 {
+						// PER-MESSAGE SUCCESS LOG: this attempt collected the final missing
+						// verification(s) and the message is now fully verified. Gated on
+						// SuccessfulVerifications so the no-op tasks that merely observe an
+						// already-complete message stay silent (one success line per message).
+						p.logger.Infow("Message fully verified", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, "messageID", task.messageID.String())
 					}
 				}
 
@@ -141,7 +148,9 @@ func (p *Pool) enqueueMessages(ctx context.Context) {
 				p.logger.Error("Discovery channel closed; exiting enqueueMessages")
 				return
 			}
-			p.logger.Infow("Enqueueing verification", "messageID", message.VerifierResult.MessageID.String(), "verifierSourceAddress", message.VerifierResult.VerifierSourceAddress)
+			// MAIN STATUS LOG: a discovered verification is entering the worker pool;
+			// emitted once per verification (keyed per verification, not per message).
+			p.logger.Infow("Enqueueing verification", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "messageID", message.VerifierResult.MessageID.String(), "verifierSourceAddress", message.VerifierResult.VerifierSourceAddress)
 			task, err := NewTask(p.logger, message.VerifierResult, p.registry, p.storage, p.scheduler.VerificationVisibilityWindow())
 			// This shouldn't happen, it can only be caused by an invalid hex conversion.
 			// We're unable to retry the message or send it to the DLQ.

--- a/protocol/log_types.go
+++ b/protocol/log_types.go
@@ -14,6 +14,12 @@ const (
 	// There is at most one of these per message on the happy path.
 	LogTypeMessageSuccess LogType = "message_success"
 
+	// LogTypeMessageFailure marks the terminal per-message failure event: a message
+	// could not be completed (e.g. it timed out and entered the dead-letter queue).
+	// Like LogTypeMessageSuccess, it is a terminal outcome — a message ends as one or
+	// the other.
+	LogTypeMessageFailure LogType = "message_failure"
+
 	// LogTypeMessageStatus marks a non-terminal per-message progress event, such as a
 	// verification being received, a message pending quorum, or a processing attempt.
 	// These can fire multiple times per message as it advances.

--- a/protocol/log_types.go
+++ b/protocol/log_types.go
@@ -1,0 +1,25 @@
+package protocol
+
+// LogType classifies a structured log line so that logs can be filtered and
+// aggregated consistently across services. Emit it under the LogTypeKey field,
+// e.g. logger.Infow("Report submitted successfully", protocol.LogTypeKey, protocol.LogTypeMessageSuccess).
+type LogType string
+
+// LogTypeKey is the structured-log field key under which a LogType value is emitted.
+const LogTypeKey = "log_type"
+
+const (
+	// LogTypeMessageSuccess marks the terminal per-message success event: a message
+	// has been fully verified (indexer) or its aggregated report submitted (aggregator).
+	// There is at most one of these per message on the happy path.
+	LogTypeMessageSuccess LogType = "message_success"
+
+	// LogTypeMessageStatus marks a non-terminal per-message progress event, such as a
+	// verification being received, a message pending quorum, or a processing attempt.
+	// These can fire multiple times per message as it advances.
+	LogTypeMessageStatus LogType = "message_status"
+
+	// LogTypeServiceStatus marks a service-level status event that is not tied to a
+	// specific message, such as a periodic health summary.
+	LogTypeServiceStatus LogType = "service_status"
+)


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Bring aggregator and indexer logging in line with operator targets — <50 logs at startup, <3 system logs/minute at steady state, a small bounded set per message — keeping only the per-message logs useful for tracing.

### Approach

- Demoted high-frequency diagnostic logs (per-RPC, per-heartbeat, per-aggregation-attempt, per-background-tick, per-poll) from Info to Debug, where metrics already cover steady-state observability.
- Kept one Info log per stage of the per-message lifecycle instead of every step, and tagged each with a structured `log_type` field (`message_success` / `message_failure` / `message_staso logs can be filtered and aggregated across services without parsing message text.
- **Aggregator:** added `"Verification received"` and a timer-based `"Message pending quorum"` (emitted on ther write) for in-flight visibility without spam.
- **Indexer:** collapsed the 5–7 per-attempt `Infof` calls into one structured `"Processed verification attemptt, Debug on retries); demoted the duplicate nd unified the success and DLQ paths into a single terminal `"Message processing finished"` line keyed by `status`.

### Log volume impact

**Aggregator** — idle: ~1 Info line/minute (health summary). Per message: ~N+1 Info lines (one `"Verification receivedReport submitted successfully"`), plus `"Message pending quorum"` per orphan-scan interval only while
incomplete. Scales linearly with verification ingest.

**Indexer** — idle: ~0 Info lines only). Per message: ~2V+1 Info lines (V = verifications discovered ≈ committee size), now independent of retry depth since retry passes log at Debug. The V multiplier is structural — each verifier's contribution is its own convergence task by design — not a logging artifact.

Net: steady-state noise is effectively eliminated, and per-message logging is a small, bounded, `log_type`-keyed s
<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
