### PR TITLE
verifier, executor: reduce steady-state log verbosity and add quorum progress logs

### DIFF
--- a/.github/workflows/test-cl-smoke.yaml
+++ b/.github/workflows/test-cl-smoke.yaml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Run Smoke Test
         id: test_run
-        run: ccv test --profile ${{ matrix.test.profile }} --pattern '${{ matrix.test.pattern }}' --timeout ${{ matrix.test.timeout }} --build=false
+        run: ccv --log-level debug test --profile ${{ matrix.test.profile }} --pattern '${{ matrix.test.pattern }}' --timeout ${{ matrix.test.timeout }} --build=false
         continue-on-error: true
         env:
           JD_IMAGE: ${{ secrets.JD_IMAGE }}

--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Run Test ${{ matrix.test.name }}
         id: test_run
-        run: ccv test --profile ${{ matrix.test.profile }} --pattern '${{ matrix.test.pattern }}' --timeout ${{ matrix.test.timeout }} --build=false
+        run: ccv --log-level debug test --profile ${{ matrix.test.profile }} --pattern '${{ matrix.test.pattern }}' --timeout ${{ matrix.test.timeout }} --build=false
         continue-on-error: true
         env:
           JD_IMAGE: ${{ secrets.JD_IMAGE }}

--- a/aggregator/pkg/aggregation/aggregator.go
+++ b/aggregator/pkg/aggregation/aggregator.go
@@ -172,7 +172,7 @@ func (c *CommitReportAggregator) checkAggregationAndSubmitComplete(ctx context.C
 		}
 		timeToAggregation := aggregatedReport.CalculateTimeToAggregation(time.Now())
 		// PER-MESSAGE LOG (success): one line per message, on quorum.
-		lggr.Infow("Report submitted successfully", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, "verifications", len(verifications), "timeToAggregation", timeToAggregation)
+		lggr.Infow("Report submitted successfully", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, protocol.LogKeyMessageID, protocol.ByteSlice(request.MessageID).String(), "verifications", len(verifications), "timeToAggregation", timeToAggregation)
 		c.metrics(ctx).IncrementCompletedAggregations(ctx)
 		c.metrics(ctx).RecordTimeToAggregation(ctx, timeToAggregation)
 	} else {

--- a/aggregator/pkg/handlers/get_messages_since.go
+++ b/aggregator/pkg/handlers/get_messages_since.go
@@ -51,7 +51,7 @@ func (h *GetMessagesSinceHandler) Handle(ctx context.Context, req *msgdiscoveryp
 		// If source verifier is not in ccvAddresses, nil out metadata addresses
 		quorumConfig, ok := h.committee.GetQuorumConfig(report.GetSourceChainSelector())
 		if !ok {
-			h.logger(ctx).Errorw("missing quorum config for source chain selector", "sourceChainSelector", report.GetSourceChainSelector(), "messageID", protocol.ByteSlice(report.MessageID))
+			h.logger(ctx).Errorw("missing quorum config for source chain selector", "sourceChainSelector", report.GetSourceChainSelector(), protocol.LogKeyMessageID, protocol.ByteSlice(report.MessageID))
 			verifierResult.Metadata.VerifierSourceAddress = nil
 			verifierResult.Metadata.VerifierDestAddress = nil
 		} else if !model.IsSourceVerifierInCCVAddresses(quorumConfig.GetSourceVerifierAddress(), report.GetMessageCCVAddresses()) {

--- a/aggregator/pkg/handlers/get_messages_since.go
+++ b/aggregator/pkg/handlers/get_messages_since.go
@@ -41,7 +41,7 @@ func (h *GetMessagesSinceHandler) Handle(ctx context.Context, req *msgdiscoveryp
 
 	records := make([]*msgdiscoverypb.VerifierResultWithSequence, 0, len(batch.Reports))
 	for _, report := range batch.Reports {
-		h.logger(ctx).Tracef("Report MessageID: %x, Sequence: %d, Verifications: %d", protocol.ByteSlice(report.MessageID), report.Sequence, len(report.Verifications))
+		h.logger(ctx).Tracef("Report MessageID: %s, Sequence: %d, Verifications: %d", protocol.ByteSlice(report.MessageID), report.Sequence, len(report.Verifications))
 		verifierResult, err := model.MapAggregatedReportToVerifierResultProto(report, h.committee)
 		if err != nil {
 			h.logger(ctx).Errorw("failed to map aggregated report to proto", "messageID", protocol.ByteSlice(report.MessageID), "error", err)
@@ -51,7 +51,7 @@ func (h *GetMessagesSinceHandler) Handle(ctx context.Context, req *msgdiscoveryp
 		// If source verifier is not in ccvAddresses, nil out metadata addresses
 		quorumConfig, ok := h.committee.GetQuorumConfig(report.GetSourceChainSelector())
 		if !ok {
-			h.logger(ctx).Errorw("missing quorum config for source chain selector", "sourceChainSelector", report.GetSourceChainSelector(), "messageID", report.MessageID)
+			h.logger(ctx).Errorw("missing quorum config for source chain selector", "sourceChainSelector", report.GetSourceChainSelector(), "messageID", protocol.ByteSlice(report.MessageID))
 			verifierResult.Metadata.VerifierSourceAddress = nil
 			verifierResult.Metadata.VerifierDestAddress = nil
 		} else if !model.IsSourceVerifierInCCVAddresses(quorumConfig.GetSourceVerifierAddress(), report.GetMessageCCVAddresses()) {

--- a/aggregator/pkg/handlers/write_commit_verifier_node_result.go
+++ b/aggregator/pkg/handlers/write_commit_verifier_node_result.go
@@ -111,7 +111,7 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 		}, status.Error(codes.Internal, "failed to save verification record")
 	}
 	// PER-MESSAGE LOG (status): one per verifier node; quorum may not be met yet.
-	h.logger(signerCtx).Infow("Verification received", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "callerID", identity.CallerID)
+	h.logger(signerCtx).Infow("Verification received", protocol.LogTypeKey, protocol.LogTypeMessageStatus, protocol.LogKeyMessageID, protocol.ByteSlice(record.MessageID).String(), "callerID", identity.CallerID)
 
 	metrics := h.m.Metrics().With(
 		"caller_id", identity.CallerID,

--- a/aggregator/pkg/orphan_recoverer.go
+++ b/aggregator/pkg/orphan_recoverer.go
@@ -133,20 +133,20 @@ func (o *OrphanRecoverer) RecoverOrphans(ctx context.Context) error {
 			// PER-MESSAGE LOG (status): timer-based, emitted per orphan scan while pending.
 			o.logger.Infow("Message pending quorum",
 				protocol.LogTypeKey, protocol.LogTypeMessageStatus,
-				"messageID", fmt.Sprintf("%x", orphanRecord.MessageID),
+				protocol.LogKeyMessageID, protocol.ByteSlice(orphanRecord.MessageID).String(),
 				"aggregationKey", orphanRecord.AggregationKey)
 
 			err := o.processOrphanedRecord(ctx, orphanRecord)
 			if err != nil {
 				o.logger.Errorw("Failed to process orphaned record",
-					"messageID", fmt.Sprintf("%x", orphanRecord.MessageID),
+					protocol.LogKeyMessageID, protocol.ByteSlice(orphanRecord.MessageID).String(),
 					"aggregationKey", orphanRecord.AggregationKey,
 					"error", err)
 				errorCount++
 				o.metrics(ctx).IncrementOrphanRecoveryErrors(ctx)
 			} else {
 				o.logger.Debugw("Successfully processed orphaned record",
-					"messageID", fmt.Sprintf("%x", orphanRecord.MessageID),
+					protocol.LogKeyMessageID, protocol.ByteSlice(orphanRecord.MessageID).String(),
 					"aggregationKey", orphanRecord.AggregationKey)
 				processedCount++
 			}
@@ -187,7 +187,7 @@ func (o *OrphanRecoverer) processOrphanedRecord(ctx context.Context, record mode
 	}
 
 	o.logger.Debugw("Successfully triggered re-aggregation check",
-		"messageID", fmt.Sprintf("%x", record.MessageID),
+		protocol.LogKeyMessageID, protocol.ByteSlice(record.MessageID).String(),
 		"aggregationKey", record.AggregationKey)
 
 	return nil

--- a/aggregator/pkg/storage/postgres/database_storage.go
+++ b/aggregator/pkg/storage/postgres/database_storage.go
@@ -291,7 +291,7 @@ func (d *DatabaseStorage) QueryAggregatedReports(ctx context.Context, sinceSeque
 		if !exists {
 			msgID, parseErr := protocol.NewByteSliceFromHex(messageIDReport)
 			if parseErr != nil {
-				d.logger(ctx).Errorw("failed to parse message_id hex in aggregated report, skipping", "error", parseErr, "message_id", messageIDReport)
+				d.logger(ctx).Errorw("failed to parse message_id hex in aggregated report, skipping", "error", parseErr, protocol.LogKeyMessageID, messageIDReport)
 				continue
 			}
 			reportsMap[reportKey] = &model.CommitAggregatedReport{
@@ -535,7 +535,7 @@ func (d *DatabaseStorage) GetBatchAggregatedReportByMessageIDs(ctx context.Conte
 		if !exists {
 			messageIDBytes, parseErr := protocol.NewByteSliceFromHex(messageIDReport)
 			if parseErr != nil {
-				d.logger(ctx).Errorw("failed to parse message_id hex in batch report, skipping", "error", parseErr, "message_id", messageIDReport)
+				d.logger(ctx).Errorw("failed to parse message_id hex in batch report, skipping", "error", parseErr, protocol.LogKeyMessageID, messageIDReport)
 				continue
 			}
 			reports[messageIDReport] = &model.CommitAggregatedReport{
@@ -559,7 +559,7 @@ func (d *DatabaseStorage) GetBatchAggregatedReportByMessageIDs(ctx context.Conte
 		for _, verRow := range verRows {
 			verification, err := rowToCommitVerificationRecord(verRow)
 			if err != nil {
-				d.logger(ctx).Errorw("corrupted verification row in batch report, excluding entire report", "error", err, "message_id", messageID, "verification_id", verRow.ID)
+				d.logger(ctx).Errorw("corrupted verification row in batch report, excluding entire report", "error", err, protocol.LogKeyMessageID, messageID, "verification_id", verRow.ID)
 				delete(reports, messageID)
 				break
 			}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -392,6 +392,23 @@ func WithLogLevel(logLevel zapcore.Level) Option {
 	}
 }
 
+// WithLogLevelFromEnv sets the log level from the LOG_LEVEL environment variable,
+// falling back to defaultLevel if the variable is unset or invalid.
+func WithLogLevelFromEnv(defaultLevel zapcore.Level) Option {
+	return func(b *Bootstrapper) error {
+		b.logLevel = defaultLevel
+		if lvlStr := os.Getenv("LOG_LEVEL"); lvlStr != "" {
+			var lvl zapcore.Level
+			if err := lvl.UnmarshalText([]byte(lvlStr)); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Invalid LOG_LEVEL '%s', defaulting to '%s'\n", lvlStr, defaultLevel)
+			} else {
+				b.logLevel = lvl
+			}
+		}
+		return nil
+	}
+}
+
 type keyToInit struct {
 	name    string
 	purpose string

--- a/build/devenv/cli/ccv.go
+++ b/build/devenv/cli/ccv.go
@@ -57,6 +57,9 @@ var rootCmd = &cobra.Command{
 			framework.L.Info().Msg("Debug mode enabled, setting CTF_CLNODE_DLV=true")
 			os.Setenv("CTF_CLNODE_DLV", "true")
 		}
+		if lvl, _ := cmd.Flags().GetString("log-level"); lvl != "" {
+			_ = os.Setenv("LOG_LEVEL", lvl)
+		}
 		mode, err := cmd.Flags().GetString("env-mode")
 		if err != nil {
 			return err
@@ -929,6 +932,7 @@ var txInfoCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable running services with dlv to allow remote debugging.")
 	rootCmd.PersistentFlags().String("env-mode", "legacy", "Environment startup mode: legacy (default) or phased.")
+	rootCmd.PersistentFlags().String("log-level", "", "Log level for services that support it (e.g. debug, info, warn)")
 
 	// Fund addresses
 	rootCmd.AddCommand(fundAddressesCmd)

--- a/build/devenv/cli/ccv.go
+++ b/build/devenv/cli/ccv.go
@@ -32,6 +32,7 @@ import (
 	ccv "github.com/smartcontractkit/chainlink-ccv/build/devenv"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/chainreg"
 	ccldf "github.com/smartcontractkit/chainlink-ccv/build/devenv/cldf"
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cli/log"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cli/send"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/evm"
 )
@@ -976,6 +977,7 @@ func init() {
 	rootCmd.AddCommand(printAddressesCmd)
 
 	rootCmd.AddCommand(send.Command())
+	rootCmd.AddCommand(log.Command())
 
 	// on-chain monitoring
 	rootCmd.AddCommand(monitorContractsCmd)

--- a/build/devenv/cli/log/command.go
+++ b/build/devenv/cli/log/command.go
@@ -23,9 +23,8 @@ func Command() *cobra.Command {
 		Use:     "logs",
 		Aliases: []string{"l"},
 		Short:   "Dump logs from all service containers",
-		Long: `Dump logs from all running service containers (verifier, aggregator,
-executor, indexer). Infrastructure containers (db, nginx, redis, etc.) are
-excluded automatically.
+		Long: `Dump logs from all running containers except known infrastructure
+(db, nginx, redis, blockchain, jd, portainer, fake).
 
 Without --sort, logs are grouped by container. With --sort, all log lines are
 merged and sorted by their JSON "ts" timestamp field, with the container name
@@ -134,9 +133,8 @@ type logLine struct {
 	ts        time.Time
 }
 
-// isServiceContainer returns true for service containers (verifier, aggregator,
-// executor, indexer) and false for infrastructure containers (db, nginx, redis,
-// blockchain, portainer, jd, fake).
+// isServiceContainer returns true for any container that is not known infrastructure
+// (db, nginx, redis, blockchain, jd, portainer, fake).
 func isServiceContainer(name string) bool {
 	for _, suffix := range []string{"-db", "-nginx", "-redis"} {
 		if strings.HasSuffix(name, suffix) {

--- a/build/devenv/cli/log/command.go
+++ b/build/devenv/cli/log/command.go
@@ -1,0 +1,218 @@
+package log
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/client"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the cobra command for dumping service container logs.
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "logs",
+		Aliases: []string{"l"},
+		Short:   "Dump logs from all service containers",
+		Long: `Dump logs from all running service containers (verifier, aggregator,
+executor, indexer). Infrastructure containers (db, nginx, redis, etc.) are
+excluded automatically.
+
+Without --sort, logs are grouped by container. With --sort, all log lines are
+merged and sorted by their JSON "ts" timestamp field, with the container name
+prepended to each line.`,
+		RunE: run,
+	}
+	cmd.Flags().BoolP("sort", "s", false, "Sort all log lines by JSON ts field across containers")
+	cmd.Flags().String("since", "", "Show logs since timestamp or duration (e.g. 5m, 1h, 2026-01-01T00:00:00Z)")
+	cmd.Flags().String("tail", "", "Number of lines to show from the end of each container's logs (default: all)")
+	cmd.Flags().StringP("filter", "f", "", "Only show lines containing this string")
+	return cmd
+}
+
+func run(cmd *cobra.Command, _ []string) error {
+	sortByTime, _ := cmd.Flags().GetBool("sort")
+	since, _ := cmd.Flags().GetString("since")
+	tail, _ := cmd.Flags().GetString("tail")
+	filter, _ := cmd.Flags().GetString("filter")
+
+	dockerClient, err := client.New(client.FromEnv)
+	if err != nil {
+		return fmt.Errorf("failed to create Docker client: %w", err)
+	}
+	defer dockerClient.Close()
+
+	ctx := context.Background()
+	result, err := dockerClient.ContainerList(ctx, client.ContainerListOptions{All: false})
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	var names []string
+	for _, c := range result.Items {
+		for _, n := range c.Names {
+			n = strings.TrimPrefix(n, "/")
+			if isServiceContainer(n) {
+				names = append(names, n)
+				break
+			}
+		}
+	}
+
+	if len(names) == 0 {
+		return fmt.Errorf("no service containers found; is the devenv running?")
+	}
+	sort.Strings(names)
+
+	matches := func(line string) bool {
+		return filter == "" || strings.Contains(line, filter)
+	}
+
+	if !sortByTime {
+		for _, name := range names {
+			lines, err := collectLogs(ctx, dockerClient, name, since, tail)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: %s: %v\n", name, err)
+				continue
+			}
+			fmt.Printf("=== %s ===\n", name)
+			for _, l := range lines {
+				if matches(l.text) {
+					fmt.Println(l.text)
+				}
+			}
+		}
+		return nil
+	}
+
+	// Collect all lines across containers, then sort by timestamp.
+	var all []logLine
+	for _, name := range names {
+		lines, err := collectLogs(ctx, dockerClient, name, since, tail)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %s: %v\n", name, err)
+			continue
+		}
+		all = append(all, lines...)
+	}
+
+	// Lines that precede any JSON entry in their container have zero ts and sort last.
+	sort.SliceStable(all, func(i, j int) bool {
+		ti, tj := all[i].ts, all[j].ts
+		if ti.IsZero() && tj.IsZero() {
+			return false
+		}
+		if ti.IsZero() {
+			return false
+		}
+		if tj.IsZero() {
+			return true
+		}
+		return ti.Before(tj)
+	})
+
+	for _, l := range all {
+		if matches(l.text) {
+			fmt.Printf("[%s] %s\n", l.container, l.text)
+		}
+	}
+	return nil
+}
+
+type logLine struct {
+	container string
+	text      string
+	ts        time.Time
+}
+
+// isServiceContainer returns true for service containers (verifier, aggregator,
+// executor, indexer) and false for infrastructure containers (db, nginx, redis,
+// blockchain, portainer, jd, fake).
+func isServiceContainer(name string) bool {
+	for _, suffix := range []string{"-db", "-nginx", "-redis"} {
+		if strings.HasSuffix(name, suffix) {
+			return false
+		}
+	}
+	for _, prefix := range []string{"blockchain-", "jd-"} {
+		if strings.HasPrefix(name, prefix) {
+			return false
+		}
+	}
+	switch name {
+	case "fake", "portainer":
+		return false
+	}
+	return true
+}
+
+func collectLogs(ctx context.Context, dockerClient *client.Client, name, since, tail string) ([]logLine, error) {
+	opts := client.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Since:      since,
+		Tail:       tail,
+	}
+	rc, err := dockerClient.ContainerLogs(ctx, name, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	var outBuf, errBuf bytes.Buffer
+	if _, err := stdcopy.StdCopy(&outBuf, &errBuf, rc); err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	combined := append(outBuf.Bytes(), errBuf.Bytes()...)
+	var lines []logLine
+	scanner := bufio.NewScanner(bytes.NewReader(combined))
+	scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1 MiB max line length
+	var lastTS time.Time
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		ts := extractTS(line)
+		if !ts.IsZero() {
+			lastTS = ts
+		} else {
+			ts = lastTS
+		}
+		lines = append(lines, logLine{
+			container: name,
+			text:      line,
+			ts:        ts,
+		})
+	}
+	return lines, scanner.Err()
+}
+
+// extractTS parses the "ts" field from a JSON log line. Returns zero time if
+// the line is not JSON or has no valid "ts" field.
+func extractTS(line string) time.Time {
+	if !strings.HasPrefix(line, "{") {
+		return time.Time{}
+	}
+	var obj struct {
+		Ts string `json:"ts"`
+	}
+	if err := json.Unmarshal([]byte(line), &obj); err != nil || obj.Ts == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339Nano, obj.Ts)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -222,7 +222,7 @@ func (m *CCIP17EVM) getOrCreateOnRampPoller() (*eventPoller[cciptestinterfaces.M
 
 			message, err := protocol.DecodeMessage(event.EncodedMessage)
 			if err != nil {
-				m.logger.Warn().Err(err).Str("messageID", protocol.ByteSlice(event.MessageId[:]).String()).Msg("Failed to decode message, skipping")
+				m.logger.Warn().Err(err).Str(protocol.LogKeyMessageID, protocol.ByteSlice(event.MessageId[:]).String()).Msg("Failed to decode message, skipping")
 				continue
 			}
 			key := eventKey{chainSelector: event.DestChainSelector, msgNum: uint64(message.SequenceNumber), messageID: event.MessageId}

--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -222,7 +222,7 @@ func (m *CCIP17EVM) getOrCreateOnRampPoller() (*eventPoller[cciptestinterfaces.M
 
 			message, err := protocol.DecodeMessage(event.EncodedMessage)
 			if err != nil {
-				m.logger.Warn().Err(err).Str("msgId", common.Bytes2Hex(event.MessageId[:])).Msg("Failed to decode message, skipping")
+				m.logger.Warn().Err(err).Str("messageID", protocol.ByteSlice(event.MessageId[:]).String()).Msg("Failed to decode message, skipping")
 				continue
 			}
 			key := eventKey{chainSelector: event.DestChainSelector, msgNum: uint64(message.SequenceNumber), messageID: event.MessageId}

--- a/build/devenv/services/committeeverifier/base.go
+++ b/build/devenv/services/committeeverifier/base.go
@@ -243,6 +243,9 @@ func launchVerifier(ctx context.Context, in *Input, outputs []*blockchain.Output
 	internalDBConnectionString := fmt.Sprintf("postgresql://%s:%s@%s:5432/%s?sslmode=disable",
 		in.ContainerName, in.ContainerName, dbContainerName(in.DB.Name, in.ChainFamily), in.ContainerName)
 	envVars["CL_DATABASE_URL"] = internalDBConnectionString
+	if lvl := os.Getenv("LOG_LEVEL"); lvl != "" {
+		envVars["LOG_LEVEL"] = lvl
+	}
 
 	// Generate and store config file.
 	bootstrapConfig, err := services.GenerateBootstrapConfig(*bootstrapInput)

--- a/build/devenv/services/tokenVerifier.go
+++ b/build/devenv/services/tokenVerifier.go
@@ -130,6 +130,9 @@ func NewTokenVerifier(in *TokenVerifierInput, blockchainOutputs []*blockchain.Ou
 	internalDBConnectionString := fmt.Sprintf("postgresql://%s:%s@%s:5432/%s?sslmode=disable",
 		in.ContainerName, in.ContainerName, in.DB.Name, in.ContainerName)
 	envVars["CL_DATABASE_URL"] = internalDBConnectionString
+	if lvl := os.Getenv("LOG_LEVEL"); lvl != "" {
+		envVars["LOG_LEVEL"] = lvl
+	}
 
 	/* Service */
 	req := testcontainers.ContainerRequest{

--- a/cmd/verifier/committee/main.go
+++ b/cmd/verifier/committee/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err := bootstrap.Run(
 		"EVMCommitteeVerifier",
 		cmd.NewCommitteeVerifierServiceFactory(),
-		bootstrap.WithLogLevel(zapcore.InfoLevel),
+		bootstrap.WithLogLevelFromEnv(zapcore.InfoLevel),
 		bootstrap.WithKey(commit.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256), // ECDSA key for signing verification results
 	); err != nil {
 		panic(fmt.Sprintf("failed to run EVM committee verifier: %s", err.Error()))

--- a/executor/executor_coordinator.go
+++ b/executor/executor_coordinator.go
@@ -171,17 +171,17 @@ func (ec *Coordinator) runStorageStream(ctx context.Context) {
 			id := msg.MustMessageID()
 
 			if ec.delayedMessageHeap.Has(id) {
-				ec.lggr.Debugw("message already in delayed heap, skipping", "messageID", id)
+				ec.lggr.Debugw("message already in delayed heap, skipping", protocol.LogKeyMessageID, id)
 				continue
 			}
 			if ec.inFlightHas(id) {
-				ec.lggr.Debugw("message already in flight, skipping", "messageID", id)
+				ec.lggr.Debugw("message already in flight, skipping", protocol.LogKeyMessageID, id)
 				continue
 			}
 
 			if !ec.leaderElector.IsExecutorForChain(msg.DestChainSelector) {
 				ec.lggr.Debugw("skipping message, executor not in pool for destination chain",
-					"messageID", id, "chainSel", msg.DestChainSelector)
+					protocol.LogKeyMessageID, id, protocol.LogKeyChainSel, msg.DestChainSelector)
 				continue
 			}
 
@@ -190,18 +190,18 @@ func (ec *Coordinator) runStorageStream(ctx context.Context) {
 				msg.DestChainSelector,
 				streamResult.Metadata.IngestionTimestamp)
 			if err != nil {
-				ec.lggr.Errorw("leader elector failed for message, skipping", "messageID", id, "chainSel", msg.DestChainSelector, "error", err)
+				ec.lggr.Errorw("leader elector failed for message, skipping", protocol.LogKeyMessageID, id, protocol.LogKeyChainSel, msg.DestChainSelector, "error", err)
 				continue
 			}
 
 			retryDelay, err := ec.leaderElector.GetRetryDelay(msg.DestChainSelector)
 			if err != nil {
-				ec.lggr.Errorw("leader elector retry delay failed for message, skipping", "messageID", id, "chainSel", msg.DestChainSelector, "error", err)
+				ec.lggr.Errorw("leader elector retry delay failed for message, skipping", protocol.LogKeyMessageID, id, protocol.LogKeyChainSel, msg.DestChainSelector, "error", err)
 				continue
 			}
 
 			ec.lggr.Debugw("pushing message to delayed heap",
-				"messageID", id,
+				protocol.LogKeyMessageID, id,
 				"ingestionTimestamp", streamResult.Metadata.IngestionTimestamp,
 				"readyTimestamp", readyTimestamp,
 			)
@@ -213,7 +213,7 @@ func (ec *Coordinator) runStorageStream(ctx context.Context) {
 				RetryInterval: retryDelay,
 				MessageID:     id,
 			}) {
-				ec.lggr.Debugw("duplicate message rejected by heap", "messageID", id)
+				ec.lggr.Debugw("duplicate message rejected by heap", protocol.LogKeyMessageID, id)
 			}
 		}
 	}
@@ -274,7 +274,7 @@ func (ec *Coordinator) processPayload(ctx context.Context, payload message_heap.
 	currentTime := ec.timeProvider.GetTime()
 	if currentTime.After(payload.ExpiryTime) {
 		// PER-MESSAGE LOG (failure): terminal; message exceeded its expiry without execution.
-		ec.lggr.Infow("message has expired", protocol.LogTypeKey, protocol.LogTypeMessageFailure, "messageID", payload.MessageID)
+		ec.lggr.Infow("message has expired", protocol.LogTypeKey, protocol.LogTypeMessageFailure, protocol.LogKeyMessageID, payload.MessageID)
 		ec.monitoring.Metrics().IncrementExpiredMessages(ctx)
 		return
 	}
@@ -282,11 +282,11 @@ func (ec *Coordinator) processPayload(ctx context.Context, payload message_heap.
 	message, id := *payload.Message, payload.MessageID
 
 	// PER-MESSAGE LOG (status): one per message picked up for an execution attempt.
-	ec.lggr.Infow("processing message with ID", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "messageID", id)
+	ec.lggr.Infow("processing message with ID", protocol.LogTypeKey, protocol.LogTypeMessageStatus, protocol.LogKeyMessageID, id)
 
 	shouldRetry, err := ec.executor.HandleMessage(ctx, message)
 	if shouldRetry {
-		ec.lggr.Debugw("message should be retried, putting back in heap", "messageID", id)
+		ec.lggr.Debugw("message should be retried, putting back in heap", protocol.LogKeyMessageID, id)
 		if !ec.delayedMessageHeap.Push(message_heap.MessageWithTimestamps{
 			Message:       &message,
 			ReadyTime:     payload.ReadyTime.Add(payload.RetryInterval),
@@ -294,12 +294,12 @@ func (ec *Coordinator) processPayload(ctx context.Context, payload message_heap.
 			RetryInterval: payload.RetryInterval,
 			MessageID:     id,
 		}) {
-			ec.lggr.Warnw("retry push rejected, message already in heap", "messageID", id)
+			ec.lggr.Warnw("retry push rejected, message already in heap", protocol.LogKeyMessageID, id)
 		}
 	}
 	ec.monitoring.Metrics().IncrementMessagesProcessing(ctx)
 	if err != nil {
-		ec.lggr.Errorw("failed to handle message", "messageID", id, "error", err, "shouldRetry", shouldRetry)
+		ec.lggr.Errorw("failed to handle message", protocol.LogKeyMessageID, id, "error", err, "shouldRetry", shouldRetry)
 		ec.monitoring.Metrics().IncrementMessagesProcessingError(ctx, shouldRetry)
 	}
 }

--- a/executor/executor_coordinator.go
+++ b/executor/executor_coordinator.go
@@ -171,16 +171,16 @@ func (ec *Coordinator) runStorageStream(ctx context.Context) {
 			id := msg.MustMessageID()
 
 			if ec.delayedMessageHeap.Has(id) {
-				ec.lggr.Infow("message already in delayed heap, skipping", "messageID", id)
+				ec.lggr.Debugw("message already in delayed heap, skipping", "messageID", id)
 				continue
 			}
 			if ec.inFlightHas(id) {
-				ec.lggr.Infow("message already in flight, skipping", "messageID", id)
+				ec.lggr.Debugw("message already in flight, skipping", "messageID", id)
 				continue
 			}
 
 			if !ec.leaderElector.IsExecutorForChain(msg.DestChainSelector) {
-				ec.lggr.Infow("skipping message, executor not in pool for destination chain",
+				ec.lggr.Debugw("skipping message, executor not in pool for destination chain",
 					"messageID", id, "chainSel", msg.DestChainSelector)
 				continue
 			}
@@ -200,7 +200,7 @@ func (ec *Coordinator) runStorageStream(ctx context.Context) {
 				continue
 			}
 
-			ec.lggr.Infow("pushing message to delayed heap",
+			ec.lggr.Debugw("pushing message to delayed heap",
 				"messageID", id,
 				"ingestionTimestamp", streamResult.Metadata.IngestionTimestamp,
 				"readyTimestamp", readyTimestamp,
@@ -213,7 +213,7 @@ func (ec *Coordinator) runStorageStream(ctx context.Context) {
 				RetryInterval: retryDelay,
 				MessageID:     id,
 			}) {
-				ec.lggr.Infow("duplicate message rejected by heap", "messageID", id)
+				ec.lggr.Debugw("duplicate message rejected by heap", "messageID", id)
 			}
 		}
 	}
@@ -273,18 +273,20 @@ func (ec *Coordinator) processPayload(ctx context.Context, payload message_heap.
 	defer ec.inFlightRemove(payload.MessageID)
 	currentTime := ec.timeProvider.GetTime()
 	if currentTime.After(payload.ExpiryTime) {
-		ec.lggr.Infow("message has expired", "messageID", payload.MessageID)
+		// PER-MESSAGE LOG (failure): terminal; message exceeded its expiry without execution.
+		ec.lggr.Infow("message has expired", protocol.LogTypeKey, protocol.LogTypeMessageFailure, "messageID", payload.MessageID)
 		ec.monitoring.Metrics().IncrementExpiredMessages(ctx)
 		return
 	}
 
 	message, id := *payload.Message, payload.MessageID
 
-	ec.lggr.Infow("processing message with ID", "messageID", id)
+	// PER-MESSAGE LOG (status): one per message picked up for an execution attempt.
+	ec.lggr.Infow("processing message with ID", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "messageID", id)
 
 	shouldRetry, err := ec.executor.HandleMessage(ctx, message)
 	if shouldRetry {
-		ec.lggr.Infow("message should be retried, putting back in heap", "messageID", id)
+		ec.lggr.Debugw("message should be retried, putting back in heap", "messageID", id)
 		if !ec.delayedMessageHeap.Push(message_heap.MessageWithTimestamps{
 			Message:       &message,
 			ReadyTime:     payload.ReadyTime.Add(payload.RetryInterval),

--- a/executor/executor_coordinator_test.go
+++ b/executor/executor_coordinator_test.go
@@ -343,7 +343,7 @@ func TestMessageExpiration(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a new observed logger for each test case
-			lggr, hook := logger.TestObserved(t, zapcore.InfoLevel)
+			lggr, hook := logger.TestObserved(t, zapcore.DebugLevel)
 
 			currentTime := time.Now().UTC()
 			mockTimeProvider := mocks.NewMockTimeProvider(t)
@@ -443,7 +443,7 @@ func TestMessageExpiration(t *testing.T) {
 }
 
 func TestDuplicateMessageIDFromStreamWhileInFlight_IsSkippedAndHandleMessageCalledOnce(t *testing.T) {
-	lggr, hook := logger.TestObserved(t, zapcore.InfoLevel)
+	lggr, hook := logger.TestObserved(t, zapcore.DebugLevel)
 	currentTime := time.Now().UTC()
 	mockTimeProvider := mocks.NewMockTimeProvider(t)
 	mockTimeProvider.EXPECT().GetTime().Return(currentTime).Maybe()

--- a/executor/pkg/executor/cl_executor.go
+++ b/executor/pkg/executor/cl_executor.go
@@ -169,7 +169,7 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 		if curseErr != nil {
 			cle.lggr.Warnw("delaying execution - curse state unknown", "messageID", messageID, "error", curseErr)
 		} else {
-			cle.lggr.Infow("delaying execution due to curse", "messageID", messageID)
+			cle.lggr.Debugw("delaying execution due to curse", "messageID", messageID)
 		}
 		return true, nil
 	}
@@ -182,7 +182,7 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 		return true, err
 	}
 	if executionSuccess {
-		cle.lggr.Infow("skipping execution due to already being successfully executed", "messageID", messageID)
+		cle.lggr.Debugw("skipping execution due to already being successfully executed", "messageID", messageID)
 		cle.monitoring.Metrics().IncrementAlreadyExecutedMessages(ctx)
 		return false, nil
 	}
@@ -197,7 +197,7 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	}
 
 	// Order the Verifier Results to match the order expected by the receiver contract.
-	cle.lggr.Infow("got ccv info and verifier results",
+	cle.lggr.Debugw("got ccv info and verifier results",
 		"messageID", messageID,
 		"destinationChain", destinationChain,
 		"verifierQuorum", verifierQuorum,
@@ -209,7 +209,8 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	// if a receiver expects more CCVs than the source message defined, we will never be able to execute.
 	// we've validated that VerifierResults are consistent in their ccv address fields, so we only need to check the first result for this check.
 	if len(verifierQuorum.RequiredCCVs)+int(verifierQuorum.OptionalThreshold) > len(verifierResults[0].MessageCCVAddresses) {
-		cle.lggr.Infow("skipping execution and not retrying due to impossible receiver verifier quorum", "messageID", messageID)
+		// PER-MESSAGE LOG (failure): terminal; receiver quorum can never be satisfied, no retry.
+		cle.lggr.Infow("skipping execution and not retrying due to impossible receiver verifier quorum", protocol.LogTypeKey, protocol.LogTypeMessageFailure, "messageID", messageID)
 		cle.monitoring.Metrics().IncrementUnrecoverableMessageFailure(ctx)
 		return false, nil
 	}
@@ -221,7 +222,7 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	}
 
 	if !cle.destinationReaders[destinationChain].IsReady(destinationChain) {
-		cle.lggr.Infow("execution attempt poller not ready, will retry",
+		cle.lggr.Debugw("execution attempt poller not ready, will retry",
 			"messageID", messageID)
 		return true, nil
 	}
@@ -237,7 +238,7 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	// If someone else has already tried to execute this message with the data
 	// that we would execute the message with or deem valid. We won't execute.
 	if honestAttempt {
-		cle.lggr.Infow("skipping execution due to existing honest attempt", "messageID", messageID)
+		cle.lggr.Debugw("skipping execution due to existing honest attempt", "messageID", messageID)
 		return false, nil
 	}
 
@@ -247,12 +248,15 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 		CCVData: orderedverifierResults,
 		Message: message,
 	}
+	// PER-MESSAGE LOG (success): one per message, when this executor transmits to chain.
 	cle.lggr.Infow("transmitting aggregated report to chain",
+		protocol.LogTypeKey, protocol.LogTypeMessageSuccess,
 		"messageID", messageID,
 		"destinationChain", destinationChain,
 		"latestCCVTimestamp", latestCCVTimestamp,
-		"aggregatedReport", aggregatedReport,
 	)
+	// Full report dumped at Debug to keep the per-message success line small.
+	cle.lggr.Debugw("aggregated report", "messageID", messageID, "aggregatedReport", aggregatedReport)
 	err = cle.contractTransmitters[destinationChain].ConvertAndWriteMessageToChain(ctx, aggregatedReport)
 	if err != nil {
 		if errors.Is(err, executor.ErrMessageEncoding) {

--- a/executor/pkg/executor/cl_executor.go
+++ b/executor/pkg/executor/cl_executor.go
@@ -167,9 +167,9 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	cursed, curseErr := cle.curseChecker.IsRemoteChainCursed(ctx, message.DestChainSelector, message.SourceChainSelector)
 	if cursed {
 		if curseErr != nil {
-			cle.lggr.Warnw("delaying execution - curse state unknown", "messageID", messageID, "error", curseErr)
+			cle.lggr.Warnw("delaying execution - curse state unknown", protocol.LogKeyMessageID, messageID, "error", curseErr)
 		} else {
-			cle.lggr.Debugw("delaying execution due to curse", "messageID", messageID)
+			cle.lggr.Debugw("delaying execution due to curse", protocol.LogKeyMessageID, messageID)
 		}
 		return true, nil
 	}
@@ -178,18 +178,18 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	if err != nil {
 		// If we can't get execution state, don't execute, but put back in heap to retry later.
 		// this usually only happens due to rpc issues, other nodes will try and this node will expect to see status SUCCESS later.
-		cle.lggr.Warnw("delaying execution due to failed check GetMessageExecutionState", "messageID", messageID)
+		cle.lggr.Warnw("delaying execution due to failed check GetMessageExecutionState", protocol.LogKeyMessageID, messageID)
 		return true, err
 	}
 	if executionSuccess {
-		cle.lggr.Debugw("skipping execution due to already being successfully executed", "messageID", messageID)
+		cle.lggr.Debugw("skipping execution due to already being successfully executed", protocol.LogKeyMessageID, messageID)
 		cle.monitoring.Metrics().IncrementAlreadyExecutedMessages(ctx)
 		return false, nil
 	}
 
 	verifierResults, verifierQuorum, err := cle.getVerifierResultsAndQuorum(ctx, message, messageID)
 	if err != nil {
-		cle.lggr.Warnw("delaying execution due to failed request for verifier results and quorum", "messageID", messageID)
+		cle.lggr.Warnw("delaying execution due to failed request for verifier results and quorum", protocol.LogKeyMessageID, messageID)
 		return true, err
 	}
 	if len(verifierResults) == 0 {
@@ -198,7 +198,7 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 
 	// Order the Verifier Results to match the order expected by the receiver contract.
 	cle.lggr.Debugw("got ccv info and verifier results",
-		"messageID", messageID,
+		protocol.LogKeyMessageID, messageID,
 		"destinationChain", destinationChain,
 		"verifierQuorum", verifierQuorum,
 		"verifierResultsLen", len(verifierResults),
@@ -210,20 +210,20 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	// we've validated that VerifierResults are consistent in their ccv address fields, so we only need to check the first result for this check.
 	if len(verifierQuorum.RequiredCCVs)+int(verifierQuorum.OptionalThreshold) > len(verifierResults[0].MessageCCVAddresses) {
 		// PER-MESSAGE LOG (failure): terminal; receiver quorum can never be satisfied, no retry.
-		cle.lggr.Infow("skipping execution and not retrying due to impossible receiver verifier quorum", protocol.LogTypeKey, protocol.LogTypeMessageFailure, "messageID", messageID)
+		cle.lggr.Infow("skipping execution and not retrying due to impossible receiver verifier quorum", protocol.LogTypeKey, protocol.LogTypeMessageFailure, protocol.LogKeyMessageID, messageID)
 		cle.monitoring.Metrics().IncrementUnrecoverableMessageFailure(ctx)
 		return false, nil
 	}
 
 	orderedverifierResults, orderedCCVOfframps, latestCCVTimestamp, err := orderCCVData(verifierResults, verifierQuorum)
 	if err != nil {
-		cle.lggr.Warnw("message did not meet verifier quorum, will retry", "messageID", messageID)
+		cle.lggr.Warnw("message did not meet verifier quorum, will retry", protocol.LogKeyMessageID, messageID)
 		return true, err
 	}
 
 	if !cle.destinationReaders[destinationChain].IsReady(destinationChain) {
 		cle.lggr.Debugw("execution attempt poller not ready, will retry",
-			"messageID", messageID)
+			protocol.LogKeyMessageID, messageID)
 		return true, nil
 	}
 
@@ -231,14 +231,14 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	// If they haven't we can execute it.
 	honestAttempt, err := cle.destinationReaders[destinationChain].HasHonestAttempt(ctx, message, verifierResults, verifierQuorum)
 	if err != nil {
-		cle.lggr.Errorw("unable to call execution checker, will retry message", "error", err, "messageID", messageID)
+		cle.lggr.Errorw("unable to call execution checker, will retry message", "error", err, protocol.LogKeyMessageID, messageID)
 		return true, err
 	}
 
 	// If someone else has already tried to execute this message with the data
 	// that we would execute the message with or deem valid. We won't execute.
 	if honestAttempt {
-		cle.lggr.Debugw("skipping execution due to existing honest attempt", "messageID", messageID)
+		cle.lggr.Debugw("skipping execution due to existing honest attempt", protocol.LogKeyMessageID, messageID)
 		return false, nil
 	}
 
@@ -251,20 +251,20 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	// PER-MESSAGE LOG (success): one per message, when this executor transmits to chain.
 	cle.lggr.Infow("transmitting aggregated report to chain",
 		protocol.LogTypeKey, protocol.LogTypeMessageSuccess,
-		"messageID", messageID,
+		protocol.LogKeyMessageID, messageID,
 		"destinationChain", destinationChain,
 		"latestCCVTimestamp", latestCCVTimestamp,
 	)
 	// Full report dumped at Debug to keep the per-message success line small.
-	cle.lggr.Debugw("aggregated report", "messageID", messageID, "aggregatedReport", aggregatedReport)
+	cle.lggr.Debugw("aggregated report", protocol.LogKeyMessageID, messageID, "aggregatedReport", aggregatedReport)
 	err = cle.contractTransmitters[destinationChain].ConvertAndWriteMessageToChain(ctx, aggregatedReport)
 	if err != nil {
 		if errors.Is(err, executor.ErrMessageEncoding) {
 			cle.monitoring.Metrics().IncrementUnrecoverableMessageFailure(ctx)
-			cle.lggr.Warnw("skipping retry due to message encoding error", "messageID", messageID, "error", err)
+			cle.lggr.Warnw("skipping retry due to message encoding error", protocol.LogKeyMessageID, messageID, "error", err)
 			return false, err
 		}
-		cle.lggr.Warnw("will retry execution due to failed ConvertAndWriteMessageToChain", "messageID", messageID)
+		cle.lggr.Warnw("will retry execution due to failed ConvertAndWriteMessageToChain", protocol.LogKeyMessageID, messageID)
 		return true, err
 	}
 

--- a/executor/pkg/executor/cl_executor.go
+++ b/executor/pkg/executor/cl_executor.go
@@ -254,6 +254,8 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 		protocol.LogKeyMessageID, messageID,
 		"destinationChain", destinationChain,
 		"latestCCVTimestamp", latestCCVTimestamp,
+		"verifierQuorum", verifierQuorum,
+		"verifierResultsLen", len(verifierResults),
 	)
 	// Full report dumped at Debug to keep the per-message success line small.
 	cle.lggr.Debugw("aggregated report", protocol.LogKeyMessageID, messageID, "aggregatedReport", aggregatedReport)

--- a/executor/pkg/executor/cl_executor.go
+++ b/executor/pkg/executor/cl_executor.go
@@ -248,15 +248,6 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 		CCVData: orderedverifierResults,
 		Message: message,
 	}
-	// PER-MESSAGE LOG (success): one per message, when this executor transmits to chain.
-	cle.lggr.Infow("transmitting aggregated report to chain",
-		protocol.LogTypeKey, protocol.LogTypeMessageSuccess,
-		protocol.LogKeyMessageID, messageID,
-		"destinationChain", destinationChain,
-		"latestCCVTimestamp", latestCCVTimestamp,
-		"verifierQuorum", verifierQuorum,
-		"verifierResultsLen", len(verifierResults),
-	)
 	// Full report dumped at Debug to keep the per-message success line small.
 	cle.lggr.Debugw("aggregated report", protocol.LogKeyMessageID, messageID, "aggregatedReport", aggregatedReport)
 	err = cle.contractTransmitters[destinationChain].ConvertAndWriteMessageToChain(ctx, aggregatedReport)
@@ -269,6 +260,16 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 		cle.lggr.Warnw("will retry execution due to failed ConvertAndWriteMessageToChain", protocol.LogKeyMessageID, messageID)
 		return true, err
 	}
+
+	// PER-MESSAGE LOG (success): one per message, when this executor transmits to chain.
+	cle.lggr.Infow("transmitting aggregated report to chain",
+		protocol.LogTypeKey, protocol.LogTypeMessageSuccess,
+		protocol.LogKeyMessageID, messageID,
+		"destinationChain", destinationChain,
+		"latestCCVTimestamp", latestCCVTimestamp,
+		"verifierQuorum", verifierQuorum,
+		"verifierResultsLen", len(verifierResults),
+	)
 
 	// Record the message execution latency.
 	cle.monitoring.Metrics().RecordMessageExecutionLatency(ctx, time.Since(start), destinationChain)

--- a/executor/pkg/executor/cl_executor.go
+++ b/executor/pkg/executor/cl_executor.go
@@ -199,7 +199,7 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	// Order the Verifier Results to match the order expected by the receiver contract.
 	cle.lggr.Debugw("got ccv info and verifier results",
 		protocol.LogKeyMessageID, messageID,
-		"destinationChain", destinationChain,
+		protocol.LogKeyDestChain, destinationChain,
 		"verifierQuorum", verifierQuorum,
 		"verifierResultsLen", len(verifierResults),
 		"verifierResultsDestVerifiers", ccvDataDestVerifiers(verifierResults),
@@ -265,7 +265,7 @@ func (cle *ChainlinkExecutor) HandleMessage(ctx context.Context, message protoco
 	cle.lggr.Infow("transmitting aggregated report to chain",
 		protocol.LogTypeKey, protocol.LogTypeMessageSuccess,
 		protocol.LogKeyMessageID, messageID,
-		"destinationChain", destinationChain,
+		protocol.LogKeyDestChain, destinationChain,
 		"latestCCVTimestamp", latestCCVTimestamp,
 		"verifierQuorum", verifierQuorum,
 		"verifierResultsLen", len(verifierResults),

--- a/indexer/pkg/worker/worker_pool.go
+++ b/indexer/pkg/worker/worker_pool.go
@@ -151,7 +151,7 @@ func (p *Pool) enqueueMessages(ctx context.Context) {
 				return
 			}
 			// PER-MESSAGE LOG (status): once per verification (not per message).
-			p.logger.Infow("Enqueueing verification", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "messageID", message.VerifierResult.MessageID.String(), "verifierSourceAddress", message.VerifierResult.VerifierSourceAddress)
+			p.logger.Infow("Enqueueing verification", protocol.LogTypeKey, protocol.LogTypeMessageStatus, protocol.LogKeyMessageID, message.VerifierResult.MessageID.String(), "verifierSourceAddress", message.VerifierResult.VerifierSourceAddress)
 			task, err := NewTask(p.logger, message.VerifierResult, p.registry, p.storage, p.scheduler.VerificationVisibilityWindow())
 			// This shouldn't happen, it can only be caused by an invalid hex conversion.
 			// We're unable to retry the message or send it to the DLQ.

--- a/integration/pkg/accessors/evm/evm_source_reader.go
+++ b/integration/pkg/accessors/evm/evm_source_reader.go
@@ -182,7 +182,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 			"sourceChainSelector", r.chainSelector,
 			"destChainSelector", destChainSelector,
 			"sender", sender,
-			"messageId", common.Bytes2Hex(messageID[:]))
+			protocol.LogKeyMessageID, protocol.Bytes32(messageID).String())
 
 		// Parse the event data using the cached ABI
 		event := &onramp.OnRampCCIPMessageSent{}
@@ -199,7 +199,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 		r.lggr.Infow("OnRamp Event Structure",
 			"destChainSelector", event.DestChainSelector,
 			"sender", event.Sender,
-			"messageId", common.Bytes2Hex(event.MessageId[:]),
+			protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String(),
 			"ReceiptsCount", len(event.Receipts),
 			"verifierBlobsCount", len(event.VerifierBlobs))
 
@@ -208,7 +208,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 			r.onCriticalInvariant(ctx)
 			r.lggr.Errorw("Insufficient receipts. Expected at least 3 (1 CCV + executor + network fees)",
 				"count", len(event.Receipts),
-				"messageId", common.Bytes2Hex(event.MessageId[:]))
+				protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String())
 			continue // to next message
 		}
 
@@ -233,7 +233,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 
 		r.lggr.Infow("Decoding encoded message",
 			"encodedMessageLength", len(event.EncodedMessage),
-			"messageId", common.Bytes2Hex(event.MessageId[:]))
+			protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String())
 		decodedMsg, err := protocol.DecodeMessage(event.EncodedMessage)
 		if err != nil {
 			r.onCriticalInvariant(ctx)
@@ -247,7 +247,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 		if decodedMsg.CcvAndExecutorHash == (protocol.Bytes32{}) {
 			r.onCriticalInvariant(ctx)
 			r.lggr.Errorw("ccvAndExecutorHash is zero in decoded message",
-				"messageID", common.Bytes2Hex(event.MessageId[:]),
+				protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String(),
 				"blockNumber", log.BlockNumber)
 			continue // to next message
 		}
@@ -255,26 +255,26 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 		if !decodedMsg.OnRampAddress.Equal(expectedSourceAddressBytes(r.onRampAddress)) {
 			r.onCriticalInvariant(ctx)
 			r.lggr.Fatalw("onRampAddress must match the value configured — critical invariant violated; escalate immediately",
-				"messageId", common.Bytes2Hex(event.MessageId[:]))
+				protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String())
 			continue // ensure we never process this msg
 		}
 
 		if !decodedMsg.Sender.Equal(expectedSourceAddressBytes(event.Sender)) {
 			r.onCriticalInvariant(ctx)
-			r.lggr.Fatalw("sender must match the value emitted from the on-chain event. This should never happen.", "messageId", common.Bytes2Hex(event.Sender[:]))
+			r.lggr.Fatalw("sender must match the value emitted from the on-chain event. This should never happen.", "sender", protocol.ByteSlice(event.Sender[:]).String())
 			continue // ensure we never process this msg
 		}
 
 		if decodedMsg.MustMessageID() != event.MessageId {
 			r.onCriticalInvariant(ctx)
 			r.lggr.Fatalw("computed messageID must match the value emitted from the on-chain event — critical invariant violated; escalate immediately",
-				"messageId", common.Bytes2Hex(event.MessageId[:]))
+				protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String())
 			continue // ensure we never process this msg
 		}
 
 		if decodedMsg.DestChainSelector != protocol.ChainSelector(event.DestChainSelector) {
 			r.onCriticalInvariant(ctx)
-			r.lggr.Fatalw("destination chain selector must match the value emitted from the on-chain event. This should never happen", "messageId", common.Bytes2Hex(event.MessageId[:]))
+			r.lggr.Fatalw("destination chain selector must match the value emitted from the on-chain event. This should never happen", protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String())
 			continue // ensure we never process this msg
 		}
 
@@ -283,7 +283,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 		if err := protocol.ValidateCCVAndExecutorHash(*decodedMsg, allReceipts); err != nil {
 			r.lggr.Errorw("ccvAndExecutorHash validation failed",
 				"error", err,
-				"messageID", common.Bytes2Hex(event.MessageId[:]),
+				protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String(),
 				"blockNumber", log.BlockNumber)
 			continue // to next message
 		}

--- a/integration/pkg/accessors/evm/evm_source_reader.go
+++ b/integration/pkg/accessors/evm/evm_source_reader.go
@@ -152,7 +152,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 
 	// Process found events
 	for _, log := range logs {
-		r.lggr.Infow("Found CCIPMessageSent event!",
+		r.lggr.Debugw("Found CCIPMessageSent event",
 			"chainSelector", r.chainSelector,
 			"blockNumber", log.BlockNumber,
 			"txHash", log.TxHash.Hex(),
@@ -178,7 +178,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 		sender = common.BytesToAddress(log.Topics[2][12:])              // Last 20 bytes for address
 		copy(messageID[:], log.Topics[3][:])                            // Full 32 bytes
 
-		r.lggr.Infow("Event details",
+		r.lggr.Debugw("Event details",
 			"sourceChainSelector", r.chainSelector,
 			"destChainSelector", destChainSelector,
 			"sender", sender,
@@ -195,8 +195,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 			r.lggr.Errorw("Failed to unpack CCIPMessageSent event payload", "error", err)
 			continue // to next message
 		}
-		// Log the event structure using the fixed bindings
-		r.lggr.Infow("OnRamp Event Structure",
+		r.lggr.Debugw("OnRamp Event Structure",
 			"destChainSelector", event.DestChainSelector,
 			"sender", event.Sender,
 			protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String(),
@@ -213,7 +212,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 		}
 
 		for i, vr := range event.Receipts {
-			r.lggr.Infow("Receipt",
+			r.lggr.Debugw("Receipt",
 				"index", i,
 				"issuer", vr.Issuer.Hex(),
 				"destGasLimit", vr.DestGasLimit,
@@ -224,14 +223,14 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 
 		// Log executor receipt
 		executorReceipt := event.Receipts[len(event.Receipts)-2]
-		r.lggr.Infow("Executor Receipt",
+		r.lggr.Debugw("Executor Receipt",
 			"issuer", executorReceipt.Issuer.Hex(),
 			"destGasLimit", executorReceipt.DestGasLimit,
 			"destBytesOverhead", executorReceipt.DestBytesOverhead,
 			"feeTokenAmount", executorReceipt.FeeTokenAmount.String(),
 			"extraArgs", common.Bytes2Hex(executorReceipt.ExtraArgs))
 
-		r.lggr.Infow("Decoding encoded message",
+		r.lggr.Debugw("Decoding encoded message",
 			"encodedMessageLength", len(event.EncodedMessage),
 			protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String())
 		decodedMsg, err := protocol.DecodeMessage(event.EncodedMessage)
@@ -240,7 +239,7 @@ func (r *SourceReader) FetchMessageSentEvents(ctx context.Context, fromBlock, to
 			r.lggr.Errorw("Failed to decode message", "error", err, "rawMessage", event.EncodedMessage)
 			continue // to next message
 		}
-		r.lggr.Infow("Decoded message",
+		r.lggr.Debugw("Decoded message",
 			"message", decodedMsg)
 
 		// Validate that ccvAndExecutorHash is not zero - it's required

--- a/integration/pkg/destinationreader/evm_execution_attempt_poller.go
+++ b/integration/pkg/destinationreader/evm_execution_attempt_poller.go
@@ -470,7 +470,7 @@ func (p *EvmExecutionAttemptPoller) run(ctx context.Context) {
 			if err := p.processExecutionStateChanged(ctx, execStateChanged); err != nil {
 				p.lggr.Warnw("Failed to process execution state changed event, this may be due to invalid callData",
 					"error", err,
-					"messageID", execStateChanged.MessageId,
+					protocol.LogKeyMessageID, protocol.Bytes32(execStateChanged.MessageId).String(),
 					"txHash", execStateChanged.Raw.TxHash)
 			}
 
@@ -659,7 +659,7 @@ func (p *EvmExecutionAttemptPoller) pollForEvents(ctx context.Context) error {
 			if err := p.processExecutionStateChanged(ctx, event); err != nil {
 				p.lggr.Warnw("Failed to process execution state changed event from polling",
 					"error", err,
-					"messageID", event.MessageId,
+					protocol.LogKeyMessageID, protocol.Bytes32(event.MessageId).String(),
 					"txHash", event.Raw.TxHash,
 					"blockNumber", event.Raw.BlockNumber)
 				// Continue processing other events even if one fails
@@ -732,7 +732,7 @@ func (p *EvmExecutionAttemptPoller) processExecutionStateChanged(ctx context.Con
 	// Invairant check: assert that computed messageID matches on-chain event emission.
 	attemptMsgID := executionAttempt.Report.Message.MustMessageID()
 	if !bytes.Equal(msgID[:], attemptMsgID[:]) {
-		p.lggr.Errorw("MessageID from event does not match the computed messageID. This should never happen.", "messageID", msgID, "computedMessageID", attemptMsgID)
+		p.lggr.Errorw("MessageID from event does not match the computed messageID. This should never happen.", protocol.LogKeyMessageID, protocol.Bytes32(msgID).String(), "computedMessageID", attemptMsgID.String())
 		return fmt.Errorf("computed message id does not match event message id")
 	}
 

--- a/protocol/log_types.go
+++ b/protocol/log_types.go
@@ -20,6 +20,11 @@ const (
 	// the other.
 	LogTypeMessageFailure LogType = "message_failure"
 
+	// LogTypeRetryableMessageFailure marks a non-terminal per-message failure event:
+	// a processing attempt failed but will be retried. Unlike LogTypeMessageFailure,
+	// this is not a terminal outcome — the message may yet succeed.
+	LogTypeRetryableMessageFailure LogType = "retryable_message_failure"
+
 	// LogTypeMessageStatus marks a non-terminal per-message progress event, such as a
 	// verification being received, a message pending quorum, or a processing attempt.
 	// These can fire multiple times per message as it advances.

--- a/protocol/log_types.go
+++ b/protocol/log_types.go
@@ -46,4 +46,6 @@ const (
 	LogKeyNonce = "nonce"
 	// LogKeyJobID is the field key for a job-queue job ID.
 	LogKeyJobID = "jobID"
+	// LogKeySeqNum is the field key for a message sequence number.
+	LogKeySeqNum = "seqNum"
 )

--- a/protocol/log_types.go
+++ b/protocol/log_types.go
@@ -29,3 +29,21 @@ const (
 	// specific message, such as a periodic health summary.
 	LogTypeServiceStatus LogType = "service_status"
 )
+
+// Canonical structured-log field keys. Prefer these constants over string literals
+// when logging these fields, so a field's key name stays identical across every
+// service and cannot drift via typo (e.g. messageID vs message_id vs messageId).
+const (
+	// LogKeyMessageID is the field key for a CCIP message ID.
+	LogKeyMessageID = "messageID"
+	// LogKeySourceChain is the field key for a source chain selector.
+	LogKeySourceChain = "sourceChain"
+	// LogKeyDestChain is the field key for a destination chain selector.
+	LogKeyDestChain = "destChain"
+	// LogKeyChainSel is the field key for a generic (single) chain selector.
+	LogKeyChainSel = "chainSel"
+	// LogKeyNonce is the field key for a message sequence number / nonce.
+	LogKeyNonce = "nonce"
+	// LogKeyJobID is the field key for a job-queue job ID.
+	LogKeyJobID = "jobID"
+)

--- a/verifier/pkg/commit/verifier.go
+++ b/verifier/pkg/commit/verifier.go
@@ -130,10 +130,10 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 		return nil, fmt.Errorf("failed to convert messageID to Bytes32: %w", err)
 	}
 	cv.lggr.Debugw("Starting message verification",
-		"messageID", msgIDStr,
-		"nonce", message.SequenceNumber,
-		"sourceChain", message.SourceChainSelector,
-		"destChain", message.DestChainSelector,
+		protocol.LogKeyMessageID, msgIDStr,
+		protocol.LogKeyNonce, message.SequenceNumber,
+		protocol.LogKeySourceChain, message.SourceChainSelector,
+		protocol.LogKeyDestChain, message.DestChainSelector,
 	)
 
 	// 1. Validate that the message comes from a configured source chain
@@ -154,7 +154,7 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 	}
 
 	cv.lggr.Debugw("Message validation passed",
-		"messageID", messageID,
+		protocol.LogKeyMessageID, messageID,
 		"verifierAddress", sourceConfig.VerifierAddress,
 		"defaultExecutorAddress", sourceConfig.DefaultExecutorAddress,
 	)
@@ -190,7 +190,7 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 
 		// Fall back to the message discovery version if the default executor is found.
 		verifierBlob = protocol.MessageDiscoveryVersion
-		cv.lggr.Debugw("Using message discovery version for message", "messageID", messageID, "version", hexutil.Encode(verifierBlob))
+		cv.lggr.Debugw("Using message discovery version for message", protocol.LogKeyMessageID, messageID, "version", hexutil.Encode(verifierBlob))
 	}
 	hash, err := committee.NewSignableHash(messageID, verifierBlob)
 	if err != nil {
@@ -203,7 +203,7 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 	}
 
 	cv.lggr.Debugw("Message signed successfully",
-		"messageID", msgIDStr,
+		protocol.LogKeyMessageID, msgIDStr,
 		"signer", cv.signerAddress,
 		"signatureLength", len(encodedSignature),
 	)
@@ -217,10 +217,10 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 	// PER-MESSAGE LOG (status): signing complete; storage write is the terminal success.
 	cv.lggr.Infow("Message verification completed successfully",
 		protocol.LogTypeKey, protocol.LogTypeMessageStatus,
-		"messageID", msgIDStr,
-		"nonce", message.SequenceNumber,
-		"sourceChain", message.SourceChainSelector,
-		"destChain", message.DestChainSelector,
+		protocol.LogKeyMessageID, msgIDStr,
+		protocol.LogKeyNonce, message.SequenceNumber,
+		protocol.LogKeySourceChain, message.SourceChainSelector,
+		protocol.LogKeyDestChain, message.DestChainSelector,
 	)
 
 	return ccvNodeData, nil

--- a/verifier/pkg/commit/verifier.go
+++ b/verifier/pkg/commit/verifier.go
@@ -70,7 +70,7 @@ func (cv *Verifier) VerifyMessages(ctx context.Context, tasks []verifier.Verific
 		return nil
 	}
 
-	cv.lggr.Infow("Starting batch verification", "batchSize", len(tasks))
+	cv.lggr.Debugw("Starting batch verification", "batchSize", len(tasks))
 
 	// Collect results from concurrent verification
 	results := make([]verifier.VerificationResult, len(tasks))
@@ -111,7 +111,7 @@ func (cv *Verifier) VerifyMessages(ctx context.Context, tasks []verifier.Verific
 		}
 	}
 
-	cv.lggr.Infow("Batch verification completed",
+	cv.lggr.Debugw("Batch verification completed",
 		"batchSize", len(tasks),
 		"successCount", successCount,
 		"errorCount", errorCount)
@@ -129,7 +129,7 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert messageID to Bytes32: %w", err)
 	}
-	cv.lggr.Infow("Starting message verification",
+	cv.lggr.Debugw("Starting message verification",
 		"messageID", msgIDStr,
 		"nonce", message.SequenceNumber,
 		"sourceChain", message.SourceChainSelector,
@@ -153,7 +153,7 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 		)
 	}
 
-	cv.lggr.Infow("Message validation passed",
+	cv.lggr.Debugw("Message validation passed",
 		"messageID", messageID,
 		"verifierAddress", sourceConfig.VerifierAddress,
 		"defaultExecutorAddress", sourceConfig.DefaultExecutorAddress,
@@ -190,7 +190,7 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 
 		// Fall back to the message discovery version if the default executor is found.
 		verifierBlob = protocol.MessageDiscoveryVersion
-		cv.lggr.Infow("Using message discovery version for message", "messageID", messageID, "version", hexutil.Encode(verifierBlob))
+		cv.lggr.Debugw("Using message discovery version for message", "messageID", messageID, "version", hexutil.Encode(verifierBlob))
 	}
 	hash, err := committee.NewSignableHash(messageID, verifierBlob)
 	if err != nil {
@@ -202,7 +202,7 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 		return nil, fmt.Errorf("failed to sign message %s: %w", msgIDStr, err)
 	}
 
-	cv.lggr.Infow("Message signed successfully",
+	cv.lggr.Debugw("Message signed successfully",
 		"messageID", msgIDStr,
 		"signer", cv.signerAddress,
 		"signatureLength", len(encodedSignature),
@@ -214,7 +214,9 @@ func (cv *Verifier) verifyMessage(_ context.Context, verificationTask verifier.V
 		return nil, fmt.Errorf("failed to create CCV node data for message %s: %w", msgIDStr, err)
 	}
 
+	// PER-MESSAGE LOG (status): signing complete; storage write is the terminal success.
 	cv.lggr.Infow("Message verification completed successfully",
+		protocol.LogTypeKey, protocol.LogTypeMessageStatus,
 		"messageID", msgIDStr,
 		"nonce", message.SequenceNumber,
 		"sourceChain", message.SourceChainSelector,

--- a/verifier/pkg/heartbeat/reporter.go
+++ b/verifier/pkg/heartbeat/reporter.go
@@ -160,7 +160,7 @@ func (hr *Reporter) sendHeartbeat(ctx context.Context) {
 		return
 	}
 
-	hr.logger.Infow("Heartbeat sent successfully",
+	hr.logger.Debugw("Heartbeat sent successfully",
 		"verifierId", hr.verifierID,
 		"aggregatorId", resp.AggregatorID,
 		"chainCount", len(blockHeightsByChain),

--- a/verifier/pkg/jobqueue/observability_decorator.go
+++ b/verifier/pkg/jobqueue/observability_decorator.go
@@ -143,7 +143,7 @@ func (d *ObservabilityDecorator[T]) logQueueSize(ctx context.Context) {
 		return
 	}
 
-	d.lggr.Infow("JobQueue size",
+	d.lggr.Debugw("JobQueue size",
 		"queue", d.queue.Name(),
 		"size", size,
 	)

--- a/verifier/pkg/jobqueue/postgres_queue.go
+++ b/verifier/pkg/jobqueue/postgres_queue.go
@@ -461,7 +461,7 @@ func (q *PostgresJobQueue[T]) Retry(ctx context.Context, delay time.Duration, er
 			}
 
 			affected, _ := result.RowsAffected()
-			q.logger.Infow("Archived jobs that exceeded retry deadline",
+			q.logger.Debugw("Archived jobs that exceeded retry deadline",
 				"queue", q.config.Name,
 				"count", affected)
 		}
@@ -472,7 +472,7 @@ func (q *PostgresJobQueue[T]) Retry(ctx context.Context, delay time.Duration, er
 		return err
 	}
 
-	q.logger.Infow("Retried jobs",
+	q.logger.Debugw("Retried jobs",
 		"queue", q.config.Name,
 		"retried", len(retried),
 		"failed", len(failed),
@@ -536,7 +536,7 @@ func (q *PostgresJobQueue[T]) Fail(ctx context.Context, errors map[string]error,
 	}
 
 	affected, _ := result.RowsAffected()
-	q.logger.Infow("Failed and archived jobs",
+	q.logger.Debugw("Failed and archived jobs",
 		"queue", q.config.Name,
 		"count", affected,
 	)

--- a/verifier/pkg/sourcereader/reorg_tracker.go
+++ b/verifier/pkg/sourcereader/reorg_tracker.go
@@ -44,7 +44,7 @@ func (t *ReorgTracker) Track(destChain protocol.ChainSelector, seqNum protocol.S
 	count := len(t.reorgedSeqNums[destChain])
 
 	t.logger.Infow("Tracking reorged sequence number",
-		"destChain", destChain,
+		protocol.LogKeyDestChain, destChain,
 		protocol.LogKeySeqNum, seqNum,
 		"trackedCount", count,
 	)
@@ -84,7 +84,7 @@ func (t *ReorgTracker) Remove(destChain protocol.ChainSelector, seqNum protocol.
 	}
 
 	t.logger.Infow("Removed reorged sequence number from tracking",
-		"destChain", destChain,
+		protocol.LogKeyDestChain, destChain,
 		protocol.LogKeySeqNum, seqNum,
 		"trackedCount", newCount,
 	)

--- a/verifier/pkg/sourcereader/reorg_tracker.go
+++ b/verifier/pkg/sourcereader/reorg_tracker.go
@@ -45,7 +45,7 @@ func (t *ReorgTracker) Track(destChain protocol.ChainSelector, seqNum protocol.S
 
 	t.logger.Infow("Tracking reorged sequence number",
 		"destChain", destChain,
-		"seqNum", seqNum,
+		protocol.LogKeySeqNum, seqNum,
 		"trackedCount", count,
 	)
 
@@ -85,7 +85,7 @@ func (t *ReorgTracker) Remove(destChain protocol.ChainSelector, seqNum protocol.
 
 	t.logger.Infow("Removed reorged sequence number from tracking",
 		"destChain", destChain,
-		"seqNum", seqNum,
+		protocol.LogKeySeqNum, seqNum,
 		"trackedCount", newCount,
 	)
 

--- a/verifier/pkg/sourcereader/service.go
+++ b/verifier/pkg/sourcereader/service.go
@@ -322,8 +322,8 @@ func (r *Service) processEventCycle(ctx context.Context, latest, finalized *prot
 	for _, event := range events {
 		if r.filter != nil && !r.filter.Filter(event) {
 			r.logger.Debugw("Message filtered out by filter",
-				"messageID", event.MessageID.String(),
-				"destChain", event.Message.DestChainSelector,
+				protocol.LogKeyMessageID, event.MessageID.String(),
+				protocol.LogKeyDestChain, event.Message.DestChainSelector,
 			)
 			continue
 		}
@@ -433,10 +433,10 @@ func (r *Service) addToPendingQueueHandleReorg(tasks []verifier.VerificationTask
 		if existingBlock.Cmp(fromBlock) >= 0 && (toBlock == nil || existingBlock.Cmp(toBlock) <= 0) {
 			if _, exists := tasksMap[msgID]; !exists {
 				r.logger.Warnw("Removing task from pending queue due to reorg",
-					"messageID", msgID,
+					protocol.LogKeyMessageID, msgID,
 					"blockNumber", existing.BlockNumber,
 					"seqNum", existing.Message.SequenceNumber,
-					"destChain", existing.Message.DestChainSelector,
+					protocol.LogKeyDestChain, existing.Message.DestChainSelector,
 					"fromBlock", fromBlock.String(),
 				)
 				r.reorgTracker.Track(existing.Message.DestChainSelector, existing.Message.SequenceNumber)
@@ -450,9 +450,9 @@ func (r *Service) addToPendingQueueHandleReorg(tasks []verifier.VerificationTask
 		if taskBlock.Cmp(fromBlock) >= 0 && (toBlock == nil || taskBlock.Cmp(toBlock) <= 0) {
 			if _, exists := tasksMap[msgID]; !exists {
 				r.logger.Warnw("Removing task from sentTasks due to reorg",
-					"messageID", msgID,
+					protocol.LogKeyMessageID, msgID,
 					"seqNum", task.Message.SequenceNumber,
-					"destChain", task.Message.DestChainSelector,
+					protocol.LogKeyDestChain, task.Message.DestChainSelector,
 				)
 				r.reorgTracker.Track(task.Message.DestChainSelector, task.Message.SequenceNumber)
 				delete(r.sentTasks, msgID)
@@ -466,13 +466,13 @@ func (r *Service) addToPendingQueueHandleReorg(tasks []verifier.VerificationTask
 		}
 		if _, alreadySent := r.sentTasks[task.MessageID]; alreadySent {
 			r.logger.Debugw("Skipping already-sent message",
-				"messageID", task.MessageID,
+				protocol.LogKeyMessageID, task.MessageID,
 				"blockNumber", task.BlockNumber)
 			continue
 		}
 		r.pendingTasks[task.MessageID] = task
 		r.logger.Debugw("Added message to pending queue",
-			"messageID", task.MessageID,
+			protocol.LogKeyMessageID, task.MessageID,
 			"blockNumber", task.BlockNumber,
 			"seqNum", task.Message.SequenceNumber,
 			"pendingCount", len(r.pendingTasks))
@@ -542,9 +542,9 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 			if cursed {
 				if curseErr != nil {
 					r.logger.Warnw("Blocking lane - curse state unknown",
-						"messageID", msgID,
-						"sourceChain", task.Message.SourceChainSelector,
-						"destChain", task.Message.DestChainSelector,
+						protocol.LogKeyMessageID, msgID,
+						protocol.LogKeySourceChain, task.Message.SourceChainSelector,
+						protocol.LogKeyDestChain, task.Message.DestChainSelector,
 						"error", curseErr)
 					hasBlockingUnknown = true
 					// In this particular case we can't make a decision, so we'll just skip the task
@@ -552,9 +552,9 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 					continue
 				}
 				r.logger.Warnw("Dropping task - lane is cursed",
-					"messageID", msgID,
-					"sourceChain", task.Message.SourceChainSelector,
-					"destChain", task.Message.DestChainSelector)
+					protocol.LogKeyMessageID, msgID,
+					protocol.LogKeySourceChain, task.Message.SourceChainSelector,
+					protocol.LogKeyDestChain, task.Message.DestChainSelector)
 				toBeDeleted = append(toBeDeleted, msgID)
 				continue
 			}
@@ -562,18 +562,18 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 			disabled, disablementErr := r.messageRules.IsMessageDisabled(ctx, task.Message)
 			if disablementErr != nil {
 				r.logger.Warnw("Blocking message - message rules state unknown",
-					"messageID", msgID,
-					"sourceChain", task.Message.SourceChainSelector,
-					"destChain", task.Message.DestChainSelector,
+					protocol.LogKeyMessageID, msgID,
+					protocol.LogKeySourceChain, task.Message.SourceChainSelector,
+					protocol.LogKeyDestChain, task.Message.DestChainSelector,
 					"error", disablementErr)
 				hasBlockingUnknown = true
 				continue
 			}
 			if disabled {
 				r.logger.Warnw("Dropping task - message matched a disablement rule",
-					"messageID", msgID,
-					"sourceChain", task.Message.SourceChainSelector,
-					"destChain", task.Message.DestChainSelector)
+					protocol.LogKeyMessageID, msgID,
+					protocol.LogKeySourceChain, task.Message.SourceChainSelector,
+					protocol.LogKeyDestChain, task.Message.DestChainSelector)
 				toBeDeleted = append(toBeDeleted, msgID)
 				continue
 			}
@@ -685,9 +685,9 @@ func (r *Service) isMessageReadyForVerification(
 	if r.reorgTracker.RequiresFinalization(destChain, seqNum) {
 		ready := msgBlock.Cmp(latestFinalizedBlock) <= 0
 		r.logger.Debugw("Reorg-affected message finality check",
-			"messageID", task.MessageID,
+			protocol.LogKeyMessageID, task.MessageID,
 			"seqNum", seqNum,
-			"destChain", destChain,
+			protocol.LogKeyDestChain, destChain,
 			"messageBlock", task.BlockNumber,
 			"finalizedBlock", latestFinalizedBlock.String(),
 			"meetsRequirement", ready,
@@ -698,7 +698,7 @@ func (r *Service) isMessageReadyForVerification(
 	ready, err := task.Message.Finality.IsMessageReady(msgBlock, latestBlock, latestSafeBlock, latestFinalizedBlock)
 	if err != nil {
 		r.logger.Errorw("Finality check failed due to nil block argument",
-			"messageID", task.MessageID,
+			protocol.LogKeyMessageID, task.MessageID,
 			"error", err,
 		)
 		return false
@@ -708,7 +708,7 @@ func (r *Service) isMessageReadyForVerification(
 		safeBlockString = latestSafeBlock.String()
 	}
 	r.logger.Debugw("Finality check",
-		"messageID", task.MessageID,
+		protocol.LogKeyMessageID, task.MessageID,
 		"finality", task.Message.Finality,
 		"messageBlock", task.BlockNumber,
 		"latestBlock", latestBlock.String(),

--- a/verifier/pkg/sourcereader/service.go
+++ b/verifier/pkg/sourcereader/service.go
@@ -301,7 +301,7 @@ func (r *Service) loadEvents(ctx context.Context, fromBlock *big.Int, latest *pr
 }
 
 func (r *Service) processEventCycle(ctx context.Context, latest, finalized *protocol.BlockHeader) {
-	r.logger.Infow("processEventCycle starting",
+	r.logger.Debugw("processEventCycle starting",
 		"latestBlock", latest.Number,
 		"finalizedBlock", finalized.Number)
 
@@ -310,7 +310,7 @@ func (r *Service) processEventCycle(ctx context.Context, latest, finalized *prot
 
 	fromBlock := r.lastProcessedFinalizedBlock.Load()
 
-	r.logger.Infow("Querying from block", "fromBlock", fromBlock.String())
+	r.logger.Debugw("Querying from block", "fromBlock", fromBlock.String())
 	events, lastQueriedBlock, err := r.loadEvents(logsCtx, fromBlock, latest)
 	if err != nil {
 		r.logger.Warnw("Error when querying logs", "error", err,
@@ -321,7 +321,7 @@ func (r *Service) processEventCycle(ctx context.Context, latest, finalized *prot
 	tasks := make([]verifier.VerificationTask, 0, len(events))
 	for _, event := range events {
 		if r.filter != nil && !r.filter.Filter(event) {
-			r.logger.Infow("Message filtered out by filter",
+			r.logger.Debugw("Message filtered out by filter",
 				"messageID", event.MessageID.String(),
 				"destChain", event.Message.DestChainSelector,
 			)
@@ -471,7 +471,7 @@ func (r *Service) addToPendingQueueHandleReorg(tasks []verifier.VerificationTask
 			continue
 		}
 		r.pendingTasks[task.MessageID] = task
-		r.logger.Infow("Added message to pending queue",
+		r.logger.Debugw("Added message to pending queue",
 			"messageID", task.MessageID,
 			"blockNumber", task.BlockNumber,
 			"seqNum", task.Message.SequenceNumber,
@@ -486,7 +486,7 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 		stringSafeBlock = strconv.FormatUint(safe.Number, 10)
 	}
 
-	r.logger.Infow("Checking for ready messages to send",
+	r.logger.Debugw("Checking for ready messages to send",
 		"latestBlock", latest.Number,
 		"safeBlock", stringSafeBlock,
 		"finalizedBlock", finalized.Number)
@@ -612,7 +612,7 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 			return safeCheckpoint
 		}
 
-		r.logger.Infow("Publishing ready tasks to job queue",
+		r.logger.Debugw("Publishing ready tasks to job queue",
 			"ready", len(ready),
 			"pending", len(r.pendingTasks),
 			"sentTasks", len(r.sentTasks))
@@ -642,7 +642,7 @@ func (r *Service) sendReadyMessages(ctx context.Context, latest, safe, finalized
 			r.reorgTracker.Remove(task.Message.DestChainSelector, task.Message.SequenceNumber)
 		}
 
-		r.logger.Infow("Successfully published and tracked tasks",
+		r.logger.Debugw("Successfully published and tracked tasks",
 			"published", len(ready),
 			"remainingPending", len(r.pendingTasks),
 			"totalSent", len(r.sentTasks))
@@ -665,7 +665,7 @@ func (r *Service) writeCheckpoint(ctx context.Context, finalizedBlock uint64) {
 	}}); err != nil {
 		r.logger.Errorw("Failed to write checkpoint", "error", err, "finalizedBlock", finalizedBlock)
 	} else {
-		r.logger.Infow("Checkpoint advanced", "finalizedBlock", finalizedBlock)
+		r.logger.Debugw("Checkpoint advanced", "finalizedBlock", finalizedBlock)
 	}
 }
 
@@ -684,7 +684,7 @@ func (r *Service) isMessageReadyForVerification(
 
 	if r.reorgTracker.RequiresFinalization(destChain, seqNum) {
 		ready := msgBlock.Cmp(latestFinalizedBlock) <= 0
-		r.logger.Infow("Reorg-affected message finality check",
+		r.logger.Debugw("Reorg-affected message finality check",
 			"messageID", task.MessageID,
 			"seqNum", seqNum,
 			"destChain", destChain,
@@ -707,7 +707,7 @@ func (r *Service) isMessageReadyForVerification(
 	if latestSafeBlock != nil {
 		safeBlockString = latestSafeBlock.String()
 	}
-	r.logger.Infow("Finality check",
+	r.logger.Debugw("Finality check",
 		"messageID", task.MessageID,
 		"finality", task.Message.Finality,
 		"messageBlock", task.BlockNumber,

--- a/verifier/pkg/sourcereader/service.go
+++ b/verifier/pkg/sourcereader/service.go
@@ -435,7 +435,7 @@ func (r *Service) addToPendingQueueHandleReorg(tasks []verifier.VerificationTask
 				r.logger.Warnw("Removing task from pending queue due to reorg",
 					protocol.LogKeyMessageID, msgID,
 					"blockNumber", existing.BlockNumber,
-					"seqNum", existing.Message.SequenceNumber,
+					protocol.LogKeySeqNum, existing.Message.SequenceNumber,
 					protocol.LogKeyDestChain, existing.Message.DestChainSelector,
 					"fromBlock", fromBlock.String(),
 				)
@@ -451,7 +451,7 @@ func (r *Service) addToPendingQueueHandleReorg(tasks []verifier.VerificationTask
 			if _, exists := tasksMap[msgID]; !exists {
 				r.logger.Warnw("Removing task from sentTasks due to reorg",
 					protocol.LogKeyMessageID, msgID,
-					"seqNum", task.Message.SequenceNumber,
+					protocol.LogKeySeqNum, task.Message.SequenceNumber,
 					protocol.LogKeyDestChain, task.Message.DestChainSelector,
 				)
 				r.reorgTracker.Track(task.Message.DestChainSelector, task.Message.SequenceNumber)
@@ -474,7 +474,7 @@ func (r *Service) addToPendingQueueHandleReorg(tasks []verifier.VerificationTask
 		r.logger.Debugw("Added message to pending queue",
 			protocol.LogKeyMessageID, task.MessageID,
 			"blockNumber", task.BlockNumber,
-			"seqNum", task.Message.SequenceNumber,
+			protocol.LogKeySeqNum, task.Message.SequenceNumber,
 			"pendingCount", len(r.pendingTasks))
 	}
 }
@@ -686,7 +686,7 @@ func (r *Service) isMessageReadyForVerification(
 		ready := msgBlock.Cmp(latestFinalizedBlock) <= 0
 		r.logger.Debugw("Reorg-affected message finality check",
 			protocol.LogKeyMessageID, task.MessageID,
-			"seqNum", seqNum,
+			protocol.LogKeySeqNum, seqNum,
 			protocol.LogKeyDestChain, destChain,
 			"messageBlock", task.BlockNumber,
 			"finalizedBlock", latestFinalizedBlock.String(),

--- a/verifier/pkg/storagewriter/processor.go
+++ b/verifier/pkg/storagewriter/processor.go
@@ -210,7 +210,8 @@ func (s *Processor) processBatch(ctx context.Context) error {
 		if writeResult.Status == protocol.WriteSuccess {
 			successfulJobs = append(successfulJobs, jobID)
 			successfulResults = append(successfulResults, writeResult.Input)
-			s.lggr.Debugw("Write succeeded for message", "messageID", messageID, "jobID", jobID)
+			// PER-MESSAGE LOG (success): terminal; verification result persisted to storage.
+			s.lggr.Infow("Write succeeded for message", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, "messageID", messageID, "jobID", jobID)
 		} else {
 			if writeResult.Retryable {
 				retriableFailedJobs = append(retriableFailedJobs, jobID)
@@ -233,7 +234,7 @@ func (s *Processor) processBatch(ctx context.Context) error {
 	}
 
 	// Log summary
-	s.lggr.Infow("CCV data batch write completed",
+	s.lggr.Debugw("CCV data batch write completed",
 		"totalRequests", len(jobs),
 		"successful", len(successfulJobs),
 		"retriableFailed", len(retriableFailedJobs),

--- a/verifier/pkg/storagewriter/processor.go
+++ b/verifier/pkg/storagewriter/processor.go
@@ -211,22 +211,22 @@ func (s *Processor) processBatch(ctx context.Context) error {
 			successfulJobs = append(successfulJobs, jobID)
 			successfulResults = append(successfulResults, writeResult.Input)
 			// PER-MESSAGE LOG (success): terminal; verification result persisted to storage.
-			s.lggr.Infow("Write succeeded for message", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, "messageID", messageID, "jobID", jobID)
+			s.lggr.Infow("Write succeeded for message", protocol.LogTypeKey, protocol.LogTypeMessageSuccess, protocol.LogKeyMessageID, messageID, protocol.LogKeyJobID, jobID)
 		} else {
 			if writeResult.Retryable {
 				retriableFailedJobs = append(retriableFailedJobs, jobID)
 				failedErrorMap[jobID] = writeResult.Error
 				s.lggr.Errorw("Write failed for message (retryable)",
-					"messageID", messageID,
-					"jobID", jobID,
+					protocol.LogKeyMessageID, messageID,
+					protocol.LogKeyJobID, jobID,
 					"error", writeResult.Error,
 				)
 			} else {
 				nonRetriableFailedJobs = append(nonRetriableFailedJobs, jobID)
 				failedErrorMap[jobID] = writeResult.Error
 				s.lggr.Errorw("Write failed for message (non-retryable)",
-					"messageID", messageID,
-					"jobID", jobID,
+					protocol.LogKeyMessageID, messageID,
+					protocol.LogKeyJobID, jobID,
 					"error", writeResult.Error,
 				)
 			}

--- a/verifier/pkg/taskverifier/processor.go
+++ b/verifier/pkg/taskverifier/processor.go
@@ -368,7 +368,9 @@ func (p *Processor) handleVerificationError(
 		).
 		IncrementMessagesVerificationFailed(ctx)
 
+	// PER-MESSAGE LOG (failure): verification failed; retryable indicates whether it is terminal.
 	p.lggr.Errorw("Message verification failed",
+		protocol.LogTypeKey, protocol.LogTypeMessageFailure,
 		"error", verificationError.Error,
 		"messageID", verificationError.Task.MessageID,
 		"nonce", message.SequenceNumber,

--- a/verifier/pkg/taskverifier/processor.go
+++ b/verifier/pkg/taskverifier/processor.go
@@ -219,7 +219,7 @@ func (p *Processor) handleVerificationResults(
 
 		jobID, exists := jobIDMap[messageID]
 		if !exists {
-			p.lggr.Errorw("Job ID not found for message", "messageID", messageID)
+			p.lggr.Errorw("Job ID not found for message", protocol.LogKeyMessageID, messageID)
 			continue
 		}
 
@@ -372,10 +372,10 @@ func (p *Processor) handleVerificationError(
 	p.lggr.Errorw("Message verification failed",
 		protocol.LogTypeKey, protocol.LogTypeMessageFailure,
 		"error", verificationError.Error,
-		"messageID", verificationError.Task.MessageID,
-		"nonce", message.SequenceNumber,
-		"sourceChain", message.SourceChainSelector,
-		"destChain", message.DestChainSelector,
+		protocol.LogKeyMessageID, verificationError.Task.MessageID,
+		protocol.LogKeyNonce, message.SequenceNumber,
+		protocol.LogKeySourceChain, message.SourceChainSelector,
+		protocol.LogKeyDestChain, message.DestChainSelector,
 		"retryable", verificationError.Retryable,
 	)
 

--- a/verifier/pkg/taskverifier/processor.go
+++ b/verifier/pkg/taskverifier/processor.go
@@ -368,9 +368,13 @@ func (p *Processor) handleVerificationError(
 		).
 		IncrementMessagesVerificationFailed(ctx)
 
-	// PER-MESSAGE LOG (failure): verification failed; retryable indicates whether it is terminal.
+	// PER-MESSAGE LOG (failure/retryable): one per failed attempt; terminal only when !retryable.
+	logType := protocol.LogTypeMessageFailure
+	if verificationError.Retryable {
+		logType = protocol.LogTypeRetryableMessageFailure
+	}
 	p.lggr.Errorw("Message verification failed",
-		protocol.LogTypeKey, protocol.LogTypeMessageFailure,
+		protocol.LogTypeKey, logType,
 		"error", verificationError.Error,
 		protocol.LogKeyMessageID, verificationError.Task.MessageID,
 		protocol.LogKeyNonce, message.SequenceNumber,

--- a/verifier/pkg/token/cctp/attestation.go
+++ b/verifier/pkg/token/cctp/attestation.go
@@ -109,7 +109,7 @@ func (h *HTTPAttestationService) extractAttestationFromResponse(response Message
 	for _, msg := range response.Messages {
 		err := cctpMatchesMessage(h.verifierVersion, h.verifierAddresses, msg, message)
 		if err != nil {
-			h.lggr.Infow(
+			h.lggr.Debugw(
 				"skipping CCTP message as it doesn't match CCIP message",
 				"message", msg,
 				"reason", err,

--- a/verifier/pkg/token/cctp/verifier.go
+++ b/verifier/pkg/token/cctp/verifier.go
@@ -65,7 +65,7 @@ func (v *Verifier) VerifyMessages(
 	//  may lead to performance bottlenecks. Consider using a worker pool or goroutines with a semaphore to limit
 	//  concurrency.
 	for _, task := range tasks {
-		lggr := logger.With(v.lggr, "messageID", task.MessageID, "txHash", task.TxHash)
+		lggr := logger.With(v.lggr, protocol.LogKeyMessageID, task.MessageID, "txHash", task.TxHash)
 		lggr.Debugw("Verifying CCTP task")
 
 		// 1. Fetch attestation

--- a/verifier/pkg/token/cctp/verifier.go
+++ b/verifier/pkg/token/cctp/verifier.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
 	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/commit"
 	verifier "github.com/smartcontractkit/chainlink-ccv/verifier/pkg/vtypes"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -65,7 +66,7 @@ func (v *Verifier) VerifyMessages(
 	//  concurrency.
 	for _, task := range tasks {
 		lggr := logger.With(v.lggr, "messageID", task.MessageID, "txHash", task.TxHash)
-		lggr.Infow("Verifying CCTP task")
+		lggr.Debugw("Verifying CCTP task")
 
 		// 1. Fetch attestation
 		attestation, err := v.attestationService.Fetch(ctx, task.TxHash, task.Message)
@@ -94,7 +95,7 @@ func (v *Verifier) VerifyMessages(
 			continue
 		}
 
-		lggr.Infow("Attestation fetched and decoded successfully",
+		lggr.Debugw("Attestation fetched and decoded successfully",
 			"status", attestation.status,
 			"attestation", attestation.attestation,
 			"encodedCCTPMessage", attestation.encodedCCTPMessage,
@@ -115,7 +116,8 @@ func (v *Verifier) VerifyMessages(
 		}
 
 		// 3. Return successful result
-		lggr.Infow("VerifierResults: Successfully verified message", "signature", result.Signature)
+		// PER-MESSAGE LOG (status): signing complete; storage write is the terminal success.
+		lggr.Infow("VerifierResults: Successfully verified message", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "signature", result.Signature)
 		results = append(results, verifier.VerificationResult{Result: result})
 	}
 

--- a/verifier/pkg/token/lombard/verifier.go
+++ b/verifier/pkg/token/lombard/verifier.go
@@ -81,7 +81,7 @@ func (v *Verifier) VerifyMessages(
 	results := make([]verifier.VerificationResult, 0, len(tasks))
 	for _, task := range tasks {
 		lggr := logger.With(v.lggr, "messageID", task.MessageID, "txHash", task.TxHash)
-		lggr.Infow("Verifying Lombard task")
+		lggr.Debugw("Verifying Lombard task")
 
 		attestation, exists := attestations[task.MessageID]
 		if !exists {
@@ -112,7 +112,7 @@ func (v *Verifier) VerifyMessages(
 			continue
 		}
 
-		lggr.Infow("Attestation fetched and decoded successfully",
+		lggr.Debugw("Attestation fetched and decoded successfully",
 			"status", attestation.status,
 			"attestation", attestation.attestation,
 			"verifierFormat", verifierFormat,
@@ -131,7 +131,8 @@ func (v *Verifier) VerifyMessages(
 		}
 
 		// 2.1 Return successful result
-		lggr.Infow("VerifierResults: Successfully verified message", "signature", result.Signature)
+		// PER-MESSAGE LOG (status): signing complete; storage write is the terminal success.
+		lggr.Infow("VerifierResults: Successfully verified message", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "signature", result.Signature)
 		results = append(results, verifier.VerificationResult{Result: result})
 	}
 

--- a/verifier/pkg/token/lombard/verifier.go
+++ b/verifier/pkg/token/lombard/verifier.go
@@ -80,7 +80,7 @@ func (v *Verifier) VerifyMessages(
 	// 2. Process each task, iterate and match from response
 	results := make([]verifier.VerificationResult, 0, len(tasks))
 	for _, task := range tasks {
-		lggr := logger.With(v.lggr, "messageID", task.MessageID, "txHash", task.TxHash)
+		lggr := logger.With(v.lggr, protocol.LogKeyMessageID, task.MessageID, "txHash", task.TxHash)
 		lggr.Debugw("Verifying Lombard task")
 
 		attestation, exists := attestations[task.MessageID]


### PR DESCRIPTION
## Description

Extends the operator-facing logging cleanup from #1163 (aggregator + indexer) to the **executor** and **verifier** services, and adds two cross-cutting consistency guarantees for structured logs.

**Goal** — same targets as #1163: <50 logs at startup, <3 system logs/min at steady state, and a small bounded, machine-filterable set of logs per message.

### Executor & verifier log verbosity
- Demoted high-frequency diagnostic Info logs to Debug where metrics already cover steady-state observability: per-poll-cycle and per-message scheduling/decision logs in the executor hot path (`cl_executor`, coordinator), the verifier source-reader polling loop, per-heartbeat (`Heartbeat sent successfully`), per-queue-poll (`JobQueue size`), per-batch summaries, and queue retry/archive counts.
- Kept **one Info per per-message lifecycle stage** instead of every step, each tagged with the shared `protocol.LogType` taxonomy: `message_status` (in-flight progress, e.g. signing complete), `message_success` (terminal: report transmitted / result persisted), `message_failure` (terminal: expired, impossible quorum, verification failed). Neither service has a periodic health-summary loop, so no `service_status` log was added.
- Dropped the full `aggregatedReport` dump from the executor's per-message success line (moved to Debug) to keep the success log small.

### Canonical log-key constants
Introduced `protocol.LogKey*` constants (`messageID`, `sourceChain`, `destChain`, `chainSel`, `nonce`, `jobID`) and adopted them at the touched call sites across executor, verifier, and aggregator. This gives a single source of truth for these field-key names so they can't drift via typo (`message_id` / `messageId` / `messageID`); also fixed three aggregator sites that keyed message IDs as `message_id`.

### Consistent messageID value encoding
Every messageID logged now renders as `0x`-prefixed lowercase hex. Replaced `fmt.Sprintf("%x", …)` (no prefix), go-ethereum `common.Bytes2Hex` (no prefix), and raw `[32]byte`/`[]byte` values (which zap rendered as base64 or int arrays) with `protocol.Bytes32`/`ByteSlice` `.String()` in the aggregator, the EVM source reader / execution-attempt poller, and devenv tooling. Also corrected a log line that mislabeled a sender value as `messageId`.

## Testing

- `just lint fix` — 0 issues across all modules.
- `go build ./...` for `protocol`, `executor`, `verifier`, `aggregator`, `integration`, and `build/devenv` — all compile; `go vet` clean.
- Static verification: grep confirms remaining Info logs are limited to startup/shutdown, infrequent maintenance (4h cleanup), event-driven (reorg) and the tagged per-message lines; and that **no** `%x`/`Bytes2Hex` messageID encodings or `message_id`/`messageId` literal log-keys remain.

## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory) — n/a (logging-only; no API/behavior change)
- [x] Cross link related PRs — follows #1163
- [x] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date — n/a (no mock/proto changes)
