### PR TITLE
integration/pkg/api/middleware: add GinLogger middleware

### DIFF
--- a/indexer/pkg/api/api.go
+++ b/indexer/pkg/api/api.go
@@ -14,7 +14,7 @@ import (
 
 func NewV1API(lggr logger.Logger, cfg *config.Config, storage common.IndexerStorage, monitoring common.IndexerMonitoring) *gin.Engine {
 	router := gin.New()
-	router.Use(gin.Logger())
+	router.Use(sharedmiddleware.GinLogger(lggr))
 	err := router.SetTrustedProxies(cfg.API.TrustedProxies)
 	if err != nil {
 		lggr.Fatalf("Unable to set Trusted Proxies", "error", err, "trustedProxies", cfg.API.TrustedProxies)

--- a/integration/pkg/api/middleware/logger.go
+++ b/integration/pkg/api/middleware/logger.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// GinLogger returns a gin middleware that logs HTTP requests using the provided logger.
+func GinLogger(lggr logger.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		path := c.Request.URL.Path
+		if raw := c.Request.URL.RawQuery; raw != "" {
+			path = path + "?" + raw
+		}
+
+		c.Next()
+
+		fields := []any{
+			"method", c.Request.Method,
+			"path", path,
+			"status", c.Writer.Status(),
+			"latency", time.Since(start),
+			"clientIP", c.ClientIP(),
+		}
+		if errMsg := c.Errors.ByType(gin.ErrorTypePrivate).String(); errMsg != "" {
+			fields = append(fields, "errors", errMsg)
+		}
+		lggr.Infow("Request", fields...)
+	}
+}

--- a/verifier/pkg/token/api/api.go
+++ b/verifier/pkg/token/api/api.go
@@ -18,7 +18,7 @@ func NewHTTPAPI(
 	monitoring verifier.Monitoring,
 ) *gin.Engine {
 	router := gin.New()
-	router.Use(gin.Logger())
+	router.Use(middleware.GinLogger(lggr))
 	router.Use(middleware.SecureRecovery(lggr))
 
 	healthHandler := health.NewHealthStatus(healthReporters)


### PR DESCRIPTION
## Description

The indexer and verifier APIs were using gin's built-in `gin.Logger()` middleware for
HTTP access logging, which writes plain text to stdout independently of the rest of the
application's logging pipeline. The rest of the codebase uses chainlink-common's
`logger.Logger` (a zap-backed structured logger), so gin's output was inconsistent in
format which made it harder to parse and read.

This PR replaces `gin.Logger()` in both APIs with a new `GinLogger` middleware in the
shared `integration/pkg/api/middleware` package. The middleware takes a `logger.Logger`
and logs each request at Info level with structured fields (method, path, status,
latency, clientIP) matching what gin's default formatter prints. gin context errors
(`ErrorTypePrivate`) are appended when present.

`gin-contrib/zap` was considered but not used: its `ZapLogger` interface requires
`Info(msg string, fields ...zap.Field)`, which chainlink-common's `Logger` does not
satisfy (it uses `...any` variadic args). Writing the middleware directly follows the
same pattern already established by `SecureRecovery`.

Before:

```
[GIN] 2026/06/09 - 13:36:47 | 200 |     388.917µs |     172.19.0.37 | GET      "/v1/messages?destChainSelectors=12922642891491394802%2C3379446385462418246%2C4793464827907405086&limit=100&start=0001-01-01T00%3A00%3A00Z"
```

After:

```json
{"level":"INFO","ts":"2026-06-09T13:28:42.791Z","logger":"indexer","caller":"middleware/logger.go:32","msg":"Request","method":"GET","path":"/v1/messages?destChainSelectors=12922642891491394802%2C3379446385462418246%2C4793464827907405086&limit=100&start=0001-01-01T00%3A00%3A00Z","status":200,"latency":"1.053708ms","clientIP":"172.19.0.39"}
```

## Testing

- `go build ./indexer/... ./verifier/... ./integration/...` passes with no errors
- No behavioral change to request handling; only the log destination and format change

## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date