### PR TITLE
logging, services: add WithService helper and tag root loggers

### DIFF
--- a/aggregator/cmd/main.go
+++ b/aggregator/cmd/main.go
@@ -23,8 +23,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/configuration"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/monitoring"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/storage/postgres"
+	ccvcommon "github.com/smartcontractkit/chainlink-ccv/common"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
-	"github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
+	zaplog "github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -41,12 +42,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Invalid LOG_LEVEL '%s', defaulting to 'info'\n", logLevelStr)
 		zapLevel = zapcore.InfoLevel
 	}
-	lggr, err := logger.NewWith(logging.GetLogProfile(zapLevel))
+	lggr, err := logger.NewWith(zaplog.GetLogProfile(zapLevel))
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create logger: %v", err))
 	}
 	lggr = logger.Named(lggr, "aggregator")
-	lggr = logging.WithService(lggr, "aggregator")
+	lggr = ccvcommon.WithService(lggr, "aggregator")
 	sugaredLggr := logger.Sugared(lggr)
 
 	var (

--- a/aggregator/cmd/main.go
+++ b/aggregator/cmd/main.go
@@ -46,6 +46,7 @@ func main() {
 		panic(fmt.Sprintf("Failed to create logger: %v", err))
 	}
 	lggr = logger.Named(lggr, "aggregator")
+	lggr = logging.WithService(lggr, "aggregator")
 	sugaredLggr := logger.Sugared(lggr)
 
 	var (

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -478,6 +478,7 @@ func Run(
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
 	lggr = logger.Sugared(logger.Named(lggr, "Bootstrapper"))
+	lggr = logging.WithService(lggr, name)
 
 	bootstrapper, err := NewBootstrapper(name, lggr, fac, opts...)
 	if err != nil {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -17,11 +17,12 @@ import (
 
 	dbpkg "github.com/smartcontractkit/chainlink-ccv/bootstrap/db"
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
+	"github.com/smartcontractkit/chainlink-ccv/common"
 	jdclient "github.com/smartcontractkit/chainlink-ccv/common/jd/client"
 	"github.com/smartcontractkit/chainlink-ccv/common/jd/lifecycle"
 	jobstore "github.com/smartcontractkit/chainlink-ccv/common/jd/store"
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
-	"github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
+	zaplog "github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
 	"github.com/smartcontractkit/chainlink-common/keystore"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -343,7 +344,7 @@ func connectToDB(ctx context.Context, connStr string) (*sqlx.DB, error) {
 }
 
 func newServiceDeps(keyStore keystore.Keystore, logLevel zapcore.Level, name string) (ServiceDeps, error) {
-	lggr, err := logger.NewWith(logging.GetLogProfile(logLevel))
+	lggr, err := logger.NewWith(zaplog.GetLogProfile(logLevel))
 	if err != nil {
 		return ServiceDeps{}, fmt.Errorf("failed to create logger: %w", err)
 	}
@@ -473,12 +474,12 @@ func Run(
 	fac ServiceFactory,
 	opts ...Option,
 ) error {
-	lggr, err := logger.NewWith(logging.GetLogProfile(zapcore.InfoLevel))
+	lggr, err := logger.NewWith(zaplog.GetLogProfile(zapcore.InfoLevel))
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
 	lggr = logger.Sugared(logger.Named(lggr, "Bootstrapper"))
-	lggr = logging.WithService(lggr, name)
+	lggr = common.WithService(lggr, name)
 
 	bootstrapper, err := NewBootstrapper(name, lggr, fac, opts...)
 	if err != nil {

--- a/common/logging.go
+++ b/common/logging.go
@@ -4,5 +4,6 @@ import "github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 // WithService returns lggr with the "service" field set to name.
 func WithService(lggr logger.Logger, name string) logger.Logger {
-	return logger.With(lggr, "service", name)
+	// do not use the reserved "service" key.
+	return logger.With(lggr, "ccip_service", name)
 }

--- a/common/logging.go
+++ b/common/logging.go
@@ -1,0 +1,8 @@
+package common
+
+import "github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+// WithService returns lggr with the "service" field set to name.
+func WithService(lggr logger.Logger, name string) logger.Logger {
+	return logger.With(lggr, "service", name)
+}

--- a/indexer/cmd/main.go
+++ b/indexer/cmd/main.go
@@ -48,6 +48,7 @@ func main() {
 	}
 
 	lggr = logger.Named(lggr, "indexer")
+	lggr = logging.WithService(lggr, "indexer")
 	// Use SugaredLogger for better API
 	lggr = logger.Sugared(lggr)
 

--- a/indexer/cmd/main.go
+++ b/indexer/cmd/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/backofftimeprovider"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
 	"github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
-	"github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
+	zaplog "github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
 	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil/pg"
@@ -42,13 +42,13 @@ func main() {
 		panic(err)
 	}
 
-	lggr, err := logger.NewWith(logging.GetLogProfile(logLevel))
+	lggr, err := logger.NewWith(zaplog.GetLogProfile(logLevel))
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create logger: %v", err))
 	}
 
 	lggr = logger.Named(lggr, "indexer")
-	lggr = logging.WithService(lggr, "indexer")
+	lggr = ccvcommon.WithService(lggr, "indexer")
 	// Use SugaredLogger for better API
 	lggr = logger.Sugared(lggr)
 

--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/onramp"
+	ccvcommon "github.com/smartcontractkit/chainlink-ccv/common"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm"
-	"github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/heartbeatclient"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/messagerules"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/sourcereader"
@@ -40,7 +40,7 @@ func NewVerificationCoordinator(
 	relayers map[protocol.ChainSelector]legacyevm.Chain,
 	ds sqlutil.DataSource,
 ) (*verifier.Coordinator, error) {
-	lggr = logging.WithService(lggr, "verifier")
+	lggr = ccvcommon.WithService(lggr, "verifier")
 
 	if err := cfg.Validate(); err != nil {
 		lggr.Errorw("Invalid CCV verifier configuration.", "error", err)

--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/onramp"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm"
+	"github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/heartbeatclient"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/messagerules"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/sourcereader"
@@ -39,6 +40,8 @@ func NewVerificationCoordinator(
 	relayers map[protocol.ChainSelector]legacyevm.Chain,
 	ds sqlutil.DataSource,
 ) (*verifier.Coordinator, error) {
+	lggr = logging.WithService(lggr, "verifier")
+
 	if err := cfg.Validate(); err != nil {
 		lggr.Errorw("Invalid CCV verifier configuration.", "error", err)
 		return nil, fmt.Errorf("invalid ccv verifier configuration: %w", err)

--- a/integration/pkg/constructors/executor.go
+++ b/integration/pkg/constructors/executor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	ccvcommon "github.com/smartcontractkit/chainlink-ccv/common"
 	"github.com/smartcontractkit/chainlink-ccv/executor"
 	adapter "github.com/smartcontractkit/chainlink-ccv/executor/pkg/adapter"
 	x "github.com/smartcontractkit/chainlink-ccv/executor/pkg/executor"
@@ -20,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/destinationreader"
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
-	"github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
@@ -49,7 +49,7 @@ func NewExecutorCoordinator(
 	keys map[protocol.ChainSelector]keys.RoundRobin,
 	fromAddresses map[protocol.ChainSelector][]common.Address,
 ) (*executor.Coordinator, error) {
-	lggr = logging.WithService(lggr, "executor")
+	lggr = ccvcommon.WithService(lggr, "executor")
 
 	if err := cfg.Validate(); err != nil {
 		lggr.Errorw("Invalid executor configuration.", "error", err)

--- a/integration/pkg/constructors/executor.go
+++ b/integration/pkg/constructors/executor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/destinationreader"
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 	"github.com/smartcontractkit/chainlink-evm/pkg/keys"
@@ -48,6 +49,8 @@ func NewExecutorCoordinator(
 	keys map[protocol.ChainSelector]keys.RoundRobin,
 	fromAddresses map[protocol.ChainSelector][]common.Address,
 ) (*executor.Coordinator, error) {
+	lggr = logging.WithService(lggr, "executor")
+
 	if err := cfg.Validate(); err != nil {
 		lggr.Errorw("Invalid executor configuration.", "error", err)
 		return nil, fmt.Errorf("invalid executor configuration: %w", err)

--- a/protocol/common/logging/logging.go
+++ b/protocol/common/logging/logging.go
@@ -5,14 +5,7 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
-
-// WithService returns lggr with the "service" field set to name.
-func WithService(lggr logger.Logger, name string) logger.Logger {
-	return logger.With(lggr, "service", name)
-}
 
 // DevelopmentConfig returns a logging configuration with reasonable defaults for
 // development.

--- a/protocol/common/logging/logging.go
+++ b/protocol/common/logging/logging.go
@@ -5,7 +5,14 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
+
+// WithService returns lggr with the "service" field set to name.
+func WithService(lggr logger.Logger, name string) logger.Logger {
+	return logger.With(lggr, "service", name)
+}
 
 // DevelopmentConfig returns a logging configuration with reasonable defaults for
 // development.


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Add `common.WithService(lggr, name)` in the root `common` package and call it at each service entry point (bootstrap Run, committee verifier and executor constructors, indexer and aggregator main). Every log message emitted within a coordinator now carries a structured `"service"` field.

`WithService` lives in the top-level `common` package rather than `protocol/common/logging` because the `protocol` layer enforces a depguard rule that denies all `chainlink-common` imports; `common` is the appropriate home for shared helpers that depend on `chainlink-common/pkg/logger`.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date