### PR TITLE
build/devenv: synthesize committee topology from committeeccv config

### DIFF
--- a/build/devenv/components/committeeccv/component.go
+++ b/build/devenv/components/committeeccv/component.go
@@ -239,6 +239,13 @@ func runPhase3Core(
 		}
 	}
 
+	// Step 5c: Deploy CommitteeVerifier contracts (idempotent; a no-op when Phase 2 already deployed them).
+	if len(inputs.impls) > 0 {
+		if err := runDeployCommitteeVerifiers(localEnv, inputs.impls, inputs.selectors, inputs.topology); err != nil {
+			return nil, nil, fmt.Errorf("committeeccv: %w", err)
+		}
+	}
+
 	// Step 6: Generate aggregator committee configuration.
 	for _, agg := range aggregators {
 		if agg == nil {
@@ -489,6 +496,15 @@ func buildVerifierJobSpecEffects(
 	return effects, nil
 }
 
+// CommitteeDeployConfig carries the minimal per-committee parameters needed
+// for topology synthesis in the protocol_contracts Phase 2 component.
+type CommitteeDeployConfig struct {
+	Qualifier                    string `toml:"qualifier"`
+	VerifierVersion              string `toml:"verifier_version"`
+	Threshold                    uint8  `toml:"threshold"`
+	InsecureAggregatorConnection bool   `toml:"insecure_aggregator_connection"`
+}
+
 // Config is the [committeeccv] component config: the aggregator and standalone
 // verifier inputs for the committee verification stack. It mirrors the phased
 // devenv's [committeeccv] TOML section (Cfg.CommitteeCCVCfg in package ccv).
@@ -496,6 +512,7 @@ type Config struct {
 	Version    int                         `toml:"version"`
 	Aggregator []*services.AggregatorInput `toml:"aggregator"`
 	Verifier   []*committeeverifier.Input  `toml:"verifier"`
+	Committees []CommitteeDeployConfig     `toml:"committee"`
 }
 
 func decodeConfig(raw any) (Config, error) {
@@ -507,4 +524,82 @@ func decodeConfig(raw any) (Config, error) {
 		return Config{}, err
 	}
 	return cfg, nil
+}
+
+// runDeployCommitteeVerifiers deploys CommitteeVerifier contracts for all committees
+// in the topology. It is idempotent: when Phase 2 has already deployed via
+// DeployChainContracts, the adapter detects existing addresses and skips re-deployment.
+func runDeployCommitteeVerifiers(
+	localEnv *deployment.Environment,
+	impls []cciptestinterfaces.CCIP17Configuration,
+	selectors []uint64,
+	topology *ccvdeployment.EnvironmentTopology,
+) error {
+	if topology == nil || topology.NOPTopology == nil || len(topology.NOPTopology.Committees) == 0 {
+		return nil
+	}
+
+	// Build per-chain deployer contracts using each chain's impl.
+	chainCfgs := make(map[uint64]ccvchangesets.DeployCommitteeVerifierPerChainCfg, len(selectors))
+	for i, impl := range impls {
+		if i >= len(selectors) {
+			break
+		}
+		sel := selectors[i]
+		ccCfg, err := impl.GetDeployChainContractsCfg(localEnv, sel, topology)
+		if err != nil {
+			return fmt.Errorf("chain %d: get chain contracts config: %w", sel, err)
+		}
+		if ccCfg.DeployerContract == nil {
+			return fmt.Errorf("chain %d: nil DeployerContract in chain contracts config", sel)
+		}
+		chainCfgs[sel] = ccvchangesets.DeployCommitteeVerifierPerChainCfg{
+			DeployerContract: *ccCfg.DeployerContract,
+		}
+	}
+
+	// Build per-committee deploy params from the enriched topology.
+	committees := make([]ccvadapters.CommitteeVerifierDeployParams, 0, len(topology.NOPTopology.Committees))
+	for qualifier, committee := range topology.NOPTopology.Committees {
+		if committee.VerifierVersion == nil {
+			return fmt.Errorf("committee %q: VerifierVersion is nil in topology", qualifier)
+		}
+		var feeAgg string
+		for _, chainCfg := range committee.ChainConfigs {
+			if chainCfg.FeeAggregator != "" {
+				feeAgg = chainCfg.FeeAggregator
+				break
+			}
+		}
+		if feeAgg == "" {
+			return fmt.Errorf("committee %q: no FeeAggregator found in topology chain configs", qualifier)
+		}
+		committees = append(committees, ccvadapters.CommitteeVerifierDeployParams{
+			Qualifier:     qualifier,
+			Version:       committee.VerifierVersion,
+			FeeAggregator: feeAgg,
+		})
+	}
+
+	cs := ccvchangesets.DeployCommitteeVerifier(ccvadapters.GetRegistry())
+	output, err := cs.Apply(*localEnv, ccvchangesets.DeployCommitteeVerifierInput{
+		ChainSelectors: selectors,
+		Committees:     committees,
+		ChainCfgs:      chainCfgs,
+	})
+	if err != nil {
+		return fmt.Errorf("deploy committee verifiers: %w", err)
+	}
+
+	// Merge newly deployed addresses into the environment's DataStore without
+	// discarding the existing Phase 2 entries.
+	mergedDS := datastore.NewMemoryDataStore()
+	if err := mergedDS.Merge(localEnv.DataStore); err != nil {
+		return fmt.Errorf("merge existing datastore: %w", err)
+	}
+	if err := mergedDS.Merge(output.DataStore.Seal()); err != nil {
+		return fmt.Errorf("merge deployed verifier addresses: %w", err)
+	}
+	localEnv.DataStore = mergedDS.Seal()
+	return nil
 }

--- a/build/devenv/components/protocol_contracts/component.go
+++ b/build/devenv/components/protocol_contracts/component.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
 
@@ -118,6 +120,15 @@ func (p *component) RunPhase2(
 		return nil, nil, fmt.Errorf("creating CLDF operations environment: %w", err)
 	}
 	p.lggr.Info().Any("Selectors", selectors).Msg("Deploying for chain selectors")
+
+	// Synthesize committee topology from committeeccv config when none is provided.
+	if envTopology.NOPTopology == nil || len(envTopology.NOPTopology.Committees) == 0 {
+		synthesized, synthErr := synthesizeCommittees(globalConfig, selectors)
+		if synthErr != nil {
+			return nil, nil, fmt.Errorf("synthesizing committees from committeeccv config: %w", synthErr)
+		}
+		envTopology = injectCommittees(envTopology, synthesized)
+	}
 
 	topology := ccdeploy.BuildEnvironmentTopology(envTopology, nil, e)
 	if topology == nil {
@@ -252,4 +263,116 @@ func decodeConfig(raw any) (config, error) {
 		return config{}, err
 	}
 	return cfg, nil
+}
+
+// committeeDeploySpec mirrors committeeccv.CommitteeDeployConfig without importing that package.
+type committeeDeploySpec struct {
+	Qualifier                    string `toml:"qualifier"`
+	VerifierVersion              string `toml:"verifier_version"`
+	Threshold                    uint8  `toml:"threshold"`
+	InsecureAggregatorConnection bool   `toml:"insecure_aggregator_connection"`
+}
+
+// committeeVerifierSpec is a partial mirror of committeeverifier.Input.
+type committeeVerifierSpec struct {
+	NOPAlias      string `toml:"nop_alias"`
+	CommitteeName string `toml:"committee_name"`
+}
+
+// committeeAggregatorSpec is a partial mirror of services.AggregatorInput.
+type committeeAggregatorSpec struct {
+	Name          string `toml:"name"`
+	CommitteeName string `toml:"committee_name"`
+}
+
+// committeeccvPartial decodes only the fields needed for committee synthesis.
+type committeeccvPartial struct {
+	Committees  []committeeDeploySpec     `toml:"committee"`
+	Verifiers   []committeeVerifierSpec   `toml:"verifier"`
+	Aggregators []committeeAggregatorSpec `toml:"aggregator"`
+}
+
+// synthesizeCommittees builds a CommitteeConfig map from committeeccv config entries,
+// using the given chain selectors to populate per-chain configs. It returns nil when no
+// [[committeeccv.committee]] entries are present, signaling that synthesis is not needed.
+func synthesizeCommittees(globalConfig map[string]any, selectors []uint64) (map[string]ccvdeployment.CommitteeConfig, error) {
+	partial, err := devenvruntime.DecodeConfig[committeeccvPartial](globalConfig["committeeccv"], "committeeccv")
+	if err != nil {
+		return nil, fmt.Errorf("decoding committeeccv config for synthesis: %w", err)
+	}
+	if len(partial.Committees) == 0 {
+		return nil, nil
+	}
+
+	// Index verifier NOPAliases per committee qualifier.
+	nopsByCommittee := make(map[string][]string)
+	for _, v := range partial.Verifiers {
+		nopsByCommittee[v.CommitteeName] = append(nopsByCommittee[v.CommitteeName], v.NOPAlias)
+	}
+
+	// Index aggregator container address per committee qualifier.
+	aggAddrByCommittee := make(map[string]string)
+	for _, a := range partial.Aggregators {
+		instanceName := a.Name
+		if instanceName == "" {
+			instanceName = a.CommitteeName
+		}
+		aggAddrByCommittee[a.CommitteeName] = fmt.Sprintf("%s-aggregator:50051", instanceName)
+	}
+
+	committees := make(map[string]ccvdeployment.CommitteeConfig, len(partial.Committees))
+	for _, spec := range partial.Committees {
+		if spec.Qualifier == "" {
+			return nil, fmt.Errorf("committeeccv.committee entry missing qualifier")
+		}
+		ver, verErr := semver.NewVersion(spec.VerifierVersion)
+		if verErr != nil {
+			return nil, fmt.Errorf("committee %q: invalid verifier_version %q: %w", spec.Qualifier, spec.VerifierVersion, verErr)
+		}
+		nopAliases := nopsByCommittee[spec.Qualifier]
+		if len(nopAliases) == 0 {
+			return nil, fmt.Errorf("committee %q: no verifiers found in committeeccv config for synthesis", spec.Qualifier)
+		}
+		aggAddr, ok := aggAddrByCommittee[spec.Qualifier]
+		if !ok {
+			return nil, fmt.Errorf("committee %q: no aggregator found in committeeccv config for synthesis", spec.Qualifier)
+		}
+		chainCfgs := make(map[string]ccvdeployment.ChainCommitteeConfig, len(selectors))
+		for _, sel := range selectors {
+			chainCfgs[strconv.FormatUint(sel, 10)] = ccvdeployment.ChainCommitteeConfig{
+				NOPAliases: nopAliases,
+				Threshold:  spec.Threshold,
+			}
+		}
+		committees[spec.Qualifier] = ccvdeployment.CommitteeConfig{
+			Qualifier:       spec.Qualifier,
+			VerifierVersion: ver,
+			ChainConfigs:    chainCfgs,
+			Aggregators: []ccvdeployment.AggregatorConfig{
+				{
+					Name:                         spec.Qualifier,
+					Address:                      aggAddr,
+					InsecureAggregatorConnection: spec.InsecureAggregatorConnection,
+				},
+			},
+		}
+	}
+	return committees, nil
+}
+
+// injectCommittees returns a shallow copy of envTopology with the supplied committees
+// set on the NOPTopology. Returns the original pointer unchanged when committees is empty.
+func injectCommittees(envTopology *ccvdeployment.EnvironmentTopology, committees map[string]ccvdeployment.CommitteeConfig) *ccvdeployment.EnvironmentTopology {
+	if len(committees) == 0 {
+		return envTopology
+	}
+	topoWithCommittees := *envTopology
+	if topoWithCommittees.NOPTopology == nil {
+		topoWithCommittees.NOPTopology = &ccvdeployment.NOPTopology{}
+	} else {
+		nopCopy := *topoWithCommittees.NOPTopology
+		topoWithCommittees.NOPTopology = &nopCopy
+	}
+	topoWithCommittees.NOPTopology.Committees = committees
+	return &topoWithCommittees
 }

--- a/build/devenv/components/protocol_contracts/component.go
+++ b/build/devenv/components/protocol_contracts/component.go
@@ -121,7 +121,12 @@ func (p *component) RunPhase2(
 	}
 	p.lggr.Info().Any("Selectors", selectors).Msg("Deploying for chain selectors")
 
-	// Synthesize committee topology from committeeccv config when none is provided.
+	// TODO: remove after changeset decoupling.
+	// Temporary bridge — DeployChainContracts (chainlink-ccip) hard-requires
+	// NOPTopology.Committees to be non-empty and derives FeeAggregator for OnRamp/Executor
+	// contracts from the first committee entry. Once the changeset is updated to make
+	// committees optional (will/decouple-committee-contracts in chainlink-ccip), remove
+	// this synthesis block and the helpers below.
 	if envTopology.NOPTopology == nil || len(envTopology.NOPTopology.Committees) == 0 {
 		synthesized, synthErr := synthesizeCommittees(globalConfig, selectors)
 		if synthErr != nil {
@@ -295,6 +300,7 @@ type committeeccvPartial struct {
 // synthesizeCommittees builds a CommitteeConfig map from committeeccv config entries,
 // using the given chain selectors to populate per-chain configs. It returns nil when no
 // [[committeeccv.committee]] entries are present, signaling that synthesis is not needed.
+// TODO: Remove after changeset decoupling.
 func synthesizeCommittees(globalConfig map[string]any, selectors []uint64) (map[string]ccvdeployment.CommitteeConfig, error) {
 	partial, err := devenvruntime.DecodeConfig[committeeccvPartial](globalConfig["committeeccv"], "committeeccv")
 	if err != nil {

--- a/build/devenv/env-phased.toml
+++ b/build/devenv/env-phased.toml
@@ -81,68 +81,6 @@ alias = "custom-executor-1"
 name = "custom-executor-1"
 mode = "standalone"
 
-[protocol_contracts.environment_topology.nop_topology.committees.default]
-qualifier = "default"
-verifier_version = "2.0.0"
-
-[[protocol_contracts.environment_topology.nop_topology.committees.default.aggregators]]
-name = "default"
-address = "default-aggregator:50051"
-insecure_connection = true
-
-[protocol_contracts.environment_topology.nop_topology.committees.default.chain_configs.3379446385462418246]
-nop_aliases = ["default-verifier-1", "default-verifier-2"]
-threshold = 2
-
-[protocol_contracts.environment_topology.nop_topology.committees.default.chain_configs.12922642891491394802]
-nop_aliases = ["default-verifier-1", "default-verifier-2"]
-threshold = 2
-
-[protocol_contracts.environment_topology.nop_topology.committees.default.chain_configs.4793464827907405086]
-nop_aliases = ["default-verifier-1", "default-verifier-2"]
-threshold = 2
-
-[protocol_contracts.environment_topology.nop_topology.committees.secondary]
-qualifier = "secondary"
-verifier_version = "2.0.0"
-
-[[protocol_contracts.environment_topology.nop_topology.committees.secondary.aggregators]]
-name = "default"
-address = "secondary-aggregator:50051"
-insecure_connection = true
-
-[protocol_contracts.environment_topology.nop_topology.committees.secondary.chain_configs.3379446385462418246]
-nop_aliases = ["secondary-verifier-1", "secondary-verifier-2"]
-threshold = 2
-
-[protocol_contracts.environment_topology.nop_topology.committees.secondary.chain_configs.12922642891491394802]
-nop_aliases = ["secondary-verifier-1", "secondary-verifier-2"]
-threshold = 2
-
-[protocol_contracts.environment_topology.nop_topology.committees.secondary.chain_configs.4793464827907405086]
-nop_aliases = ["secondary-verifier-1", "secondary-verifier-2"]
-threshold = 2
-
-[protocol_contracts.environment_topology.nop_topology.committees.tertiary]
-qualifier = "tertiary"
-verifier_version = "2.0.0"
-
-[[protocol_contracts.environment_topology.nop_topology.committees.tertiary.aggregators]]
-name = "default"
-address = "tertiary-aggregator:50051"
-insecure_connection = true
-
-[protocol_contracts.environment_topology.nop_topology.committees.tertiary.chain_configs.3379446385462418246]
-nop_aliases = ["tertiary-verifier-1", "tertiary-verifier-2"]
-threshold = 2
-
-[protocol_contracts.environment_topology.nop_topology.committees.tertiary.chain_configs.12922642891491394802]
-nop_aliases = ["tertiary-verifier-1", "tertiary-verifier-2"]
-threshold = 2
-
-[protocol_contracts.environment_topology.nop_topology.committees.tertiary.chain_configs.4793464827907405086]
-nop_aliases = ["tertiary-verifier-1", "tertiary-verifier-2"]
-threshold = 2
 
 [protocol_contracts.environment_topology.executor_pools.default.chain_configs."3379446385462418246"]
 nop_aliases = ["default-executor-1"]
@@ -302,6 +240,24 @@ execution_interval = 15_000_000_000
     image = "postgres:16-alpine"
     name = "tertiary-verifier-2-db"
     port = 8437
+
+[[committeeccv.committee]]
+qualifier = "default"
+verifier_version = "2.0.0"
+threshold = 2
+insecure_aggregator_connection = true
+
+[[committeeccv.committee]]
+qualifier = "secondary"
+verifier_version = "2.0.0"
+threshold = 2
+insecure_aggregator_connection = true
+
+[[committeeccv.committee]]
+qualifier = "tertiary"
+verifier_version = "2.0.0"
+threshold = 2
+insecure_aggregator_connection = true
 
 
 [[token_verifier]]

--- a/go.sum
+++ b/go.sum
@@ -756,6 +756,7 @@ github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260608180601-efa8
 github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260608180601-efa81bfdfda9/go.mod h1:TfYlPkIj2wa35qqWLrk5//HkLoee5jzokxZ7PhK0tgk=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260224214816-cb23ec38649f h1:yimfZ/uU+o7YJ9ALvcgVxmRoQto/XqUbxgE+QgIWnlk=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260224214816-cb23ec38649f/go.mod h1:Kle+8kmKvbF8Cagj5hOAT+En5cZh28Qoi25aqxTHLUY=
+github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260526052449-0ceed63f1a5a/go.mod h1:Ls0oszLvhzV3/D0ivG85sh8qmmcsVhKplmepQdFq98E=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629 h1:YZCgnZteDIaV+Jrb6DDk4NQVJJ/ZwwYUaX9De/XUoCA=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629/go.mod h1:RnNTmxoheJYec/Gl/9t3wPLtFIHrlYjmWDdwZZJjchw=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2 h1:AWisx4JT3QV8tcgh6J5NCrex+wAgTYpWyHsyNPSXzsQ=

--- a/go.sum
+++ b/go.sum
@@ -756,7 +756,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260608180601-efa8
 github.com/smartcontractkit/chainlink-ccip/chains/evm v0.0.0-20260608180601-efa81bfdfda9/go.mod h1:TfYlPkIj2wa35qqWLrk5//HkLoee5jzokxZ7PhK0tgk=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260224214816-cb23ec38649f h1:yimfZ/uU+o7YJ9ALvcgVxmRoQto/XqUbxgE+QgIWnlk=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260224214816-cb23ec38649f/go.mod h1:Kle+8kmKvbF8Cagj5hOAT+En5cZh28Qoi25aqxTHLUY=
-github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260526052449-0ceed63f1a5a/go.mod h1:Ls0oszLvhzV3/D0ivG85sh8qmmcsVhKplmepQdFq98E=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629 h1:YZCgnZteDIaV+Jrb6DDk4NQVJJ/ZwwYUaX9De/XUoCA=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629/go.mod h1:RnNTmxoheJYec/Gl/9t3wPLtFIHrlYjmWDdwZZJjchw=
 github.com/smartcontractkit/chainlink-common/keystore v1.0.2 h1:AWisx4JT3QV8tcgh6J5NCrex+wAgTYpWyHsyNPSXzsQ=


### PR DESCRIPTION


<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Removes the duplicate `[protocol_contracts.environment_topology.nop_topology.committees.*]`
sections from `env-phased.toml`. Committee information now lives only under
`[[committeeccv.committee]]` entries.

### What changed

- **`env-phased.toml`**: Removes 62 lines of committee topology from the
  `protocol_contracts` section; adds three `[[committeeccv.committee]]` entries
  (qualifier, verifier_version, threshold, insecure_aggregator_connection).
- **`committeeccv/component.go`**: Adds `CommitteeDeployConfig` struct and
  `Committees []CommitteeDeployConfig` to `Config`. Phase 3 calls
  `runDeployCommitteeVerifiers` (idempotent) to register committee verifier
  contracts via the `DeployCommitteeVerifier` changeset.
- **`protocol_contracts/component.go`**: Adds a synthesis bridge — when the
  topology has no committees, Phase 2 derives them at runtime from
  `[[committeeccv.committee]]` config so `DeployChainContracts` receives the
  topology it requires.

### Why the synthesis bridge exists

`DeployChainContracts` (chainlink-ccip) hard-requires `NOPTopology.Committees` to
be non-empty and uses the first committee's `FeeAggregator` for OnRamp/Executor
contracts. The synthesis bridge is a temporary workaround that satisfies this
requirement without forcing users to duplicate committee config.

### Follow-up required

The synthesis bridge in `protocol_contracts/component.go` should be removed once
`DeployChainContracts` is updated to make committees optional (tracked in the
`will/decouple-committee-contracts` branch of chainlink-ccip). Once that lands, the
bridge can be dropped and Phase 3 fully owns CommitteeVerifier deployment.
<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
