### PR TITLE
Fix token rule matching

### DIFF
--- a/aggregator/cli/messagedisablement/README.md
+++ b/aggregator/cli/messagedisablement/README.md
@@ -72,6 +72,11 @@ chain/token pair on the same side of the message. Matching is strict:
 source selector is checked only against source token, and destination selector
 is checked only against destination token.
 
+Token addresses may be configured in minimal hex form (for example `0x7a9e...`).
+Matching treats two encodings as equal when one is the other with only leading
+zero bytes prepended, which covers variable-length CCIP wire encodings across
+chain families.
+
 ```sh
 aggregator message-disablement-rules create token --token 3379446385462418246,0xabc123
 ```

--- a/aggregator/cli/messagedisablement/README.md
+++ b/aggregator/cli/messagedisablement/README.md
@@ -72,7 +72,7 @@ chain/token pair on the same side of the message. Matching is strict:
 source selector is checked only against source token, and destination selector
 is checked only against destination token.
 
-Token addresses may be configured in minimal hex form (for example `0x7a9e...`).
+Token addresses may be configured in unpadded hex form (for example `0x7a9e...`).
 Matching treats two encodings as equal when one is the other with only leading
 zero bytes prepended, which covers variable-length CCIP wire encodings across
 chain families.

--- a/aggregator/pkg/messagerules/registry_test.go
+++ b/aggregator/pkg/messagerules/registry_test.go
@@ -204,6 +204,23 @@ func TestRegistry_TokenRule_DisablesSourceOrDestinationTokenTouch(t *testing.T) 
 	}))
 }
 
+func TestRegistry_TokenRule_DisablesLeftZeroPaddedSourceTokenAddress(t *testing.T) {
+	t.Parallel()
+
+	sourceData, err := shared.NewTokenRuleData(10, "0xAA")
+	require.NoError(t, err)
+	registry := newRegistry(t, []shared.Rule{makeRule(t, sourceData)})
+
+	paddedSourceToken := make([]byte, 32)
+	paddedSourceToken[31] = 0xaa
+
+	assert.True(t, registry.IsDisabled(report{
+		source: 10,
+		dest:   20,
+		token:  &protocol.TokenTransfer{SourceTokenAddress: paddedSourceToken},
+	}))
+}
+
 func TestRegistry_TokenRule_DoesNotDisableNonTokenMessage(t *testing.T) {
 	t.Parallel()
 

--- a/common/messagerules/addresses.go
+++ b/common/messagerules/addresses.go
@@ -1,0 +1,38 @@
+package messagerules
+
+import (
+	"bytes"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+func tokenAddressBytesEqual(ruleAddress string, messageToken protocol.ByteSlice) bool {
+	if len(messageToken) == 0 {
+		return false
+	}
+	ruleBytes, err := protocol.NewByteSliceFromHex(ruleAddress)
+	if err != nil || len(ruleBytes) == 0 {
+		return false
+	}
+	return addressBytesEqual(ruleBytes, messageToken)
+}
+
+func addressBytesEqual(a, b []byte) bool {
+	if bytes.Equal(a, b) {
+		return true
+	}
+	return isLeftZeroPaddedExtension(a, b) || isLeftZeroPaddedExtension(b, a)
+}
+
+func isLeftZeroPaddedExtension(longer, shorter []byte) bool {
+	if len(longer) <= len(shorter) {
+		return false
+	}
+	pad := longer[:len(longer)-len(shorter)]
+	for _, b := range pad {
+		if b != 0 {
+			return false
+		}
+	}
+	return bytes.Equal(longer[len(longer)-len(shorter):], shorter)
+}

--- a/common/messagerules/addresses_test.go
+++ b/common/messagerules/addresses_test.go
@@ -1,0 +1,166 @@
+package messagerules
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+)
+
+func TestAddressBytesEqual(t *testing.T) {
+	t.Parallel()
+
+	token20 := mustHexBytes(t, "7A9Ec1d04904907De0ED7b6839CcdD59c3716AC9")
+	token20Padded := leftZeroPad(token20, 32)
+	token20PaddedNonZeroPrefix := append([]byte(nil), token20Padded...)
+	token20PaddedNonZeroPrefix[0] = 0x01
+	tokenB := mustHexBytes(t, "0000000000000000000000000000000000000001")
+	pubkey32 := protocol.ByteSlice{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
+
+	tests := []struct {
+		name string
+		a    []byte
+		b    []byte
+		want bool
+	}{
+		{name: "exact_equal_length", a: []byte{0x01, 0x02}, b: []byte{0x01, 0x02}, want: true},
+		{name: "left_padded_message", a: token20, b: token20Padded, want: true},
+		{name: "left_padded_rule", a: token20Padded, b: token20, want: true},
+		{name: "equal_32_byte_non_evm", a: pubkey32, b: pubkey32, want: true},
+		{name: "padded_mismatch_non_zero_prefix", a: token20, b: token20PaddedNonZeroPrefix, want: false},
+		{name: "different_identity", a: token20, b: tokenB, want: false},
+		{name: "empty_shorter", a: []byte{}, b: token20, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, addressBytesEqual(tt.a, tt.b))
+		})
+	}
+}
+
+func TestTokenAddressBytesEqual(t *testing.T) {
+	t.Parallel()
+
+	token20Padded := leftZeroPad(mustHexBytes(t, "7A9Ec1d04904907De0ED7b6839CcdD59c3716AC9"), 32)
+
+	require.True(t, tokenAddressBytesEqual("0x7A9Ec1d04904907De0ED7b6839CcdD59c3716AC9", token20Padded))
+	require.False(t, tokenAddressBytesEqual("0x7A9Ec1d04904907De0ED7b6839CcdD59c3716AC9", protocol.ByteSlice{}))
+	require.False(t, tokenAddressBytesEqual("not-hex", token20Padded))
+}
+
+func TestCompiledRules_TokenRule_MatchesLeftZeroPaddedSourceTokenAddress(t *testing.T) {
+	t.Parallel()
+
+	const sourceSelector = protocol.ChainSelector(3379446385462418246)
+	const destSelector = protocol.ChainSelector(4793464827907405086)
+
+	token20 := mustHexBytes(t, "7A9Ec1d04904907De0ED7b6839CcdD59c3716AC9")
+	token20Padded := leftZeroPad(token20, 32)
+	token20PaddedNonZeroPrefix := append([]byte(nil), token20Padded...)
+	token20PaddedNonZeroPrefix[0] = 0x01
+	tokenB := mustHexBytes(t, "0000000000000000000000000000000000000001")
+	pubkey32 := protocol.ByteSlice{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
+
+	tokenRuleData, err := NewTokenRuleData(uint64(sourceSelector), "0x7A9Ec1d04904907De0ED7b6839CcdD59c3716AC9")
+	require.NoError(t, err)
+	tokenRule, err := NewRule("token", tokenRuleData, time.Time{}, time.Time{})
+	require.NoError(t, err)
+
+	compiled, err := CompileRules([]Rule{tokenRule})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		report   testMessageReport
+		disabled bool
+	}{
+		{
+			name: "exact_equal_length_dest_token",
+			report: testMessageReport{
+				source: 1,
+				dest:   sourceSelector,
+				tt:     &protocol.TokenTransfer{DestTokenAddress: protocol.ByteSlice{0x01, 0x02}},
+			},
+			disabled: false,
+		},
+		{
+			name: "left_padded_source_token_matches_minimal_rule",
+			report: testMessageReport{
+				source: sourceSelector,
+				dest:   destSelector,
+				tt:     &protocol.TokenTransfer{SourceTokenAddress: token20Padded},
+			},
+			disabled: true,
+		},
+		{
+			name: "left_padded_rule_matches_minimal_message_token",
+			report: testMessageReport{
+				source: sourceSelector,
+				dest:   destSelector,
+				tt:     &protocol.TokenTransfer{SourceTokenAddress: token20},
+			},
+			disabled: true,
+		},
+		{
+			name: "equal_32_byte_non_evm_token",
+			report: testMessageReport{
+				source: sourceSelector,
+				dest:   destSelector,
+				tt: &protocol.TokenTransfer{
+					SourceTokenAddress: pubkey32,
+				},
+			},
+			disabled: false,
+		},
+		{
+			name: "padded_mismatch_non_zero_prefix_does_not_disable",
+			report: testMessageReport{
+				source: sourceSelector,
+				dest:   destSelector,
+				tt:     &protocol.TokenTransfer{SourceTokenAddress: token20PaddedNonZeroPrefix},
+			},
+			disabled: false,
+		},
+		{
+			name: "different_token_identity_does_not_disable",
+			report: testMessageReport{
+				source: sourceSelector,
+				dest:   destSelector,
+				tt:     &protocol.TokenTransfer{SourceTokenAddress: tokenB},
+			},
+			disabled: false,
+		},
+		{
+			name:     "non_token_message_not_disabled",
+			report:   testMessageReport{source: sourceSelector, dest: destSelector},
+			disabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.disabled, compiled.IsDisabled(tt.report))
+		})
+	}
+}
+
+func mustHexBytes(t *testing.T, hex string) []byte {
+	t.Helper()
+	b, err := protocol.NewByteSliceFromHex("0x" + hex)
+	require.NoError(t, err)
+	return b
+}
+
+func leftZeroPad(b []byte, size int) []byte {
+	if len(b) >= size {
+		return append([]byte(nil), b...)
+	}
+	out := make([]byte, size)
+	copy(out[size-len(b):], b)
+	return out
+}

--- a/common/messagerules/rules.go
+++ b/common/messagerules/rules.go
@@ -3,7 +3,6 @@ package messagerules
 import (
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
 )
@@ -113,5 +112,5 @@ func matchesTokenRule(rule TokenRuleData, selector uint64, token protocol.ByteSl
 	if len(token) == 0 {
 		return false
 	}
-	return strings.EqualFold(token.String(), rule.TokenAddress)
+	return tokenAddressBytesEqual(rule.TokenAddress, token)
 }


### PR DESCRIPTION
This pull request improves the handling of token address matching in message disablement rules to support both minimal and left-zero-padded encodings, ensuring compatibility across different chain families and token formats. The changes introduce new logic for address comparison, update documentation, and add comprehensive tests to validate the new behavior.

**Token address matching improvements:**

* Added a new function `tokenAddressBytesEqual` (and helpers) in `common/messagerules/addresses.go` to treat token addresses as equal if one is a left-zero-padded extension of the other, covering both minimal and padded hex encodings.
* Updated `matchesTokenRule` in `common/messagerules/rules.go` to use the new address comparison logic instead of simple string equality.

**Documentation updates:**

* Expanded the `aggregator/cli/messagedisablement/README.md` to explain support for minimal and padded token addresses, including guidance on matching rules and destination-side behavior.

**Testing enhancements:**

* Added comprehensive unit tests for address matching logic in `common/messagerules/addresses_test.go`, covering various cases of minimal, padded, and mismatched addresses.
* Added a registry test to ensure that left-zero-padded source token addresses are correctly disabled by rules using minimal addresses in `aggregator/pkg/messagerules/registry_test.go`.

**Minor cleanup:**

* Removed unused import of `strings` from `common/messagerules/rules.go`.