### PR TITLE
Add per profile payload size for EVMTXGun load tests

### DIFF
--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -388,7 +388,7 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 	}
 
 	if messageProfile.HasData {
-		data := make([]byte, avgMsgDataSize)
+		data := make([]byte, load.MessageDataSizeBytes(messageProfile, avgMsgDataSize))
 		_, err2 := rand.Read(data)
 		if err2 != nil {
 			return cciptestinterfaces.MessageFields{}, cciptestinterfaces.MessageOptions{}, fmt.Errorf("failed to generate data: %w", err2)

--- a/build/devenv/tests/e2e/load/types.go
+++ b/build/devenv/tests/e2e/load/types.go
@@ -12,10 +12,23 @@ import (
 
 // MessageProfileConfig corresponds to a message profile in the TOML config.
 type MessageProfileConfig struct {
-	Finality int    `toml:"finality"`  // e.g., 1
-	Name     string `toml:"name"`      // e.g., "data only"
-	HasData  bool   `toml:"has_data"`  // e.g., true
-	HasToken bool   `toml:"has_token"` // e.g., true
+	Finality      int    `toml:"finality"`        // e.g., 1
+	Name          string `toml:"name"`            // e.g., "data only"
+	HasData       bool   `toml:"has_data"`        // e.g., true
+	DataSizeBytes int    `toml:"data_size_bytes"` // payload size when has_data is true; 0 uses default
+	HasToken      bool   `toml:"has_token"`       // e.g., true
+}
+
+// MessageDataSizeBytes returns the arbitrary-message payload size for a profile.
+// When HasData is false, returns 0. When DataSizeBytes is unset (0), returns defaultSize.
+func MessageDataSizeBytes(profile MessageProfileConfig, defaultSize int) int {
+	if !profile.HasData {
+		return 0
+	}
+	if profile.DataSizeBytes > 0 {
+		return profile.DataSizeBytes
+	}
+	return defaultSize
 }
 
 // ChainProfileConfig represents an chain in the test profile config.

--- a/build/devenv/tests/e2e/load/types_test.go
+++ b/build/devenv/tests/e2e/load/types_test.go
@@ -1,0 +1,44 @@
+package load
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageDataSizeBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		profile     MessageProfileConfig
+		defaultSize int
+		want        int
+	}{
+		{
+			name:        "no data",
+			profile:     MessageProfileConfig{Name: "empty"},
+			defaultSize: 1000,
+			want:        0,
+		},
+		{
+			name:        "has data uses default when size unset",
+			profile:     MessageProfileConfig{Name: "data", HasData: true},
+			defaultSize: 1000,
+			want:        1000,
+		},
+		{
+			name:        "has data uses explicit size",
+			profile:     MessageProfileConfig{Name: "large", HasData: true, DataSizeBytes: 1500},
+			defaultSize: 1000,
+			want:        1500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, MessageDataSizeBytes(tt.profile, tt.defaultSize))
+		})
+	}
+}


### PR DESCRIPTION
## What
Adding configurable payload size per profile for EVMTXGun load tests.

## Why
We need configurable arbitrary message payloads to exercise buffered execution under sustained RPS in Solana. CCV's profiles supports weighted selection but hardcodes 1000B for all `has_data` profiles which is not enough to trigger the use case.