### PR TITLE
verifier: committee verifier multi-aggregator support

### DIFF
--- a/changelog/2026-06-19_multi_aggregator_committee_verifier.md
+++ b/changelog/2026-06-19_multi_aggregator_committee_verifier.md
@@ -1,0 +1,110 @@
+# Multi-aggregator committee verifier (consolidated job)
+
+## Summary
+
+A committee verifier can now write to **multiple aggregators** from a single job
+(fan-out), instead of requiring one job per aggregator. This is fully additive and
+**opt-in**: existing single-`aggregator_address` configs and the existing changeset
+output are unchanged until a caller explicitly enables the new path. See
+`docs/adr/0001-multi-aggregator-committee-verifier.md` for the design and trade-offs.
+
+No breaking changes in this PR. One breaking change (`NewVerificationCoordinator`) is
+deliberately deferred to a coordinated follow-up — see *Heads-up* below.
+
+## AI Adapter Index
+
+All rows are **additive** — downstream code keeps compiling and behaving as before
+without changes. Adopt these only to enable the consolidated topology.
+
+| Symbol | Kind | Search | Section |
+|---|---|---|---|
+| `commit.Config.Aggregators` | added | `\bAggregators\b\|\[\[aggregators\]\]` | [#new-aggregators-config](#new-multi-aggregator-config) |
+| `commit.AggregatorConnection` | added | `AggregatorConnection\b` | [#new-aggregators-config](#new-multi-aggregator-config) |
+| `commit.Config.AggregatorAddress` | deprecated | `\bAggregatorAddress\b\|aggregator_address` | [#new-aggregators-config](#new-multi-aggregator-config) |
+| `commit.Config.ResolvedAggregators` | added | `ResolvedAggregators\(` | [#new-aggregators-config](#new-multi-aggregator-config) |
+| `commit.AggregatorCredentialEnvVars` | added | `AggregatorCredentialEnvVars\(` | [#new-per-aggregator-credentials](#new-per-aggregator-credentials) |
+| `commit.AggregatorConnection.ResolveHMACConfig` | added | `ResolveHMACConfig\(` | [#new-per-aggregator-credentials](#new-per-aggregator-credentials) |
+| `changesets.ApplyVerifierConfigInput.ConsolidateAggregators` | added | `ConsolidateAggregators\b` | [#new-consolidateaggregators-flag](#new-consolidateaggregators-changeset-flag) |
+| `changesets.AddNOPOffchainInput.ConsolidateAggregators` | added | `ConsolidateAggregators\b` | [#new-consolidateaggregators-flag](#new-consolidateaggregators-changeset-flag) |
+| `shared.NewConsolidatedVerifierJobID` | added | `NewConsolidatedVerifierJobID\(` | [#new-consolidateaggregators-flag](#new-consolidateaggregators-changeset-flag) |
+| `hmac.ValidateAPIKey` | behavior-changed | `ValidateAPIKey\(` | [#bug-fixes](#bug-fixes) |
+
+---
+
+## New: multi-aggregator config
+
+`commit.Config` gains an `aggregators` list. The legacy `aggregator_address` still works
+and is mutually exclusive with the list (setting both is a validation error). When the
+list is empty, the legacy field synthesizes a single-aggregator connection, so existing
+configs are unchanged.
+
+```toml
+# Legacy (still supported):
+aggregator_address = "agg:50051"
+insecure_aggregator_connection = true
+
+# New consolidated form:
+[[aggregators]]
+name = "primary"
+secret_name = "primary-default-verifier"
+address = "agg-1:50051"
+insecure_connection = true
+
+[[aggregators]]
+name = "secondary"
+secret_name = "secondary-default-verifier"
+address = "agg-2:50051"
+```
+
+Each result is written to **all** aggregators (all-must-ack; idempotent retries),
+heartbeats fan out to all, and disablement rules use a fail-safe union across all.
+
+---
+
+## New: per-aggregator credentials
+
+Each aggregator authenticates the verifier with its **own** HMAC credential, referenced
+by `AggregatorConnection.SecretName` (distinct from the display `Name`). Secrets are never
+stored in config — only the reference is.
+
+- **Standalone binary**: read from `VERIFIER_AGGREGATOR_<SECRETNAME>_API_KEY` /
+  `VERIFIER_AGGREGATOR_<SECRETNAME>_SECRET_KEY` (`<SECRETNAME>` upper-cased,
+  non-alphanumerics → `_`). A connection without a `secret_name` (legacy single aggregator)
+  falls back to the un-suffixed `VERIFIER_AGGREGATOR_API_KEY` / `VERIFIER_AGGREGATOR_SECRET_KEY`.
+- Multiple aggregators require a unique, non-empty `secret_name` each.
+
+---
+
+## New: `ConsolidateAggregators` changeset flag
+
+`ApplyVerifierConfig` and `AddNOPOffchain` gain a `ConsolidateAggregators bool`, **default
+`false`** (byte-identical one-job-per-aggregator output). When `true`, one consolidated job
+per NOP is emitted using the `aggregators` list and an aggregator-name-free `verifier_id`
+(`shared.NewConsolidatedVerifierJobID`); each aggregator's `secret_name` is set to the
+legacy per-aggregator `verifier_id` so existing operator secrets need no re-provisioning.
+
+```go
+changesets.ApplyVerifierConfigInput{
+    // ...
+    ConsolidateAggregators: true, // opt in; pair with RevokeOrphanedJobs to clean up old jobs
+}
+```
+
+---
+
+## Bug fixes
+
+- **`protocol/common/hmac`**: `ValidateAPIKey` no longer includes the API key value in its
+  error message (callers log this error). Fixes a CodeQL clear-text-logging finding on the
+  aggregator-credential path.
+
+---
+
+## Heads-up: deferred breaking change
+
+The Chainlink-node path (`constructors.NewVerificationCoordinator`) still takes a single
+`*hmac.ClientConfig` and is unchanged in this PR. A follow-up migrates it to a
+`SecretName`-keyed `map[string]*hmac.ClientConfig` (a breaking change), landed in lockstep
+with the chainlink-side `ccvcommitteeverifier/delegate.go` migration and devenv
+consolidation. Because `SecretName` reuses the existing `secrets.toml` `VerifierID` key,
+that migration needs no secret-store schema change.

--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -65,30 +64,6 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 	}
 	lggr.Infow("Using blockchain information from config", "info", genericConfig.ChainConfig)
 
-	// TODO: this should be passed in via the config maybe?
-	apiKey := os.Getenv("VERIFIER_AGGREGATOR_API_KEY")
-	if apiKey == "" {
-		lggr.Errorw("VERIFIER_AGGREGATOR_API_KEY environment variable is required")
-		return fmt.Errorf("VERIFIER_AGGREGATOR_API_KEY environment variable is required")
-	}
-	if err := hmac.ValidateAPIKey(apiKey); err != nil {
-		lggr.Errorw("Invalid VERIFIER_AGGREGATOR_API_KEY", "error", err)
-		return fmt.Errorf("invalid VERIFIER_AGGREGATOR_API_KEY: %w", err)
-	}
-	lggr.Infow("Loaded VERIFIER_AGGREGATOR_API_KEY from environment")
-
-	// TODO: this should be passed in via the config maybe?
-	secretKey := os.Getenv("VERIFIER_AGGREGATOR_SECRET_KEY")
-	if secretKey == "" {
-		lggr.Errorw("VERIFIER_AGGREGATOR_SECRET_KEY environment variable is required")
-		return fmt.Errorf("VERIFIER_AGGREGATOR_SECRET_KEY environment variable is required")
-	}
-	if err := hmac.ValidateSecret(secretKey); err != nil {
-		lggr.Errorw("Invalid VERIFIER_AGGREGATOR_SECRET_KEY", "error", err)
-		return fmt.Errorf("invalid VERIFIER_AGGREGATOR_SECRET_KEY: %w", err)
-	}
-	lggr.Infow("Loaded VERIFIER_AGGREGATOR_SECRET_KEY from environment")
-
 	profiler, err := StartPyroscope(lggr, config.PyroscopeURL, "verifier")
 	if err != nil {
 		lggr.Errorw("Failed to start pyroscope", "error", err)
@@ -118,11 +93,6 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		defaultExecutorAddresses[selector] = addr
 	}
 
-	hmacConfig := &hmac.ClientConfig{
-		APIKey: apiKey,
-		Secret: secretKey,
-	}
-
 	// Resolve the aggregators this job writes to, heartbeats, and reads disablement rules from.
 	// Backwards compatible: a legacy single aggregator_address resolves to a one-element list.
 	resolvedAggregators, err := config.ResolvedAggregators()
@@ -132,20 +102,34 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 	}
 	lggr.Infow("Resolved aggregators", "count", len(resolvedAggregators))
 
+	// Each aggregator authenticates the verifier with its own HMAC credential, read from
+	// per-aggregator environment variables (VERIFIER_AGGREGATOR_<NAME>_API_KEY/SECRET_KEY).
+	aggregatorHMACs := make([]*hmac.ClientConfig, len(resolvedAggregators))
+	for i, a := range resolvedAggregators {
+		hmacConfig, hErr := a.ResolveHMACConfig()
+		if hErr != nil {
+			lggr.Errorw("Failed to resolve aggregator credentials", "error", hErr, "aggregator", a.Label())
+			return fmt.Errorf("failed to resolve aggregator credentials: %w", hErr)
+		}
+		aggregatorHMACs[i] = hmacConfig
+	}
+
 	writeTargets := make([]storageaccess.AggregatorTarget, len(resolvedAggregators))
 	heartbeatTargets := make([]heartbeatclient.AggregatorTarget, len(resolvedAggregators))
 	for i, a := range resolvedAggregators {
 		writeTargets[i] = storageaccess.AggregatorTarget{
-			Label:               a.Name,
+			Label:               a.Label(),
 			Address:             a.Address,
 			Insecure:            a.InsecureConnection,
+			HMACConfig:          aggregatorHMACs[i],
 			MaxSendMsgSizeBytes: a.MaxSendMsgSizeBytes,
 			MaxRecvMsgSizeBytes: a.MaxRecvMsgSizeBytes,
 		}
 		heartbeatTargets[i] = heartbeatclient.AggregatorTarget{
-			Label:    a.Name,
-			Address:  a.Address,
-			Insecure: a.InsecureConnection,
+			Label:      a.Label(),
+			Address:    a.Address,
+			Insecure:   a.InsecureConnection,
+			HMACConfig: aggregatorHMACs[i],
 		}
 	}
 
@@ -231,7 +215,6 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		writeTargets,
 		config.VerifierID,
 		lggr,
-		hmacConfig,
 		verifierMonitoring,
 	)
 	if err != nil {
@@ -253,7 +236,6 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		heartbeatTargets,
 		config.VerifierID,
 		lggr,
-		hmacConfig,
 		heartbeat.NewHeartbeatMonitoringAdapter(verifierMonitoring),
 	)
 	if err != nil {
@@ -274,18 +256,18 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 	// Message-rules union: one poller per aggregator; a message is disabled if any aggregator
 	// disables it (fail-safe union), and verification is blocked while any source is unknown.
 	namedPollers := make([]messagerules.NamedPoller, 0, len(resolvedAggregators))
-	for _, a := range resolvedAggregators {
-		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Name)
+	for i, a := range resolvedAggregators {
+		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Label())
 		messageRulesClient, rErr := messagerules.NewGRPCClient(
 			a.Address,
 			aggLggr,
-			hmacConfig,
+			aggregatorHMACs[i],
 			a.InsecureConnection,
 			a.MaxRecvMsgSizeBytes,
 		)
 		if rErr != nil {
-			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Name)
-			return fmt.Errorf("failed to create message rules client for %q: %w", a.Name, rErr)
+			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Label())
+			return fmt.Errorf("failed to create message rules client for %q: %w", a.Label(), rErr)
 		}
 
 		poller, rErr := messagerules.NewPollerService(
@@ -293,13 +275,13 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 			messageRulesPollInterval,
 			messageRulesClientTimeout,
 			aggLggr,
-			verifierMonitoring.Metrics().With("aggregator", a.Name),
+			verifierMonitoring.Metrics().With("aggregator", a.Label()),
 		)
 		if rErr != nil {
-			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Name)
-			return fmt.Errorf("failed to create message rules poller for %q: %w", a.Name, rErr)
+			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Label())
+			return fmt.Errorf("failed to create message rules poller for %q: %w", a.Label(), rErr)
 		}
-		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Name, poller))
+		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Label(), poller))
 	}
 
 	messageRulesPoller, err := messagerules.NewUnionPollerService(

--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -35,8 +35,8 @@ type factory struct {
 	server           *http.Server
 	coordinator      *verifier.Coordinator
 	profiler         *pyroscope.Profiler
-	aggregatorWriter *storageaccess.AggregatorWriter
-	heartbeatClient  *heartbeatclient.HeartbeatClient
+	aggregatorWriter *storageaccess.FanOutWriter
+	heartbeatClient  heartbeatclient.HeartbeatSender
 	chainStatusDB    sqlutil.DataSource
 }
 
@@ -123,20 +123,31 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		Secret: secretKey,
 	}
 
-	aggregatorWriter, err := storageaccess.NewAggregatorWriter(
-		config.AggregatorAddress,
-		lggr,
-		hmacConfig,
-		config.InsecureAggregatorConnection,
-		config.AggregatorMaxSendMsgSizeBytes,
-		config.AggregatorMaxRecvMsgSizeBytes,
-	)
+	// Resolve the aggregators this job writes to, heartbeats, and reads disablement rules from.
+	// Backwards compatible: a legacy single aggregator_address resolves to a one-element list.
+	resolvedAggregators, err := config.ResolvedAggregators()
 	if err != nil {
-		lggr.Errorw("Failed to create aggregator writer", "error", err)
-		return fmt.Errorf("failed to create aggregator writer: %w", err)
+		lggr.Errorw("Invalid aggregator configuration", "error", err)
+		return fmt.Errorf("invalid aggregator configuration: %w", err)
 	}
+	lggr.Infow("Resolved aggregators", "count", len(resolvedAggregators))
 
-	f.aggregatorWriter = aggregatorWriter
+	writeTargets := make([]storageaccess.AggregatorTarget, len(resolvedAggregators))
+	heartbeatTargets := make([]heartbeatclient.AggregatorTarget, len(resolvedAggregators))
+	for i, a := range resolvedAggregators {
+		writeTargets[i] = storageaccess.AggregatorTarget{
+			Label:               a.Name,
+			Address:             a.Address,
+			Insecure:            a.InsecureConnection,
+			MaxSendMsgSizeBytes: a.MaxSendMsgSizeBytes,
+			MaxRecvMsgSizeBytes: a.MaxRecvMsgSizeBytes,
+		}
+		heartbeatTargets[i] = heartbeatclient.AggregatorTarget{
+			Label:    a.Name,
+			Address:  a.Address,
+			Insecure: a.InsecureConnection,
+		}
+	}
 
 	sourceReaders := make(map[protocol.ChainSelector]chainaccess.SourceReader)
 	for _, selector := range chainSelectors {
@@ -214,47 +225,42 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		return fmt.Errorf("failed to create commit verifier: %w", err)
 	}
 
+	// Write fan-out: one resilient + observed stack per aggregator, all writes fan out to every
+	// aggregator (all-must-ack). The top-level observed writer records the aggregate outcome.
+	fanOutWriter, err := storageaccess.NewFanOutAggregatorWriter(
+		writeTargets,
+		config.VerifierID,
+		lggr,
+		hmacConfig,
+		verifierMonitoring,
+	)
+	if err != nil {
+		lggr.Errorw("Failed to create fan-out aggregator writer", "error", err)
+		return fmt.Errorf("failed to create fan-out aggregator writer: %w", err)
+	}
+	f.aggregatorWriter = fanOutWriter
+
 	observedStorageWriter := storageaccess.NewObservedStorageWriter(
-		storageaccess.NewDefaultResilientStorageWriter(
-			aggregatorWriter,
-			lggr,
-		),
+		fanOutWriter,
 		config.VerifierID,
 		lggr,
 		verifierMonitoring,
 	)
 
-	heartbeatClient, err := heartbeatclient.NewHeartbeatClient(
-		config.AggregatorAddress,
-		lggr,
-		hmacConfig,
-		config.InsecureAggregatorConnection,
-	)
-	if err != nil {
-		lggr.Errorw("Failed to create heartbeat client", "error", err)
-		return fmt.Errorf("failed to create heartbeat client: %w", err)
-	}
-
-	f.heartbeatClient = heartbeatClient
-
-	observedHeartbeatClient := heartbeatclient.NewObservedHeartbeatClient(
-		heartbeatClient,
+	// Heartbeat fan-out: send liveness to every aggregator; per-aggregator metrics are recorded
+	// inside each wrapped observed client. A failure to one aggregator is non-blocking.
+	heartbeatSender, err := heartbeatclient.NewFanOutHeartbeatSender(
+		heartbeatTargets,
 		config.VerifierID,
 		lggr,
+		hmacConfig,
 		heartbeat.NewHeartbeatMonitoringAdapter(verifierMonitoring),
 	)
-
-	messageRulesClient, err := messagerules.NewGRPCClient(
-		config.AggregatorAddress,
-		lggr,
-		hmacConfig,
-		config.InsecureAggregatorConnection,
-		config.AggregatorMaxRecvMsgSizeBytes,
-	)
 	if err != nil {
-		lggr.Errorw("Failed to create message rules gRPC client", "error", err)
-		return fmt.Errorf("failed to create message rules client: %w", err)
+		lggr.Errorw("Failed to create fan-out heartbeat sender", "error", err)
+		return fmt.Errorf("failed to create fan-out heartbeat sender: %w", err)
 	}
+	f.heartbeatClient = heartbeatSender
 
 	messageRulesPollInterval, err := config.MessageDisablementRulesPollIntervalDuration()
 	if err != nil {
@@ -265,16 +271,44 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		return fmt.Errorf("message disablement rules client timeout: %w", err)
 	}
 
-	messageRulesPoller, err := messagerules.NewPollerService(
-		messageRulesClient,
-		messageRulesPollInterval,
-		messageRulesClientTimeout,
-		logger.With(lggr, "component", "MessageRulesPoller"),
-		verifierMonitoring.Metrics(),
+	// Message-rules union: one poller per aggregator; a message is disabled if any aggregator
+	// disables it (fail-safe union), and verification is blocked while any source is unknown.
+	namedPollers := make([]messagerules.NamedPoller, 0, len(resolvedAggregators))
+	for _, a := range resolvedAggregators {
+		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Name)
+		messageRulesClient, rErr := messagerules.NewGRPCClient(
+			a.Address,
+			aggLggr,
+			hmacConfig,
+			a.InsecureConnection,
+			a.MaxRecvMsgSizeBytes,
+		)
+		if rErr != nil {
+			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Name)
+			return fmt.Errorf("failed to create message rules client for %q: %w", a.Name, rErr)
+		}
+
+		poller, rErr := messagerules.NewPollerService(
+			messageRulesClient,
+			messageRulesPollInterval,
+			messageRulesClientTimeout,
+			aggLggr,
+			verifierMonitoring.Metrics().With("aggregator", a.Name),
+		)
+		if rErr != nil {
+			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Name)
+			return fmt.Errorf("failed to create message rules poller for %q: %w", a.Name, rErr)
+		}
+		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Name, poller))
+	}
+
+	messageRulesPoller, err := messagerules.NewUnionPollerService(
+		logger.With(lggr, "component", "UnionMessageRulesPoller"),
+		namedPollers...,
 	)
 	if err != nil {
-		lggr.Errorw("Failed to create message rules poller", "error", err)
-		return fmt.Errorf("failed to create message rules poller: %w", err)
+		lggr.Errorw("Failed to create union message rules poller", "error", err)
+		return fmt.Errorf("failed to create union message rules poller: %w", err)
 	}
 
 	messageTracker := monitoring.NewMessageLatencyTracker(
@@ -292,7 +326,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		messageTracker,
 		verifierMonitoring,
 		chainStatusManager,
-		observedHeartbeatClient,
+		heartbeatSender,
 		messageRulesPoller,
 		chainStatusDB,
 	)
@@ -336,7 +370,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 	})
 
 	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
-		stats := aggregatorWriter.GetStats()
+		stats := fanOutWriter.GetStats()
 		lggr.Infow("Storage Statistics:\n")
 		for key, value := range stats {
 			lggr.Infow("%s: %v\n", key, value)

--- a/deployment/changesets/add_nop_to_committee.go
+++ b/deployment/changesets/add_nop_to_committee.go
@@ -91,6 +91,10 @@ type AddNOPOffchainInput struct {
 	DisableFinalityCheckers []string
 	// Monitoring holds monitoring configuration included in the job spec.
 	Monitoring ccvdeployment.MonitoringConfig
+	// ConsolidateAggregators when true emits a single consolidated verifier job (writing to all of
+	// the committee's aggregators) for the added NOP, matching the consolidated topology. Default
+	// false preserves the legacy one-job-per-aggregator output.
+	ConsolidateAggregators bool
 }
 
 // AddNOPToCommittee is step-1 of a coupled onchain-first two-entry product.
@@ -372,6 +376,7 @@ func provisionVerifierJobForNOP(
 		cfg.Monitoring,
 		cfg.DisableFinalityCheckers,
 		signerFamily,
+		cfg.ConsolidateAggregators,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build verifier job specs: %w", err)

--- a/deployment/changesets/apply_verifier_config.go
+++ b/deployment/changesets/apply_verifier_config.go
@@ -51,6 +51,13 @@ type ApplyVerifierConfigInput struct {
 	DisableFinalityCheckers []string
 	// RevokeOrphanedJobs when true revokes and cleans up orphaned jobs; default false.
 	RevokeOrphanedJobs bool
+	// ConsolidateAggregators when true emits a single verifier job per NOP that writes to ALL of
+	// the committee's aggregators (using the aggregators list in the verifier config), instead of
+	// one job per aggregator. Default false preserves the legacy one-job-per-aggregator output
+	// byte-for-byte. Flipping it to true changes the verifier_id (the consolidated job omits the
+	// aggregator name) and orphans the old per-aggregator jobs; pair it with RevokeOrphanedJobs to
+	// clean those up.
+	ConsolidateAggregators bool
 }
 
 // ApplyVerifierConfig is the offchain-only single-entry product for §5.9 / §5.10:
@@ -182,6 +189,7 @@ func ApplyVerifierConfig() deployment.ChangeSetV2[ApplyVerifierConfigInput] {
 			cfg.Monitoring,
 			cfg.DisableFinalityCheckers,
 			signerFamily,
+			cfg.ConsolidateAggregators,
 		)
 		if err != nil {
 			return deployment.ChangesetOutput{}, err
@@ -314,6 +322,7 @@ func buildVerifierJobSpecs(
 	monitoring ccvdeployment.MonitoringConfig,
 	disableFinalityCheckers []string,
 	signerFamily string,
+	consolidateAggregators bool,
 ) (shared.NOPJobSpecs, shared.VerifierJobScope, error) {
 	scope := shared.VerifierJobScope{
 		CommitteeQualifier: committee.Qualifier,
@@ -355,36 +364,33 @@ func buildVerifierJobSpecs(
 			continue
 		}
 
-		for _, agg := range committee.Aggregators {
-			verifierJobID := shared.NewVerifierJobID(nopAlias, agg.Name, scope)
+		signerAddress := nop.SignerAddressByFamily[signerFamily]
+		if signerAddress == "" {
+			return nil, scope, fmt.Errorf("NOP %q missing signer address for family %s", nop.Alias, signerFamily)
+		}
 
-			signerAddress := nop.SignerAddressByFamily[signerFamily]
-			if signerAddress == "" {
-				return nil, scope, fmt.Errorf("NOP %q missing signer address for family %s", nop.Alias, signerFamily)
-			}
+		sortedFinalityCheckers := slices.Clone(disableFinalityCheckers)
+		slices.Sort(sortedFinalityCheckers)
 
-			sortedFinalityCheckers := slices.Clone(disableFinalityCheckers)
-			slices.Sort(sortedFinalityCheckers)
+		// baseCfg holds the per-NOP fields shared by both topologies. The aggregator wiring
+		// (legacy AggregatorAddress vs. Aggregators list) and VerifierID are filled in per job.
+		baseCfg := commit.Config{
+			SignerAddress:                  signerAddress,
+			PyroscopeURL:                   pyroscopeURL,
+			CommitteeVerifierAddresses:     filterAddressesByChains(committeeVerifierAddrs, nopChains),
+			DefaultExecutorOnRampAddresses: filterAddressesByChains(executorOnRampAddrs, nopChains),
+			DisableFinalityCheckers:        sortedFinalityCheckers,
+			Monitoring:                     monitoring,
+			CommitteeConfig: chainaccess.CommitteeConfig{
+				OnRampAddresses:    filterAddressesByChains(onRampAddrs, nopChains),
+				RMNRemoteAddresses: filterAddressesByChains(rmnRemoteAddrs, nopChains),
+			},
+		}
 
-			verifierCfg := commit.Config{
-				VerifierID:                     verifierJobID.GetVerifierID(),
-				AggregatorAddress:              agg.Address,
-				InsecureAggregatorConnection:   agg.InsecureAggregatorConnection,
-				SignerAddress:                  signerAddress,
-				PyroscopeURL:                   pyroscopeURL,
-				CommitteeVerifierAddresses:     filterAddressesByChains(committeeVerifierAddrs, nopChains),
-				DefaultExecutorOnRampAddresses: filterAddressesByChains(executorOnRampAddrs, nopChains),
-				DisableFinalityCheckers:        sortedFinalityCheckers,
-				Monitoring:                     monitoring,
-				CommitteeConfig: chainaccess.CommitteeConfig{
-					OnRampAddresses:    filterAddressesByChains(onRampAddrs, nopChains),
-					RMNRemoteAddresses: filterAddressesByChains(rmnRemoteAddrs, nopChains),
-				},
-			}
-
+		emitJob := func(verifierJobID shared.VerifierJobID, verifierCfg commit.Config, label string) error {
 			configBytes, err := toml.Marshal(verifierCfg)
 			if err != nil {
-				return nil, scope, fmt.Errorf("failed to marshal verifier config for NOP %q aggregator %q: %w", nopAlias, agg.Name, err)
+				return fmt.Errorf("failed to marshal verifier config for NOP %q (%s): %w", nopAlias, label, err)
 			}
 
 			jobID := verifierJobID.ToJobID()
@@ -400,6 +406,39 @@ committeeVerifierConfig = '''
 				jobSpecs[nopAlias] = make(map[shared.JobID]string)
 			}
 			jobSpecs[nopAlias][jobID] = jobSpec
+			return nil
+		}
+
+		if consolidateAggregators {
+			// One consolidated job per NOP writing to all aggregators via the Aggregators list.
+			verifierJobID := shared.NewConsolidatedVerifierJobID(nopAlias, scope)
+			aggregators := make([]commit.AggregatorConnection, len(committee.Aggregators))
+			for i, agg := range committee.Aggregators {
+				aggregators[i] = commit.AggregatorConnection{
+					Name:               agg.Name,
+					Address:            agg.Address,
+					InsecureConnection: agg.InsecureAggregatorConnection,
+				}
+			}
+			verifierCfg := baseCfg
+			verifierCfg.VerifierID = verifierJobID.GetVerifierID()
+			verifierCfg.Aggregators = aggregators
+			if err := emitJob(verifierJobID, verifierCfg, "consolidated"); err != nil {
+				return nil, scope, err
+			}
+			continue
+		}
+
+		// Legacy topology: one job per aggregator, each carrying a single AggregatorAddress.
+		for _, agg := range committee.Aggregators {
+			verifierJobID := shared.NewVerifierJobID(nopAlias, agg.Name, scope)
+			verifierCfg := baseCfg
+			verifierCfg.VerifierID = verifierJobID.GetVerifierID()
+			verifierCfg.AggregatorAddress = agg.Address
+			verifierCfg.InsecureAggregatorConnection = agg.InsecureAggregatorConnection
+			if err := emitJob(verifierJobID, verifierCfg, agg.Name); err != nil {
+				return nil, scope, err
+			}
 		}
 	}
 

--- a/deployment/changesets/apply_verifier_config.go
+++ b/deployment/changesets/apply_verifier_config.go
@@ -414,8 +414,13 @@ committeeVerifierConfig = '''
 			verifierJobID := shared.NewConsolidatedVerifierJobID(nopAlias, scope)
 			aggregators := make([]commit.AggregatorConnection, len(committee.Aggregators))
 			for i, agg := range committee.Aggregators {
+				// SecretName is the per-aggregator credential lookup key. We reuse the legacy
+				// per-aggregator verifier_id so operators' existing secrets (keyed by that id)
+				// keep working without re-provisioning when a NOP moves to a consolidated job.
+				secretName := shared.NewVerifierJobID(nopAlias, agg.Name, scope).GetVerifierID()
 				aggregators[i] = commit.AggregatorConnection{
 					Name:               agg.Name,
+					SecretName:         secretName,
 					Address:            agg.Address,
 					InsecureConnection: agg.InsecureAggregatorConnection,
 				}

--- a/deployment/changesets/apply_verifier_config_consolidation_test.go
+++ b/deployment/changesets/apply_verifier_config_consolidation_test.go
@@ -108,6 +108,11 @@ func TestBuildVerifierJobSpecs_ConsolidatedEmitsOneJobWithAllAggregators(t *test
 	assert.Equal(t, "agg-b:50051", cfg.Aggregators[1].Address)
 	assert.False(t, cfg.Aggregators[1].InsecureConnection)
 
+	// SecretName reuses the legacy per-aggregator verifier_id so existing operator secrets keep
+	// working without re-provisioning.
+	assert.Equal(t, "agg-a-default-verifier", cfg.Aggregators[0].SecretName)
+	assert.Equal(t, "agg-b-default-verifier", cfg.Aggregators[1].SecretName)
+
 	// Verifier ID omits the aggregator name.
 	assert.Equal(t, "default-verifier", cfg.VerifierID)
 }

--- a/deployment/changesets/apply_verifier_config_consolidation_test.go
+++ b/deployment/changesets/apply_verifier_config_consolidation_test.go
@@ -1,0 +1,113 @@
+package changesets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ccvdeployment "github.com/smartcontractkit/chainlink-ccv/deployment"
+	"github.com/smartcontractkit/chainlink-ccv/deployment/adapters"
+	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
+	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/commit"
+)
+
+func buildVerifierSpecsForTest(t *testing.T, consolidate bool) shared.NOPJobSpecs {
+	t.Helper()
+
+	contractAddresses := map[string]*adapters.VerifierContractAddresses{
+		"1": {
+			CommitteeVerifierAddress: "0xCommittee1",
+			OnRampAddress:            "0xOnRamp1",
+			ExecutorProxyAddress:     "0xExec1",
+			RMNRemoteAddress:         "0xRMN1",
+		},
+	}
+	nops := []verifierNOPInput{{
+		Alias:                 "nop1",
+		SignerAddressByFamily: map[string]string{"evm": "0xSIGNER"},
+	}}
+	committee := verifierCommitteeInput{
+		Qualifier: "default",
+		Aggregators: []AggregatorRef{
+			{Name: "agg-a", Address: "agg-a:50051", InsecureAggregatorConnection: true},
+			{Name: "agg-b", Address: "agg-b:50051"},
+		},
+		NOPAliases: []shared.NOPAlias{"nop1"},
+	}
+
+	specs, _, err := buildVerifierJobSpecs(
+		contractAddresses,
+		nil,
+		nops,
+		committee,
+		"",
+		ccvdeployment.MonitoringConfig{},
+		nil,
+		"evm",
+		consolidate,
+	)
+	require.NoError(t, err)
+	return specs
+}
+
+func parseVerifierConfig(t *testing.T, jobSpec string) commit.Config {
+	t.Helper()
+	const open = "committeeVerifierConfig = '''\n"
+	i := strings.Index(jobSpec, open)
+	require.GreaterOrEqual(t, i, 0, "job spec must contain committeeVerifierConfig")
+	rest := jobSpec[i+len(open):]
+	end := strings.Index(rest, "'''")
+	require.GreaterOrEqual(t, end, 0)
+	var cfg commit.Config
+	require.NoError(t, toml.Unmarshal([]byte(rest[:end]), &cfg))
+	return cfg
+}
+
+func TestBuildVerifierJobSpecs_LegacyEmitsOneJobPerAggregator(t *testing.T) {
+	specs := buildVerifierSpecsForTest(t, false)
+
+	jobs := specs["nop1"]
+	require.Len(t, jobs, 2, "legacy topology emits one job per aggregator")
+
+	byAggregator := map[string]commit.Config{}
+	for _, spec := range jobs {
+		parsed := parseVerifierConfig(t, spec)
+		require.Empty(t, parsed.Aggregators, "legacy jobs must not use the aggregators list")
+		require.NotEmpty(t, parsed.AggregatorAddress, "legacy jobs carry a single aggregator_address")
+		byAggregator[parsed.AggregatorAddress] = parsed
+	}
+	require.Contains(t, byAggregator, "agg-a:50051")
+	require.Contains(t, byAggregator, "agg-b:50051")
+	assert.True(t, byAggregator["agg-a:50051"].InsecureAggregatorConnection)
+	assert.False(t, byAggregator["agg-b:50051"].InsecureAggregatorConnection)
+
+	// Verifier IDs keep the aggregator name (legacy identity).
+	assert.Contains(t, jobs, shared.NewVerifierJobID("nop1", "agg-a", shared.VerifierJobScope{CommitteeQualifier: "default"}).ToJobID())
+	assert.Contains(t, jobs, shared.NewVerifierJobID("nop1", "agg-b", shared.VerifierJobScope{CommitteeQualifier: "default"}).ToJobID())
+}
+
+func TestBuildVerifierJobSpecs_ConsolidatedEmitsOneJobWithAllAggregators(t *testing.T) {
+	specs := buildVerifierSpecsForTest(t, true)
+
+	jobs := specs["nop1"]
+	require.Len(t, jobs, 1, "consolidated topology emits a single job per NOP")
+
+	consolidatedID := shared.NewConsolidatedVerifierJobID("nop1", shared.VerifierJobScope{CommitteeQualifier: "default"})
+	spec, ok := jobs[consolidatedID.ToJobID()]
+	require.True(t, ok, "consolidated job id must be present")
+
+	cfg := parseVerifierConfig(t, spec)
+	assert.Empty(t, cfg.AggregatorAddress, "consolidated job must not set the legacy aggregator_address")
+	require.Len(t, cfg.Aggregators, 2)
+	assert.Equal(t, "agg-a", cfg.Aggregators[0].Name)
+	assert.Equal(t, "agg-a:50051", cfg.Aggregators[0].Address)
+	assert.True(t, cfg.Aggregators[0].InsecureConnection)
+	assert.Equal(t, "agg-b:50051", cfg.Aggregators[1].Address)
+	assert.False(t, cfg.Aggregators[1].InsecureConnection)
+
+	// Verifier ID omits the aggregator name.
+	assert.Equal(t, "default-verifier", cfg.VerifierID)
+}

--- a/deployment/shared/types.go
+++ b/deployment/shared/types.go
@@ -136,6 +136,9 @@ type VerifierJobID struct {
 	NOPAlias           NOPAlias
 	CommitteeQualifier string
 	AggregatorName     string
+	// Consolidated marks a single verifier job that writes to all of a committee's aggregators
+	// (rather than one job per aggregator). Such a job's identity omits the aggregator name.
+	Consolidated bool
 }
 
 func NewVerifierJobID(nopAlias NOPAlias, aggregatorName string, scope VerifierJobScope) VerifierJobID {
@@ -146,11 +149,28 @@ func NewVerifierJobID(nopAlias NOPAlias, aggregatorName string, scope VerifierJo
 	}
 }
 
+// NewConsolidatedVerifierJobID builds the identity for a consolidated verifier job (one job per
+// NOP writing to every aggregator). The identity omits the aggregator name; its job ID still ends
+// in "-{committeeQualifier}-verifier" so scope matching (and orphaned-job cleanup) keeps working.
+func NewConsolidatedVerifierJobID(nopAlias NOPAlias, scope VerifierJobScope) VerifierJobID {
+	return VerifierJobID{
+		NOPAlias:           nopAlias,
+		CommitteeQualifier: scope.CommitteeQualifier,
+		Consolidated:       true,
+	}
+}
+
 func (id VerifierJobID) GetVerifierID() string {
+	if id.Consolidated {
+		return fmt.Sprintf("%s-verifier", id.CommitteeQualifier)
+	}
 	return fmt.Sprintf("%s-%s-verifier", id.AggregatorName, id.CommitteeQualifier)
 }
 
 func (id VerifierJobID) ToJobID() JobID {
+	if id.Consolidated {
+		return JobID(fmt.Sprintf("%s-%s-verifier", string(id.NOPAlias), id.CommitteeQualifier))
+	}
 	return JobID(fmt.Sprintf("%s-%s-%s-verifier", string(id.NOPAlias), id.AggregatorName, id.CommitteeQualifier))
 }
 

--- a/deployment/shared/verifier_job_id_test.go
+++ b/deployment/shared/verifier_job_id_test.go
@@ -1,0 +1,27 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifierJobID_PerAggregator(t *testing.T) {
+	scope := VerifierJobScope{CommitteeQualifier: "default"}
+	id := NewVerifierJobID("nop1", "agg-a", scope)
+
+	assert.Equal(t, "agg-a-default-verifier", id.GetVerifierID())
+	assert.Equal(t, JobID("nop1-agg-a-default-verifier"), id.ToJobID())
+	assert.True(t, scope.IsJobInScope(id.ToJobID()))
+}
+
+func TestVerifierJobID_Consolidated(t *testing.T) {
+	scope := VerifierJobScope{CommitteeQualifier: "default"}
+	id := NewConsolidatedVerifierJobID("nop1", scope)
+
+	assert.Equal(t, "default-verifier", id.GetVerifierID(), "consolidated verifier id omits the aggregator name")
+	assert.Equal(t, JobID("nop1-default-verifier"), id.ToJobID())
+	// Scope matching must still recognize consolidated jobs so orphaned-job cleanup works across
+	// the topology switch.
+	assert.True(t, scope.IsJobInScope(id.ToJobID()))
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/oklog/run v1.2.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.7.0
@@ -238,7 +239,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pion/dtls/v2 v2.2.12 // indirect
 	github.com/pion/logging v0.2.2 // indirect
 	github.com/pion/stun/v2 v2.0.0 // indirect

--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -28,9 +28,14 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 )
 
-// NewVerificationCoordinator starts the Committee Verifier with evm chains.
-// Signing is passed in because it's managed differently in the CL node vs standalone modes.
-// The DataSource is passed in from CL node, or created by standalone mode.
+// NewVerificationCoordinator builds a verifier coordinator. aggregatorSecret is the HMAC
+// credential used for every configured aggregator.
+//
+// TODO(CCIP-11776 follow-up): for a consolidated job each aggregator authenticates with its own
+// credential, so this should take a per-aggregator map keyed by AggregatorConnection.SecretName.
+// That is a breaking change to the Chainlink-node caller (ccvcommitteeverifier/delegate.go) and
+// lands together with that migration; until then this constructor applies one credential to all
+// aggregators, which is correct for the single-aggregator (legacy) configs in use today.
 func NewVerificationCoordinator(
 	lggr logger.Logger,
 	cfg commit.Config,
@@ -150,20 +155,23 @@ func NewVerificationCoordinator(
 		return nil, fmt.Errorf("invalid aggregator configuration: %w", err)
 	}
 
+	// The single provided credential is applied to every aggregator (see the constructor's TODO).
 	writeTargets := make([]storageaccess.AggregatorTarget, len(resolvedAggregators))
 	heartbeatTargets := make([]heartbeatclient.AggregatorTarget, len(resolvedAggregators))
 	for i, a := range resolvedAggregators {
 		writeTargets[i] = storageaccess.AggregatorTarget{
-			Label:               a.Name,
+			Label:               a.Label(),
 			Address:             a.Address,
 			Insecure:            a.InsecureConnection,
+			HMACConfig:          aggregatorSecret,
 			MaxSendMsgSizeBytes: a.MaxSendMsgSizeBytes,
 			MaxRecvMsgSizeBytes: a.MaxRecvMsgSizeBytes,
 		}
 		heartbeatTargets[i] = heartbeatclient.AggregatorTarget{
-			Label:    a.Name,
-			Address:  a.Address,
-			Insecure: a.InsecureConnection,
+			Label:      a.Label(),
+			Address:    a.Address,
+			Insecure:   a.InsecureConnection,
+			HMACConfig: aggregatorSecret,
 		}
 	}
 
@@ -173,7 +181,6 @@ func NewVerificationCoordinator(
 		writeTargets,
 		cfg.VerifierID,
 		lggr,
-		aggregatorSecret,
 		verifierMonitoring,
 	)
 	if err != nil {
@@ -212,7 +219,6 @@ func NewVerificationCoordinator(
 		heartbeatTargets,
 		cfg.VerifierID,
 		lggr,
-		aggregatorSecret,
 		heartbeat.NewHeartbeatMonitoringAdapter(verifierMonitoring),
 	)
 	if err != nil {
@@ -231,7 +237,7 @@ func NewVerificationCoordinator(
 
 	namedPollers := make([]messagerules.NamedPoller, 0, len(resolvedAggregators))
 	for _, a := range resolvedAggregators {
-		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Name)
+		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Label())
 		messageRulesClient, rErr := messagerules.NewGRPCClient(
 			a.Address,
 			aggLggr,
@@ -240,8 +246,8 @@ func NewVerificationCoordinator(
 			a.MaxRecvMsgSizeBytes,
 		)
 		if rErr != nil {
-			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Name)
-			return nil, fmt.Errorf("failed to create message rules client for %q: %w", a.Name, rErr)
+			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Label())
+			return nil, fmt.Errorf("failed to create message rules client for %q: %w", a.Label(), rErr)
 		}
 
 		poller, rErr := messagerules.NewPollerService(
@@ -249,13 +255,13 @@ func NewVerificationCoordinator(
 			messageRulesPollInterval,
 			messageRulesClientTimeout,
 			aggLggr,
-			verifierMonitoring.Metrics().With("aggregator", a.Name),
+			verifierMonitoring.Metrics().With("aggregator", a.Label()),
 		)
 		if rErr != nil {
-			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Name)
-			return nil, fmt.Errorf("failed to create message rules poller for %q: %w", a.Name, rErr)
+			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Label())
+			return nil, fmt.Errorf("failed to create message rules poller for %q: %w", a.Label(), rErr)
 		}
-		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Name, poller))
+		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Label(), poller))
 	}
 
 	messageRulesPoller, err := messagerules.NewUnionPollerService(

--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -142,26 +142,47 @@ func NewVerificationCoordinator(
 
 	// Initialize other required services and configs.
 
+	// Resolve the aggregators this verifier writes to, heartbeats, and reads disablement rules
+	// from. Backwards compatible: a legacy single aggregator_address resolves to a one-element list.
+	resolvedAggregators, err := cfg.ResolvedAggregators()
+	if err != nil {
+		lggr.Errorw("Invalid aggregator configuration", "error", err)
+		return nil, fmt.Errorf("invalid aggregator configuration: %w", err)
+	}
+
+	writeTargets := make([]storageaccess.AggregatorTarget, len(resolvedAggregators))
+	heartbeatTargets := make([]heartbeatclient.AggregatorTarget, len(resolvedAggregators))
+	for i, a := range resolvedAggregators {
+		writeTargets[i] = storageaccess.AggregatorTarget{
+			Label:               a.Name,
+			Address:             a.Address,
+			Insecure:            a.InsecureConnection,
+			MaxSendMsgSizeBytes: a.MaxSendMsgSizeBytes,
+			MaxRecvMsgSizeBytes: a.MaxRecvMsgSizeBytes,
+		}
+		heartbeatTargets[i] = heartbeatclient.AggregatorTarget{
+			Label:    a.Name,
+			Address:  a.Address,
+			Insecure: a.InsecureConnection,
+		}
+	}
+
 	// Checkpoint manager
 	// TODO: these are secrets, probably shouldn't be in config.
-	aggregatorWriter, err := storageaccess.NewAggregatorWriter(
-		cfg.AggregatorAddress,
+	fanOutWriter, err := storageaccess.NewFanOutAggregatorWriter(
+		writeTargets,
+		cfg.VerifierID,
 		lggr,
 		aggregatorSecret,
-		cfg.InsecureAggregatorConnection,
-		cfg.AggregatorMaxSendMsgSizeBytes,
-		cfg.AggregatorMaxRecvMsgSizeBytes,
+		verifierMonitoring,
 	)
 	if err != nil {
-		lggr.Errorw("Failed to create aggregator writer", "error", err)
-		return nil, fmt.Errorf("failed to create aggregator writer: %w", err)
+		lggr.Errorw("Failed to create fan-out aggregator writer", "error", err)
+		return nil, fmt.Errorf("failed to create fan-out aggregator writer: %w", err)
 	}
 
 	observedStorageWriter := storageaccess.NewObservedStorageWriter(
-		storageaccess.NewDefaultResilientStorageWriter(
-			aggregatorWriter,
-			lggr,
-		),
+		fanOutWriter,
 		cfg.VerifierID,
 		lggr,
 		verifierMonitoring,
@@ -187,34 +208,16 @@ func NewVerificationCoordinator(
 		return nil, fmt.Errorf("failed to create commit verifier: %w", err)
 	}
 
-	heartbeatClient, err := heartbeatclient.NewHeartbeatClient(
-		cfg.AggregatorAddress,
-		lggr,
-		aggregatorSecret,
-		cfg.InsecureAggregatorConnection,
-	)
-	if err != nil {
-		lggr.Errorw("Failed to create heartbeat client", "error", err)
-		return nil, fmt.Errorf("failed to create heartbeat client: %w", err)
-	}
-
-	observedHeartbeatClient := heartbeatclient.NewObservedHeartbeatClient(
-		heartbeatClient,
+	heartbeatSender, err := heartbeatclient.NewFanOutHeartbeatSender(
+		heartbeatTargets,
 		cfg.VerifierID,
 		lggr,
+		aggregatorSecret,
 		heartbeat.NewHeartbeatMonitoringAdapter(verifierMonitoring),
 	)
-
-	messageRulesClient, err := messagerules.NewGRPCClient(
-		cfg.AggregatorAddress,
-		lggr,
-		aggregatorSecret,
-		cfg.InsecureAggregatorConnection,
-		cfg.AggregatorMaxRecvMsgSizeBytes,
-	)
 	if err != nil {
-		lggr.Errorw("Failed to create message rules gRPC client", "error", err)
-		return nil, fmt.Errorf("failed to create message rules client: %w", err)
+		lggr.Errorw("Failed to create fan-out heartbeat sender", "error", err)
+		return nil, fmt.Errorf("failed to create fan-out heartbeat sender: %w", err)
 	}
 
 	messageRulesPollInterval, err := cfg.MessageDisablementRulesPollIntervalDuration()
@@ -226,16 +229,42 @@ func NewVerificationCoordinator(
 		return nil, fmt.Errorf("message disablement rules client timeout: %w", err)
 	}
 
-	messageRulesPoller, err := messagerules.NewPollerService(
-		messageRulesClient,
-		messageRulesPollInterval,
-		messageRulesClientTimeout,
-		logger.With(lggr, "component", "MessageRulesPoller"),
-		verifierMonitoring.Metrics(),
+	namedPollers := make([]messagerules.NamedPoller, 0, len(resolvedAggregators))
+	for _, a := range resolvedAggregators {
+		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Name)
+		messageRulesClient, rErr := messagerules.NewGRPCClient(
+			a.Address,
+			aggLggr,
+			aggregatorSecret,
+			a.InsecureConnection,
+			a.MaxRecvMsgSizeBytes,
+		)
+		if rErr != nil {
+			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Name)
+			return nil, fmt.Errorf("failed to create message rules client for %q: %w", a.Name, rErr)
+		}
+
+		poller, rErr := messagerules.NewPollerService(
+			messageRulesClient,
+			messageRulesPollInterval,
+			messageRulesClientTimeout,
+			aggLggr,
+			verifierMonitoring.Metrics().With("aggregator", a.Name),
+		)
+		if rErr != nil {
+			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Name)
+			return nil, fmt.Errorf("failed to create message rules poller for %q: %w", a.Name, rErr)
+		}
+		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Name, poller))
+	}
+
+	messageRulesPoller, err := messagerules.NewUnionPollerService(
+		logger.With(lggr, "component", "UnionMessageRulesPoller"),
+		namedPollers...,
 	)
 	if err != nil {
-		lggr.Errorw("Failed to create message rules poller", "error", err)
-		return nil, fmt.Errorf("failed to create message rules poller: %w", err)
+		lggr.Errorw("Failed to create union message rules poller", "error", err)
+		return nil, fmt.Errorf("failed to create union message rules poller: %w", err)
 	}
 
 	messageTracker := monitoring.NewMessageLatencyTracker(
@@ -253,7 +282,7 @@ func NewVerificationCoordinator(
 		messageTracker,
 		verifierMonitoring,
 		chainStatusManager,
-		observedHeartbeatClient,
+		heartbeatSender,
 		messageRulesPoller,
 		ds,
 	)

--- a/integration/pkg/heartbeatclient/fanout_heartbeat_client.go
+++ b/integration/pkg/heartbeatclient/fanout_heartbeat_client.go
@@ -1,0 +1,149 @@
+package heartbeatclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+var _ HeartbeatSender = (*FanOutHeartbeatSender)(nil)
+
+// AggregatorTarget describes one aggregator the fan-out heartbeat sender delivers to.
+type AggregatorTarget struct {
+	// Label identifies the aggregator in logs and metrics.
+	Label string
+	// Address is the aggregator gRPC endpoint.
+	Address string
+	// Insecure disables TLS for this aggregator's connection.
+	Insecure bool
+}
+
+type labeledSender struct {
+	label  string
+	sender HeartbeatSender
+}
+
+// FanOutHeartbeatSender sends each heartbeat to all configured aggregators. Per-aggregator
+// outcomes (sent/failed counters, durations) are recorded by each wrapped observed client under
+// an "aggregator" metric label. A failure to one aggregator is logged and does not prevent the
+// others from receiving the heartbeat: SendHeartbeat returns an error only when every aggregator
+// fails.
+type FanOutHeartbeatSender struct {
+	senders []labeledSender
+	lggr    logger.Logger
+}
+
+// NewFanOutHeartbeatSender builds a fan-out heartbeat sender over the given aggregator targets.
+// Each target gets its own heartbeat client wrapped in an observed client labeled with the
+// aggregator, so per-aggregator liveness metrics are emitted. At least one target is required.
+func NewFanOutHeartbeatSender(
+	targets []AggregatorTarget,
+	verifierID string,
+	lggr logger.Logger,
+	hmacConfig *hmac.ClientConfig,
+	monitoring Monitoring,
+) (*FanOutHeartbeatSender, error) {
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("fan-out heartbeat sender requires at least one aggregator target")
+	}
+
+	f := &FanOutHeartbeatSender{
+		senders: make([]labeledSender, 0, len(targets)),
+		lggr:    lggr,
+	}
+
+	for _, t := range targets {
+		aggLggr := logger.With(lggr, "aggregator", t.Label)
+		client, err := NewHeartbeatClient(t.Address, aggLggr, hmacConfig, t.Insecure)
+		if err != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("failed to create heartbeat client for %q: %w", t.Label, err)
+		}
+
+		observed := NewObservedHeartbeatClient(
+			client,
+			verifierID,
+			aggLggr,
+			aggregatorLabeledMonitoring{inner: monitoring, label: t.Label},
+		)
+		f.senders = append(f.senders, labeledSender{label: t.Label, sender: observed})
+	}
+
+	return f, nil
+}
+
+// SendHeartbeat sends the heartbeat to all aggregators concurrently. It returns the first
+// successful response, or a joined error if all aggregators failed.
+func (f *FanOutHeartbeatSender) SendHeartbeat(ctx context.Context, blockHeightsByChain map[uint64]uint64) (HeartbeatResponse, error) {
+	type outcome struct {
+		resp HeartbeatResponse
+		err  error
+	}
+	outcomes := make([]outcome, len(f.senders))
+
+	var wg sync.WaitGroup
+	for i := range f.senders {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			resp, err := f.senders[i].sender.SendHeartbeat(ctx, blockHeightsByChain)
+			outcomes[i] = outcome{resp: resp, err: err}
+		}(i)
+	}
+	wg.Wait()
+
+	var (
+		errs        []error
+		firstOK     *HeartbeatResponse
+		failedCount int
+	)
+	for i, o := range outcomes {
+		if o.err != nil {
+			failedCount++
+			errs = append(errs, fmt.Errorf("aggregator %q: %w", f.senders[i].label, o.err))
+			continue
+		}
+		if firstOK == nil {
+			resp := o.resp
+			firstOK = &resp
+		}
+	}
+
+	if firstOK == nil {
+		return HeartbeatResponse{}, fmt.Errorf("all aggregators failed to receive heartbeat: %w", errors.Join(errs...))
+	}
+	if failedCount > 0 {
+		f.lggr.Warnw("Heartbeat failed for some aggregators",
+			"failedCount", failedCount,
+			"totalAggregators", len(f.senders),
+			"error", errors.Join(errs...),
+		)
+	}
+	return *firstOK, nil
+}
+
+// Close closes every aggregator's heartbeat client, returning the joined error.
+func (f *FanOutHeartbeatSender) Close() error {
+	var errs []error
+	for _, s := range f.senders {
+		if err := s.sender.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// aggregatorLabeledMonitoring decorates a Monitoring so that every MetricLabeler it hands out is
+// pre-tagged with the aggregator label.
+type aggregatorLabeledMonitoring struct {
+	inner Monitoring
+	label string
+}
+
+func (m aggregatorLabeledMonitoring) Metrics() MetricLabeler {
+	return m.inner.Metrics().With("aggregator", m.label)
+}

--- a/integration/pkg/heartbeatclient/fanout_heartbeat_client.go
+++ b/integration/pkg/heartbeatclient/fanout_heartbeat_client.go
@@ -20,6 +20,8 @@ type AggregatorTarget struct {
 	Address string
 	// Insecure disables TLS for this aggregator's connection.
 	Insecure bool
+	// HMACConfig holds this aggregator's HMAC credentials (per-aggregator, not shared).
+	HMACConfig *hmac.ClientConfig
 }
 
 type labeledSender struct {
@@ -44,7 +46,6 @@ func NewFanOutHeartbeatSender(
 	targets []AggregatorTarget,
 	verifierID string,
 	lggr logger.Logger,
-	hmacConfig *hmac.ClientConfig,
 	monitoring Monitoring,
 ) (*FanOutHeartbeatSender, error) {
 	if len(targets) == 0 {
@@ -58,7 +59,7 @@ func NewFanOutHeartbeatSender(
 
 	for _, t := range targets {
 		aggLggr := logger.With(lggr, "aggregator", t.Label)
-		client, err := NewHeartbeatClient(t.Address, aggLggr, hmacConfig, t.Insecure)
+		client, err := NewHeartbeatClient(t.Address, aggLggr, t.HMACConfig, t.Insecure)
 		if err != nil {
 			_ = f.Close()
 			return nil, fmt.Errorf("failed to create heartbeat client for %q: %w", t.Label, err)

--- a/integration/pkg/heartbeatclient/fanout_heartbeat_client_test.go
+++ b/integration/pkg/heartbeatclient/fanout_heartbeat_client_test.go
@@ -1,0 +1,51 @@
+package heartbeatclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+type stubSender struct {
+	resp HeartbeatResponse
+	err  error
+}
+
+func (s *stubSender) SendHeartbeat(_ context.Context, _ map[uint64]uint64) (HeartbeatResponse, error) {
+	return s.resp, s.err
+}
+func (s *stubSender) Close() error { return nil }
+
+func newFanOutSender(t *testing.T, senders ...labeledSender) *FanOutHeartbeatSender {
+	t.Helper()
+	return &FanOutHeartbeatSender{senders: senders, lggr: logger.Test(t)}
+}
+
+func TestFanOutHeartbeat_PartialFailureIsNotAnError(t *testing.T) {
+	f := newFanOutSender(t,
+		labeledSender{label: "a", sender: &stubSender{resp: HeartbeatResponse{AggregatorID: "a", Timestamp: 7}}},
+		labeledSender{label: "b", sender: &stubSender{err: errors.New("down")}},
+	)
+
+	resp, err := f.SendHeartbeat(context.Background(), map[uint64]uint64{1: 100})
+	require.NoError(t, err, "a single aggregator failure must not fail the heartbeat")
+	assert.Equal(t, "a", resp.AggregatorID, "returns the first successful response")
+}
+
+func TestFanOutHeartbeat_AllFailIsAnError(t *testing.T) {
+	f := newFanOutSender(t,
+		labeledSender{label: "a", sender: &stubSender{err: errors.New("down-a")}},
+		labeledSender{label: "b", sender: &stubSender{err: errors.New("down-b")}},
+	)
+
+	_, err := f.SendHeartbeat(context.Background(), map[uint64]uint64{1: 100})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "all aggregators failed")
+	assert.ErrorContains(t, err, "down-a")
+	assert.ErrorContains(t, err, "down-b")
+}

--- a/integration/pkg/messagerules/union_poller.go
+++ b/integration/pkg/messagerules/union_poller.go
@@ -1,0 +1,115 @@
+package messagerules
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-ccv/common"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+)
+
+var _ common.MessageRulesCheckerService = (*UnionPollerService)(nil)
+
+// NamedPoller pairs a per-aggregator poller with its label for health reporting.
+type NamedPoller struct {
+	label  string
+	poller common.MessageRulesCheckerService
+}
+
+// UnionPollerService aggregates message-disablement rules across multiple aggregators with
+// fail-safe union semantics:
+//
+//   - A message is disabled if ANY aggregator's rules disable it (so no kill-switch set on any
+//     aggregator is silently ignored). Disabled takes precedence over unknown: a known
+//     disablement results in (true, nil) so the task is dropped rather than retried.
+//   - If no aggregator disables the message but ANY aggregator is in the unknown state (no
+//     successful poll yet), the result is (true, ErrMessageRulesStateUnknown) so verification is
+//     blocked and retried (strict fail-safe). One unreachable rules endpoint therefore blocks the
+//     whole consolidated job.
+type UnionPollerService struct {
+	services.StateMachine
+	pollers []NamedPoller
+	lggr    logger.Logger
+}
+
+// NewUnionPollerService builds a union poller over the given per-aggregator pollers. At least one
+// poller is required.
+func NewUnionPollerService(lggr logger.Logger, pollers ...NamedPoller) (*UnionPollerService, error) {
+	if len(pollers) == 0 {
+		return nil, fmt.Errorf("union poller requires at least one aggregator poller")
+	}
+	return &UnionPollerService{pollers: pollers, lggr: lggr}, nil
+}
+
+// NewNamedPoller pairs a poller with an aggregator label for use with NewUnionPollerService.
+func NewNamedPoller(label string, poller common.MessageRulesCheckerService) NamedPoller {
+	return NamedPoller{label: label, poller: poller}
+}
+
+func (u *UnionPollerService) Start(ctx context.Context) error {
+	return u.StartOnce(u.Name(), func() error {
+		started := make([]NamedPoller, 0, len(u.pollers))
+		for _, p := range u.pollers {
+			if err := p.poller.Start(ctx); err != nil {
+				// Roll back any pollers already started before failing.
+				for _, s := range started {
+					_ = s.poller.Close()
+				}
+				return fmt.Errorf("failed to start message rules poller for %q: %w", p.label, err)
+			}
+			started = append(started, p)
+		}
+		u.lggr.Infow("Union message rules service started", "aggregatorCount", len(u.pollers))
+		return nil
+	})
+}
+
+func (u *UnionPollerService) Close() error {
+	return u.StopOnce(u.Name(), func() error {
+		var errs []error
+		for _, p := range u.pollers {
+			if err := p.poller.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("aggregator %q: %w", p.label, err))
+			}
+		}
+		return errors.Join(errs...)
+	})
+}
+
+// IsMessageDisabled applies fail-safe union semantics across all aggregator pollers.
+func (u *UnionPollerService) IsMessageDisabled(ctx context.Context, message protocol.Message) (bool, error) {
+	anyUnknown := false
+	for _, p := range u.pollers {
+		disabled, err := p.poller.IsMessageDisabled(ctx, message)
+		if err != nil {
+			// Unknown state (or any other error) blocks fail-safe, unless another source has a
+			// definitive disablement (handled by the disabled check below across all sources).
+			anyUnknown = true
+			continue
+		}
+		if disabled {
+			return true, nil
+		}
+	}
+	if anyUnknown {
+		return true, common.ErrMessageRulesStateUnknown
+	}
+	return false, nil
+}
+
+func (u *UnionPollerService) HealthReport() map[string]error {
+	report := map[string]error{u.Name(): u.Ready()}
+	for _, p := range u.pollers {
+		for k, v := range p.poller.HealthReport() {
+			report[fmt.Sprintf("%s[%s]", k, p.label)] = v
+		}
+	}
+	return report
+}
+
+func (u *UnionPollerService) Name() string {
+	return "messagerules.UnionPollerService"
+}

--- a/integration/pkg/messagerules/union_poller_test.go
+++ b/integration/pkg/messagerules/union_poller_test.go
@@ -1,0 +1,103 @@
+package messagerules
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccv/common"
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// stubChecker is a stub common.MessageRulesCheckerService driven by canned IsMessageDisabled output.
+type stubChecker struct {
+	disabled bool
+	err      error
+}
+
+func (s *stubChecker) IsMessageDisabled(context.Context, protocol.Message) (bool, error) {
+	return s.disabled, s.err
+}
+func (s *stubChecker) Start(context.Context) error    { return nil }
+func (s *stubChecker) Close() error                   { return nil }
+func (s *stubChecker) Ready() error                   { return nil }
+func (s *stubChecker) HealthReport() map[string]error { return map[string]error{} }
+func (s *stubChecker) Name() string                   { return "stub" }
+
+func unionOf(t *testing.T, checkers ...NamedPoller) *UnionPollerService {
+	t.Helper()
+	u, err := NewUnionPollerService(logger.Test(t), checkers...)
+	require.NoError(t, err)
+	return u
+}
+
+func TestUnionPoller_IsMessageDisabled(t *testing.T) {
+	unknown := common.ErrMessageRulesStateUnknown
+
+	tests := []struct {
+		name         string
+		checkers     []*stubChecker
+		wantDisabled bool
+		wantErr      error
+	}{
+		{
+			name:         "none disable, all known -> not disabled",
+			checkers:     []*stubChecker{{disabled: false}, {disabled: false}},
+			wantDisabled: false,
+			wantErr:      nil,
+		},
+		{
+			name:         "any disables -> disabled, no error (drop)",
+			checkers:     []*stubChecker{{disabled: false}, {disabled: true}},
+			wantDisabled: true,
+			wantErr:      nil,
+		},
+		{
+			name:         "disabled wins over unknown",
+			checkers:     []*stubChecker{{err: unknown}, {disabled: true}},
+			wantDisabled: true,
+			wantErr:      nil,
+		},
+		{
+			name:         "any unknown and none disable -> blocked (strict fail-safe)",
+			checkers:     []*stubChecker{{disabled: false}, {err: unknown}},
+			wantDisabled: true,
+			wantErr:      unknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			named := make([]NamedPoller, len(tt.checkers))
+			for i, c := range tt.checkers {
+				named[i] = NewNamedPoller("agg", c)
+			}
+			u := unionOf(t, named...)
+
+			disabled, err := u.IsMessageDisabled(context.Background(), protocol.Message{})
+			assert.Equal(t, tt.wantDisabled, disabled)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUnionPoller_RequiresAtLeastOne(t *testing.T) {
+	_, err := NewUnionPollerService(logger.Test(t))
+	require.Error(t, err)
+}
+
+func TestUnionPoller_StartCloseWiring(t *testing.T) {
+	u := unionOf(t,
+		NewNamedPoller("a", &stubChecker{}),
+		NewNamedPoller("b", &stubChecker{}),
+	)
+	require.NoError(t, u.Start(context.Background()))
+	require.NoError(t, u.Close())
+}

--- a/integration/storageaccess/fanout_writer.go
+++ b/integration/storageaccess/fanout_writer.go
@@ -22,6 +22,9 @@ type AggregatorTarget struct {
 	Address string
 	// Insecure disables TLS for this aggregator's connection.
 	Insecure bool
+	// HMACConfig holds this aggregator's HMAC credentials. Each aggregator authenticates the
+	// verifier with its own credential, so this is per-target rather than shared.
+	HMACConfig *hmac.ClientConfig
 	// MaxSendMsgSizeBytes / MaxRecvMsgSizeBytes set per-aggregator gRPC message-size limits
 	// (0 -> DefaultMaxMessageSize).
 	MaxSendMsgSizeBytes int
@@ -55,7 +58,6 @@ func NewFanOutAggregatorWriter(
 	targets []AggregatorTarget,
 	verifierID string,
 	lggr logger.Logger,
-	hmacConfig *hmac.ClientConfig,
 	monitoring verifier.Monitoring,
 ) (*FanOutWriter, error) {
 	if len(targets) == 0 {
@@ -72,7 +74,7 @@ func NewFanOutAggregatorWriter(
 		aggWriter, err := NewAggregatorWriter(
 			t.Address,
 			logger.With(lggr, "aggregator", t.Label),
-			hmacConfig,
+			t.HMACConfig,
 			t.Insecure,
 			t.MaxSendMsgSizeBytes,
 			t.MaxRecvMsgSizeBytes,

--- a/integration/storageaccess/fanout_writer.go
+++ b/integration/storageaccess/fanout_writer.go
@@ -1,0 +1,231 @@
+package storageaccess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
+	verifier "github.com/smartcontractkit/chainlink-ccv/verifier/pkg"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+var _ protocol.CCVNodeDataWriter = (*FanOutWriter)(nil)
+
+// AggregatorTarget describes one aggregator the fan-out writer delivers to.
+type AggregatorTarget struct {
+	// Label identifies the aggregator in logs and metrics.
+	Label string
+	// Address is the aggregator gRPC endpoint.
+	Address string
+	// Insecure disables TLS for this aggregator's connection.
+	Insecure bool
+	// MaxSendMsgSizeBytes / MaxRecvMsgSizeBytes set per-aggregator gRPC message-size limits
+	// (0 -> DefaultMaxMessageSize).
+	MaxSendMsgSizeBytes int
+	MaxRecvMsgSizeBytes int
+}
+
+// namedWriter pairs a per-aggregator writer with its label for result merging and logging.
+type namedWriter struct {
+	label  string
+	writer protocol.CCVNodeDataWriter
+}
+
+// FanOutWriter writes each VerifierNodeResult to all configured aggregators concurrently and
+// merges the per-item outcomes. Aggregators are independent sinks, so an item is only reported
+// as written (WriteSuccess) when every aggregator acks it. Because aggregator writes are
+// idempotent, retried re-sends to aggregators that already have the item are safe no-ops.
+//
+// Each aggregator has its own resilience (circuit breaker etc.) and observed wrapper, so a slow
+// or failing aggregator does not impede writes to the healthy ones.
+type FanOutWriter struct {
+	writers []namedWriter
+	closers []*AggregatorWriter
+	lggr    logger.Logger
+}
+
+// NewFanOutAggregatorWriter builds a fan-out writer over the given aggregator targets. For each
+// target it constructs an AggregatorWriter, wraps it in the default resilience policies, and
+// then in a per-aggregator observed writer (so metrics carry an "aggregator" label). At least
+// one target is required.
+func NewFanOutAggregatorWriter(
+	targets []AggregatorTarget,
+	verifierID string,
+	lggr logger.Logger,
+	hmacConfig *hmac.ClientConfig,
+	monitoring verifier.Monitoring,
+) (*FanOutWriter, error) {
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("fan-out writer requires at least one aggregator target")
+	}
+
+	f := &FanOutWriter{
+		writers: make([]namedWriter, 0, len(targets)),
+		closers: make([]*AggregatorWriter, 0, len(targets)),
+		lggr:    lggr,
+	}
+
+	for _, t := range targets {
+		aggWriter, err := NewAggregatorWriter(
+			t.Address,
+			logger.With(lggr, "aggregator", t.Label),
+			hmacConfig,
+			t.Insecure,
+			t.MaxSendMsgSizeBytes,
+			t.MaxRecvMsgSizeBytes,
+		)
+		if err != nil {
+			// Best-effort close anything created so far before returning.
+			_ = f.Close()
+			return nil, fmt.Errorf("failed to create aggregator writer for %q: %w", t.Label, err)
+		}
+
+		observed := NewObservedAggregatorWriter(
+			NewDefaultResilientStorageWriter(aggWriter, logger.With(lggr, "aggregator", t.Label)),
+			verifierID,
+			t.Label,
+			lggr,
+			monitoring,
+		)
+
+		f.writers = append(f.writers, namedWriter{label: t.Label, writer: observed})
+		f.closers = append(f.closers, aggWriter)
+	}
+
+	return f, nil
+}
+
+// WriteCCVNodeData writes every item to all aggregators concurrently and merges the results.
+// The returned slice has the same length and ordering as ccvDataList.
+func (f *FanOutWriter) WriteCCVNodeData(ctx context.Context, ccvDataList []protocol.VerifierNodeResult) ([]protocol.WriteResult, error) {
+	if len(ccvDataList) == 0 {
+		return nil, nil
+	}
+
+	perAggregator := make([][]protocol.WriteResult, len(f.writers))
+	var wg sync.WaitGroup
+	for i := range f.writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			perAggregator[i] = f.writeToAggregator(ctx, f.writers[i], ccvDataList)
+		}(i)
+	}
+	// wg.Wait() is bounded even when ctx has no deadline (the caller passes the long-lived
+	// service context). Each writer built by NewFanOutAggregatorWriter is wrapped in the
+	// resilient writer, whose innermost failsafe timeout policy (WriteTimeout, default 2s)
+	// cancels the per-attempt context and aborts the underlying gRPC call. A stalled aggregator
+	// therefore returns within ~WriteTimeout rather than blocking the fan-out forever. This
+	// invariant relies on the resilient wrapper being present, which the constructor guarantees.
+	wg.Wait()
+
+	return f.merge(ccvDataList, perAggregator), nil
+}
+
+// writeToAggregator writes to a single aggregator and always returns a result slice aligned to
+// ccvDataList, synthesizing retryable failures if the writer returns a short or nil slice.
+func (f *FanOutWriter) writeToAggregator(ctx context.Context, nw namedWriter, ccvDataList []protocol.VerifierNodeResult) []protocol.WriteResult {
+	results, err := nw.writer.WriteCCVNodeData(ctx, ccvDataList)
+	if len(results) == len(ccvDataList) {
+		return results
+	}
+
+	// The writer returned an incomplete result set (e.g. a failsafe policy short-circuited with
+	// no per-item results). Treat every item as a retryable failure for this aggregator.
+	if err == nil {
+		err = fmt.Errorf("aggregator %q returned %d results for %d items", nw.label, len(results), len(ccvDataList))
+	}
+	synthesized := make([]protocol.WriteResult, len(ccvDataList))
+	for i, data := range ccvDataList {
+		if i < len(results) {
+			synthesized[i] = results[i]
+			continue
+		}
+		synthesized[i] = protocol.WriteResult{
+			Input:     data,
+			Status:    protocol.WriteFailure,
+			Error:     err,
+			Retryable: true,
+		}
+	}
+	return synthesized
+}
+
+// merge collapses the per-aggregator results into one result per item using all-must-ack
+// semantics:
+//   - success only when every aggregator acked the item;
+//   - on failure, retryable unless any aggregator returned a non-retryable error (retrying
+//     cannot help that aggregator, so the item is failed permanently and logged distinctly).
+func (f *FanOutWriter) merge(ccvDataList []protocol.VerifierNodeResult, perAggregator [][]protocol.WriteResult) []protocol.WriteResult {
+	merged := make([]protocol.WriteResult, len(ccvDataList))
+	for i, data := range ccvDataList {
+		var (
+			anyFailure      bool
+			anyNonRetryable bool
+			errs            []error
+			failedLabels    []string
+		)
+		for a := range f.writers {
+			r := perAggregator[a][i]
+			if r.Status == protocol.WriteSuccess {
+				continue
+			}
+			anyFailure = true
+			failedLabels = append(failedLabels, f.writers[a].label)
+			if !r.Retryable {
+				anyNonRetryable = true
+			}
+			if r.Error != nil {
+				errs = append(errs, fmt.Errorf("aggregator %q: %w", f.writers[a].label, r.Error))
+			}
+		}
+
+		if !anyFailure {
+			merged[i] = protocol.WriteResult{Input: data, Status: protocol.WriteSuccess}
+			continue
+		}
+
+		merged[i] = protocol.WriteResult{
+			Input:     data,
+			Status:    protocol.WriteFailure,
+			Error:     errors.Join(errs...),
+			Retryable: !anyNonRetryable,
+		}
+
+		if anyNonRetryable {
+			// Permanent partial write: some aggregators may have the item, but at least one
+			// rejected it non-retryably and re-sending will not help. The item will not be
+			// retried, so those aggregators will not receive it.
+			f.lggr.Errorw("Permanent partial write: item rejected non-retryably by an aggregator and will not be retried",
+				"messageID", data.MessageID.String(),
+				"sourceChain", data.Message.SourceChainSelector,
+				"failedAggregators", failedLabels,
+				"error", merged[i].Error,
+			)
+		}
+	}
+	return merged
+}
+
+// GetStats aggregates per-aggregator stats keyed by aggregator label.
+func (f *FanOutWriter) GetStats() map[string]any {
+	stats := make(map[string]any, len(f.closers))
+	for i, w := range f.closers {
+		stats[f.writers[i].label] = w.GetStats()
+	}
+	return stats
+}
+
+// Close closes every aggregator's gRPC connection, returning the joined error.
+func (f *FanOutWriter) Close() error {
+	var errs []error
+	for _, w := range f.closers {
+		if err := w.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/integration/storageaccess/fanout_writer_test.go
+++ b/integration/storageaccess/fanout_writer_test.go
@@ -1,0 +1,227 @@
+package storageaccess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccv/protocol"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// stubWriter returns canned per-item results (or a top-level error / short slice).
+type stubWriter struct {
+	results []protocol.WriteResult
+	err     error
+}
+
+func (s *stubWriter) WriteCCVNodeData(_ context.Context, _ []protocol.VerifierNodeResult) ([]protocol.WriteResult, error) {
+	return s.results, s.err
+}
+
+func item(b byte) protocol.VerifierNodeResult {
+	var id protocol.Bytes32
+	id[0] = b
+	return protocol.VerifierNodeResult{MessageID: id}
+}
+
+func success(in protocol.VerifierNodeResult) protocol.WriteResult {
+	return protocol.WriteResult{Input: in, Status: protocol.WriteSuccess}
+}
+
+func failure(in protocol.VerifierNodeResult, retryable bool) protocol.WriteResult {
+	return protocol.WriteResult{Input: in, Status: protocol.WriteFailure, Error: errors.New("boom"), Retryable: retryable}
+}
+
+func newFanOut(t *testing.T, writers ...namedWriter) *FanOutWriter {
+	t.Helper()
+	return &FanOutWriter{writers: writers, lggr: logger.Test(t)}
+}
+
+func TestFanOutWriter_AllSucceed(t *testing.T) {
+	in := []protocol.VerifierNodeResult{item(1), item(2)}
+	f := newFanOut(t,
+		namedWriter{label: "a", writer: &stubWriter{results: []protocol.WriteResult{success(in[0]), success(in[1])}}},
+		namedWriter{label: "b", writer: &stubWriter{results: []protocol.WriteResult{success(in[0]), success(in[1])}}},
+	)
+
+	got, err := f.WriteCCVNodeData(context.Background(), in)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, r := range got {
+		assert.Equal(t, protocol.WriteSuccess, r.Status)
+	}
+}
+
+// outcome enumerates the three per-aggregator results that drive the merge.
+type outcome int
+
+const (
+	ok    outcome = iota // WriteSuccess
+	retry                // WriteFailure, retryable
+	perm                 // WriteFailure, non-retryable
+)
+
+func resultFor(in protocol.VerifierNodeResult, o outcome) protocol.WriteResult {
+	switch o {
+	case ok:
+		return success(in)
+	case retry:
+		return failure(in, true)
+	case perm:
+		return failure(in, false)
+	default:
+		panic("unknown outcome")
+	}
+}
+
+// fanOutForOutcomes builds a fan-out with one aggregator per outcome ("agg0", "agg1", ...),
+// each returning the corresponding single-item result.
+func fanOutForOutcomes(t *testing.T, in protocol.VerifierNodeResult, outcomes ...outcome) *FanOutWriter {
+	t.Helper()
+	writers := make([]namedWriter, len(outcomes))
+	for i, o := range outcomes {
+		writers[i] = namedWriter{
+			label:  fmt.Sprintf("agg%d", i),
+			writer: &stubWriter{results: []protocol.WriteResult{resultFor(in, o)}},
+		}
+	}
+	return newFanOut(t, writers...)
+}
+
+// TestFanOutWriter_Merge exhaustively covers the merge decision over every combination of
+// per-aggregator outcomes for N = 1, 2, and 3 aggregators: an item succeeds only when all
+// aggregators ack; otherwise it fails, and is retryable iff no aggregator failed non-retryably.
+func TestFanOutWriter_Merge(t *testing.T) {
+	tests := []struct {
+		name          string
+		outcomes      []outcome
+		wantStatus    protocol.WriteResultStatus
+		wantRetryable bool
+		// wantFailedLabels are the aggregator labels that must appear in the joined error.
+		wantFailedLabels []string
+	}{
+		// N = 1 (degenerate / legacy single-aggregator case).
+		{"single success", []outcome{ok}, protocol.WriteSuccess, false, nil},
+		{"single retryable", []outcome{retry}, protocol.WriteFailure, true, []string{"agg0"}},
+		{"single permanent", []outcome{perm}, protocol.WriteFailure, false, []string{"agg0"}},
+
+		// N = 2.
+		{"both success", []outcome{ok, ok}, protocol.WriteSuccess, false, nil},
+		{"success + retryable", []outcome{ok, retry}, protocol.WriteFailure, true, []string{"agg1"}},
+		{"success + permanent", []outcome{ok, perm}, protocol.WriteFailure, false, []string{"agg1"}},
+		{"both retryable", []outcome{retry, retry}, protocol.WriteFailure, true, []string{"agg0", "agg1"}},
+		{"retryable + permanent", []outcome{retry, perm}, protocol.WriteFailure, false, []string{"agg0", "agg1"}},
+		{"both permanent", []outcome{perm, perm}, protocol.WriteFailure, false, []string{"agg0", "agg1"}},
+
+		// N = 3.
+		{"all success", []outcome{ok, ok, ok}, protocol.WriteSuccess, false, nil},
+		{"all retryable", []outcome{retry, retry, retry}, protocol.WriteFailure, true, []string{"agg0", "agg1", "agg2"}},
+		{"success + retryable + permanent", []outcome{ok, retry, perm}, protocol.WriteFailure, false, []string{"agg1", "agg2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := item(1)
+			f := fanOutForOutcomes(t, in, tt.outcomes...)
+
+			got, err := f.WriteCCVNodeData(context.Background(), []protocol.VerifierNodeResult{in})
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+
+			assert.Equal(t, tt.wantStatus, got[0].Status)
+			assert.Equal(t, tt.wantRetryable, got[0].Retryable)
+			assert.Equal(t, in.MessageID, got[0].Input.MessageID, "merged result preserves the input")
+
+			if tt.wantStatus == protocol.WriteSuccess {
+				assert.NoError(t, got[0].Error)
+				return
+			}
+			require.Error(t, got[0].Error)
+			for _, label := range tt.wantFailedLabels {
+				assert.ErrorContains(t, got[0].Error, fmt.Sprintf("aggregator %q", label),
+					"joined error must name every failing aggregator")
+			}
+		})
+	}
+}
+
+// TestFanOutWriter_Merge_HeterogeneousBatch verifies the merge is computed independently per
+// item index within a single batch.
+func TestFanOutWriter_Merge_HeterogeneousBatch(t *testing.T) {
+	in := []protocol.VerifierNodeResult{item(1), item(2), item(3)}
+	// agg "a" acks everything; agg "b" acks item0, fails item1 retryably, rejects item2 permanently.
+	f := newFanOut(t,
+		namedWriter{label: "a", writer: &stubWriter{results: []protocol.WriteResult{
+			success(in[0]), success(in[1]), success(in[2]),
+		}}},
+		namedWriter{label: "b", writer: &stubWriter{results: []protocol.WriteResult{
+			success(in[0]), failure(in[1], true), failure(in[2], false),
+		}}},
+	)
+
+	got, err := f.WriteCCVNodeData(context.Background(), in)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	assert.Equal(t, protocol.WriteSuccess, got[0].Status)
+
+	assert.Equal(t, protocol.WriteFailure, got[1].Status)
+	assert.True(t, got[1].Retryable)
+
+	assert.Equal(t, protocol.WriteFailure, got[2].Status)
+	assert.False(t, got[2].Retryable)
+
+	// Each merged result maps back to its own input.
+	for i := range in {
+		assert.Equal(t, in[i].MessageID, got[i].Input.MessageID, "item %d", i)
+	}
+}
+
+// TestFanOutWriter_Merge_FailureWithNilError documents that a failure carrying no underlying
+// error still yields a WriteFailure (with a nil joined error) rather than being treated as success.
+func TestFanOutWriter_Merge_FailureWithNilError(t *testing.T) {
+	in := item(1)
+	f := newFanOut(t,
+		namedWriter{label: "a", writer: &stubWriter{results: []protocol.WriteResult{success(in)}}},
+		// Status=Failure but Error=nil (e.g. a writer that fails without populating Error).
+		namedWriter{label: "b", writer: &stubWriter{results: []protocol.WriteResult{
+			{Input: in, Status: protocol.WriteFailure, Retryable: true},
+		}}},
+	)
+
+	got, err := f.WriteCCVNodeData(context.Background(), []protocol.VerifierNodeResult{in})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, protocol.WriteFailure, got[0].Status, "a failure with a nil error is still a failure")
+	assert.True(t, got[0].Retryable)
+	assert.NoError(t, got[0].Error, "joining zero underlying errors yields nil")
+}
+
+func TestFanOutWriter_ShortResultSliceSynthesizesRetryableFailure(t *testing.T) {
+	in := []protocol.VerifierNodeResult{item(1), item(2)}
+	// a returns full success; b returns a short slice with a top-level error.
+	f := newFanOut(t,
+		namedWriter{label: "a", writer: &stubWriter{results: []protocol.WriteResult{success(in[0]), success(in[1])}}},
+		namedWriter{label: "b", writer: &stubWriter{results: nil, err: errors.New("circuit open")}},
+	)
+
+	got, err := f.WriteCCVNodeData(context.Background(), in)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for i, r := range got {
+		assert.Equal(t, protocol.WriteFailure, r.Status, "item %d", i)
+		assert.True(t, r.Retryable, "synthesized failures are retryable")
+	}
+}
+
+func TestFanOutWriter_EmptyInput(t *testing.T) {
+	f := newFanOut(t, namedWriter{label: "a", writer: &stubWriter{}})
+	got, err := f.WriteCCVNodeData(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/integration/storageaccess/observed_storage.go
+++ b/integration/storageaccess/observed_storage.go
@@ -15,8 +15,12 @@ type observedStorageWriter struct {
 	protocol.CCVNodeDataWriter
 
 	verifierID string
-	lggr       logger.Logger
-	monitoring verifier.Monitoring
+	// aggregatorLabel, when non-empty, scopes this observer to a single aggregator and is
+	// emitted as the "aggregator" label on metrics/logs. Empty means the observer covers the
+	// aggregate (fan-out-wide) outcome.
+	aggregatorLabel string
+	lggr            logger.Logger
+	monitoring      verifier.Monitoring
 }
 
 func NewObservedStorageWriter(
@@ -31,6 +35,35 @@ func NewObservedStorageWriter(
 		lggr:              lggr,
 		monitoring:        monitoring,
 	}
+}
+
+// NewObservedAggregatorWriter wraps a single aggregator's writer, tagging its metrics and logs
+// with an "aggregator" label so per-aggregator write health is observable independently of the
+// fan-out aggregate.
+func NewObservedAggregatorWriter(
+	delegate protocol.CCVNodeDataWriter,
+	verifierID string,
+	aggregatorLabel string,
+	lggr logger.Logger,
+	monitoring verifier.Monitoring,
+) protocol.CCVNodeDataWriter {
+	return &observedStorageWriter{
+		CCVNodeDataWriter: delegate,
+		verifierID:        verifierID,
+		aggregatorLabel:   aggregatorLabel,
+		lggr:              logger.With(lggr, "aggregator", aggregatorLabel),
+		monitoring:        monitoring,
+	}
+}
+
+// metrics returns the metric labeler scoped to this observer's verifier_id and (when set)
+// aggregator label.
+func (o *observedStorageWriter) metrics() verifier.MetricLabeler {
+	m := o.monitoring.Metrics().With("verifier_id", o.verifierID)
+	if o.aggregatorLabel != "" {
+		m = m.With("aggregator", o.aggregatorLabel)
+	}
+	return m
 }
 
 func (o *observedStorageWriter) WriteCCVNodeData(ctx context.Context, ccvDataList []protocol.VerifierNodeResult) ([]protocol.WriteResult, error) {
@@ -54,8 +87,9 @@ func (o *observedStorageWriter) WriteCCVNodeData(ctx context.Context, ccvDataLis
 		}
 	}
 
+	metrics := o.metrics()
 	if failureCount > 0 {
-		o.monitoring.Metrics().IncrementStorageWriteErrors(ctx)
+		metrics.IncrementStorageWriteErrors(ctx)
 		o.lggr.Errorw("Error storing CCV data batch",
 			"verifier_id", o.verifierID,
 			"error", err,
@@ -64,9 +98,7 @@ func (o *observedStorageWriter) WriteCCVNodeData(ctx context.Context, ccvDataLis
 		)
 	}
 
-	o.monitoring.Metrics().
-		With("verifier_id", o.verifierID).
-		RecordStorageWriteDuration(ctx, time.Since(start))
+	metrics.RecordStorageWriteDuration(ctx, time.Since(start))
 
 	return results, err
 }

--- a/protocol/common/hmac/hmac_auth.go
+++ b/protocol/common/hmac/hmac_auth.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -80,7 +81,8 @@ func GenerateCredentials() (Credentials, error) {
 // ValidateAPIKey validates that the API key is a valid UUID.
 func ValidateAPIKey(apiKey string) error {
 	if _, err := uuid.Parse(apiKey); err != nil {
-		return fmt.Errorf("API key must be a valid UUID, got %q", apiKey)
+		// Do not echo the key value: it is a credential and callers log this error.
+		return errors.New("API key must be a valid UUID")
 	}
 	return nil
 }

--- a/verifier/pkg/commit/config.go
+++ b/verifier/pkg/commit/config.go
@@ -2,10 +2,12 @@ package commit
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
+	"github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
 	verifier "github.com/smartcontractkit/chainlink-ccv/verifier/pkg/vtypes"
 )
 
@@ -19,6 +21,15 @@ type AggregatorConnection struct {
 	// Name is an optional human-readable label used in logs and metric labels.
 	// When empty it defaults to Address.
 	Name string `toml:"name"`
+	// SecretName is the credential lookup key for this aggregator — the one join key used in both
+	// deployment modes to resolve the aggregator's HMAC credential (kept distinct from Name so the
+	// display label can change without re-wiring secrets):
+	//   - standalone: the env var pair VERIFIER_AGGREGATOR_<SECRETNAME>_API_KEY / _SECRET_KEY;
+	//   - Chainlink node: the secrets.toml entry whose VerifierID equals this value, which also
+	//     becomes the key in the per-aggregator credential map passed to the coordinator.
+	// Empty (the legacy single-aggregator path) falls back to the default un-suffixed credential
+	// variables. Secrets themselves never live in config — only this reference does.
+	SecretName string `toml:"secret_name"`
 	// Address is the aggregator gRPC endpoint (host:port). Required.
 	Address string `toml:"address"`
 	// InsecureConnection disables TLS for this aggregator's gRPC connection.
@@ -40,6 +51,81 @@ func (a AggregatorConnection) Label() string {
 		return a.Name
 	}
 	return a.Address
+}
+
+const (
+	// DefaultAggregatorAPIKeyEnvVar and DefaultAggregatorSecretKeyEnvVar are the environment
+	// variables a verifier reads for its aggregator HMAC credentials in the legacy
+	// single-aggregator configuration (AggregatorConnection with no Name). These are env var
+	// names, not secret values.
+	DefaultAggregatorAPIKeyEnvVar    = "VERIFIER_AGGREGATOR_API_KEY"    //nolint:gosec // G101: env var name, not a credential
+	DefaultAggregatorSecretKeyEnvVar = "VERIFIER_AGGREGATOR_SECRET_KEY" //nolint:gosec // G101: env var name, not a credential
+)
+
+// AggregatorCredentialEnvVars returns the names of the environment variables that hold this
+// aggregator's HMAC credentials (standalone mode), derived from its SecretName:
+//
+//	VERIFIER_AGGREGATOR_<SECRETNAME>_API_KEY
+//	VERIFIER_AGGREGATOR_<SECRETNAME>_SECRET_KEY
+//
+// where <SECRETNAME> is SecretName upper-cased with every non-alphanumeric rune replaced by '_'.
+// A connection without a SecretName (the legacy single-aggregator path synthesized from
+// aggregator_address) falls back to the un-suffixed DefaultAggregator* variables, preserving the
+// existing single-aggregator deployment contract. Config generators (changeset, devenv) and the
+// deploy layer use the same convention to set the matching environment variables.
+func (a AggregatorConnection) AggregatorCredentialEnvVars() (apiKeyVar, secretKeyVar string) {
+	return AggregatorCredentialEnvVars(a.SecretName)
+}
+
+// AggregatorCredentialEnvVars returns the credential environment variable names for an aggregator
+// with the given secret name. An empty secret name yields the default (legacy) un-suffixed variables.
+func AggregatorCredentialEnvVars(secretName string) (apiKeyVar, secretKeyVar string) {
+	if strings.TrimSpace(secretName) == "" {
+		return DefaultAggregatorAPIKeyEnvVar, DefaultAggregatorSecretKeyEnvVar
+	}
+	seg := sanitizeEnvVarSegment(secretName)
+	return "VERIFIER_AGGREGATOR_" + seg + "_API_KEY", "VERIFIER_AGGREGATOR_" + seg + "_SECRET_KEY"
+}
+
+// ResolveHMACConfig reads and validates this aggregator's HMAC credentials from the environment
+// variables named by AggregatorCredentialEnvVars. Each aggregator authenticates the verifier with
+// its own credential, so a consolidated verifier resolves one config per aggregator.
+func (a AggregatorConnection) ResolveHMACConfig() (*hmac.ClientConfig, error) {
+	apiKeyVar, secretKeyVar := a.AggregatorCredentialEnvVars()
+
+	apiKey := os.Getenv(apiKeyVar)
+	if apiKey == "" {
+		return nil, fmt.Errorf("missing %s for aggregator %q", apiKeyVar, a.Label())
+	}
+	if err := hmac.ValidateAPIKey(apiKey); err != nil {
+		return nil, fmt.Errorf("invalid %s for aggregator %q: %w", apiKeyVar, a.Label(), err)
+	}
+
+	secret := os.Getenv(secretKeyVar)
+	if secret == "" {
+		return nil, fmt.Errorf("missing %s for aggregator %q", secretKeyVar, a.Label())
+	}
+	if err := hmac.ValidateSecret(secret); err != nil {
+		return nil, fmt.Errorf("invalid %s for aggregator %q: %w", secretKeyVar, a.Label(), err)
+	}
+
+	return &hmac.ClientConfig{APIKey: apiKey, Secret: secret}, nil
+}
+
+// sanitizeEnvVarSegment upper-cases s and replaces every non-alphanumeric rune with '_' so it is
+// a valid environment-variable name segment.
+func sanitizeEnvVarSegment(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToUpper(s) {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 type Config struct {
@@ -158,17 +244,34 @@ func (c *Config) ResolvedAggregators() ([]AggregatorConnection, error) {
 		}}
 	}
 
-	seen := make(map[string]struct{}, len(resolved))
+	// With multiple aggregators each must carry a unique secret_name: it is the credential lookup
+	// key (the per-aggregator HMAC env vars / secret map key are derived from it, see
+	// AggregatorCredentialEnvVars). A single aggregator may omit it and falls back to the default
+	// (legacy) credential variables.
+	multi := len(resolved) > 1
+	seenAddr := make(map[string]struct{}, len(resolved))
+	seenSecret := make(map[string]struct{}, len(resolved))
 	for i := range resolved {
 		addr := strings.TrimSpace(resolved[i].Address)
 		if addr == "" {
 			return nil, fmt.Errorf("invalid verifier configuration: aggregator at index %d has an empty address", i)
 		}
-		if _, dup := seen[addr]; dup {
+		if _, dup := seenAddr[addr]; dup {
 			return nil, fmt.Errorf("invalid verifier configuration: duplicate aggregator address %q", addr)
 		}
-		seen[addr] = struct{}{}
-		resolved[i].Name = resolved[i].Label()
+		seenAddr[addr] = struct{}{}
+
+		if !multi {
+			continue
+		}
+		secretName := strings.TrimSpace(resolved[i].SecretName)
+		if secretName == "" {
+			return nil, fmt.Errorf("invalid verifier configuration: aggregator at index %d (%s) must have a secret_name when multiple aggregators are configured (it is the credential lookup key)", i, addr)
+		}
+		if _, dup := seenSecret[secretName]; dup {
+			return nil, fmt.Errorf("invalid verifier configuration: duplicate aggregator secret_name %q", secretName)
+		}
+		seenSecret[secretName] = struct{}{}
 	}
 
 	return resolved, nil

--- a/verifier/pkg/commit/config.go
+++ b/verifier/pkg/commit/config.go
@@ -12,20 +12,62 @@ import (
 // DefaultECDSASigningKeyName is the keystore key name for the ECDSA key used to sign verification results.
 const DefaultECDSASigningKeyName = "bootstrap_default_ecdsa_signing_key"
 
+// AggregatorConnection describes a single aggregator the verifier writes to, sends
+// heartbeats to, and reads message-disablement rules from. A consolidated verifier job
+// carries one of these per aggregator in Config.Aggregators.
+type AggregatorConnection struct {
+	// Name is an optional human-readable label used in logs and metric labels.
+	// When empty it defaults to Address.
+	Name string `toml:"name"`
+	// Address is the aggregator gRPC endpoint (host:port). Required.
+	Address string `toml:"address"`
+	// InsecureConnection disables TLS for this aggregator's gRPC connection.
+	// Only use this for testing when custom certificates cannot be injected.
+	InsecureConnection bool `toml:"insecure_connection"`
+	// MaxSendMsgSizeBytes is the maximum gRPC message size for sending requests to this
+	// aggregator. The batch-splitting logic uses this to keep outgoing batches under the
+	// limit. If 0 or not set, defaults to 4MB.
+	MaxSendMsgSizeBytes int `toml:"max_send_msg_size_bytes"`
+	// MaxRecvMsgSizeBytes is the maximum gRPC message size for receiving responses from
+	// this aggregator. If 0 or not set, defaults to 4MB.
+	MaxRecvMsgSizeBytes int `toml:"max_recv_msg_size_bytes"`
+}
+
+// Label returns the value used to identify this aggregator in logs and metrics:
+// Name when set, otherwise Address.
+func (a AggregatorConnection) Label() string {
+	if strings.TrimSpace(a.Name) != "" {
+		return a.Name
+	}
+	return a.Address
+}
+
 type Config struct {
-	VerifierID        string `toml:"verifier_id"`
+	VerifierID string `toml:"verifier_id"`
+	// AggregatorAddress configures a single aggregator. DEPRECATED in favor of Aggregators;
+	// retained for backwards compatibility. It is mutually exclusive with Aggregators: setting
+	// both is a configuration error. When Aggregators is empty, this address (together with the
+	// legacy InsecureAggregatorConnection and AggregatorMax*MsgSizeBytes fields) is used to
+	// synthesize a single-aggregator connection.
 	AggregatorAddress string `toml:"aggregator_address"`
+	// Aggregators is the list of aggregators a consolidated verifier job writes to. When
+	// non-empty it is authoritative and the legacy AggregatorAddress field must be empty.
+	Aggregators []AggregatorConnection `toml:"aggregators"`
 	// InsecureAggregatorConnection disables TLS for the aggregator gRPC connection.
+	// DEPRECATED: only applies to the legacy AggregatorAddress path; use
+	// AggregatorConnection.InsecureConnection with Aggregators instead.
 	// Only use this for testing when custom certificates cannot be injected.
 	InsecureAggregatorConnection bool `toml:"insecure_aggregator_connection"`
 	// AggregatorMaxSendMsgSizeBytes is the maximum gRPC message size for sending requests to the aggregator.
 	// The batch-splitting logic uses this value to ensure outgoing batches don't exceed this limit.
 	// Should match or be less than the aggregator's server maxRecvMsgSizeBytes setting.
 	// If 0 or not set, defaults to 4MB.
+	// DEPRECATED: only applies to the legacy AggregatorAddress path.
 	AggregatorMaxSendMsgSizeBytes int `toml:"aggregator_max_send_msg_size_bytes"`
 	// AggregatorMaxRecvMsgSizeBytes is the maximum gRPC message size for receiving responses from the aggregator.
 	// Should match or be less than the aggregator's server maxSendMsgSizeBytes setting.
 	// If 0 or not set, defaults to 4MB.
+	// DEPRECATED: only applies to the legacy AggregatorAddress path.
 	AggregatorMaxRecvMsgSizeBytes int `toml:"aggregator_max_recv_msg_size_bytes"`
 
 	// MessageDisablementRulesPollInterval and MessageDisablementRulesClientTimeout are Go duration strings
@@ -78,7 +120,71 @@ func (c *Config) MessageDisablementRulesClientTimeoutDuration() (time.Duration, 
 	return parseOptionalDurationString(c.MessageDisablementRulesClientTimeout, "message_disablement_rules_client_timeout")
 }
 
+// ResolvedAggregators returns the effective list of aggregators for this config, applying
+// backwards-compatible fallback to the legacy single-aggregator fields.
+//
+// Precedence:
+//   - If Aggregators is non-empty it is authoritative; setting the legacy AggregatorAddress
+//     as well is an error (no silent ambiguity).
+//   - If Aggregators is empty and AggregatorAddress is set, a single AggregatorConnection is
+//     synthesized from the legacy AggregatorAddress / InsecureAggregatorConnection /
+//     AggregatorMax*MsgSizeBytes fields.
+//   - If neither is set, it is an error: at least one aggregator must be configured.
+//
+// The returned connections have Name defaulted to Address when unset. Message-size defaults
+// (0 -> 4MB) are intentionally left to the aggregator writer constructor.
+func (c *Config) ResolvedAggregators() ([]AggregatorConnection, error) {
+	legacySet := strings.TrimSpace(c.AggregatorAddress) != ""
+	listSet := len(c.Aggregators) > 0
+
+	switch {
+	case legacySet && listSet:
+		return nil, fmt.Errorf("invalid verifier configuration: both aggregator_address and aggregators are set; " +
+			"aggregator_address is deprecated, use only one")
+	case !legacySet && !listSet:
+		return nil, fmt.Errorf("invalid verifier configuration: no aggregator configured; set aggregators (or the deprecated aggregator_address)")
+	}
+
+	var resolved []AggregatorConnection
+	if listSet {
+		resolved = make([]AggregatorConnection, len(c.Aggregators))
+		copy(resolved, c.Aggregators)
+	} else {
+		resolved = []AggregatorConnection{{
+			Address:             c.AggregatorAddress,
+			InsecureConnection:  c.InsecureAggregatorConnection,
+			MaxSendMsgSizeBytes: c.AggregatorMaxSendMsgSizeBytes,
+			MaxRecvMsgSizeBytes: c.AggregatorMaxRecvMsgSizeBytes,
+		}}
+	}
+
+	seen := make(map[string]struct{}, len(resolved))
+	for i := range resolved {
+		addr := strings.TrimSpace(resolved[i].Address)
+		if addr == "" {
+			return nil, fmt.Errorf("invalid verifier configuration: aggregator at index %d has an empty address", i)
+		}
+		if _, dup := seen[addr]; dup {
+			return nil, fmt.Errorf("invalid verifier configuration: duplicate aggregator address %q", addr)
+		}
+		seen[addr] = struct{}{}
+		resolved[i].Name = resolved[i].Label()
+	}
+
+	return resolved, nil
+}
+
 func (c *Config) Validate() error {
+	// Only validate aggregator wiring when something is configured. A config with neither
+	// aggregator_address nor aggregators set has always passed Validate (the gRPC client is
+	// created lazily), so we keep that lenient behavior; the strict "at least one aggregator"
+	// requirement is enforced by ResolvedAggregators on the startup path.
+	if strings.TrimSpace(c.AggregatorAddress) != "" || len(c.Aggregators) > 0 {
+		if _, err := c.ResolvedAggregators(); err != nil {
+			return err
+		}
+	}
+
 	// Compare map lengths first
 	if len(c.OnRampAddresses) != len(c.CommitteeVerifierAddresses) ||
 		len(c.OnRampAddresses) != len(c.RMNRemoteAddresses) {

--- a/verifier/pkg/commit/config_test.go
+++ b/verifier/pkg/commit/config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	burntsushi "github.com/BurntSushi/toml"
+	pelletier "github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -221,4 +223,130 @@ func TestConfig_Validate_Errors(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.errSubstr)
 		})
 	}
+}
+
+func TestConfig_ResolvedAggregators(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    Config
+		want      []AggregatorConnection
+		errSubstr string
+	}{
+		{
+			name:      "neither set is an error",
+			config:    Config{},
+			errSubstr: "no aggregator configured",
+		},
+		{
+			name: "both set is an error",
+			config: Config{
+				AggregatorAddress: "legacy:50051",
+				Aggregators:       []AggregatorConnection{{Address: "a:50051"}},
+			},
+			errSubstr: "both aggregator_address and aggregators are set",
+		},
+		{
+			name: "legacy single address synthesizes one connection",
+			config: Config{
+				AggregatorAddress:             "legacy:50051",
+				InsecureAggregatorConnection:  true,
+				AggregatorMaxSendMsgSizeBytes: 111,
+				AggregatorMaxRecvMsgSizeBytes: 222,
+			},
+			want: []AggregatorConnection{{
+				Name:                "legacy:50051",
+				Address:             "legacy:50051",
+				InsecureConnection:  true,
+				MaxSendMsgSizeBytes: 111,
+				MaxRecvMsgSizeBytes: 222,
+			}},
+		},
+		{
+			name: "list is authoritative and names default to address",
+			config: Config{
+				Aggregators: []AggregatorConnection{
+					{Address: "a:50051", InsecureConnection: true},
+					{Name: "secondary", Address: "b:50051"},
+				},
+			},
+			want: []AggregatorConnection{
+				{Name: "a:50051", Address: "a:50051", InsecureConnection: true},
+				{Name: "secondary", Address: "b:50051"},
+			},
+		},
+		{
+			name: "duplicate addresses are rejected",
+			config: Config{
+				Aggregators: []AggregatorConnection{
+					{Address: "a:50051"},
+					{Address: "a:50051"},
+				},
+			},
+			errSubstr: "duplicate aggregator address",
+		},
+		{
+			name: "empty address in list is rejected",
+			config: Config{
+				Aggregators: []AggregatorConnection{{Name: "noaddr"}},
+			},
+			errSubstr: "empty address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.config.ResolvedAggregators()
+			if tt.errSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestConfig_AggregatorsTOMLRoundTrip guards the design risk that the aggregators
+// array-of-tables must decode cleanly under BOTH TOML libraries used in this repo:
+// BurntSushi/toml (standalone / devenv / changeset marshal) and pelletier/go-toml
+// (Chainlink node job-spec decoding).
+func TestConfig_AggregatorsTOMLRoundTrip(t *testing.T) {
+	const tomlDoc = `
+verifier_id = "v1"
+
+[[aggregators]]
+name = "primary"
+address = "a:50051"
+insecure_connection = true
+max_send_msg_size_bytes = 1048576
+
+[[aggregators]]
+address = "b:50051"
+`
+	want := []AggregatorConnection{
+		{Name: "primary", Address: "a:50051", InsecureConnection: true, MaxSendMsgSizeBytes: 1048576},
+		{Address: "b:50051"},
+	}
+
+	t.Run("BurntSushi", func(t *testing.T) {
+		var c Config
+		require.NoError(t, burntsushi.Unmarshal([]byte(tomlDoc), &c))
+		assert.Equal(t, want, c.Aggregators)
+	})
+
+	t.Run("pelletier", func(t *testing.T) {
+		var c Config
+		require.NoError(t, pelletier.Unmarshal([]byte(tomlDoc), &c))
+		assert.Equal(t, want, c.Aggregators)
+	})
+
+	t.Run("BurntSushi marshal round-trips", func(t *testing.T) {
+		c := Config{VerifierID: "v1", Aggregators: want}
+		b, err := burntsushi.Marshal(c)
+		require.NoError(t, err)
+		var back Config
+		require.NoError(t, burntsushi.Unmarshal(b, &back))
+		assert.Equal(t, want, back.Aggregators)
+	})
 }

--- a/verifier/pkg/commit/config_test.go
+++ b/verifier/pkg/commit/config_test.go
@@ -246,15 +246,15 @@ func TestConfig_ResolvedAggregators(t *testing.T) {
 			errSubstr: "both aggregator_address and aggregators are set",
 		},
 		{
-			name: "legacy single address synthesizes one connection",
+			name: "legacy single address synthesizes one nameless connection",
 			config: Config{
 				AggregatorAddress:             "legacy:50051",
 				InsecureAggregatorConnection:  true,
 				AggregatorMaxSendMsgSizeBytes: 111,
 				AggregatorMaxRecvMsgSizeBytes: 222,
 			},
+			// Name stays empty so it falls back to the default credential env vars.
 			want: []AggregatorConnection{{
-				Name:                "legacy:50051",
 				Address:             "legacy:50051",
 				InsecureConnection:  true,
 				MaxSendMsgSizeBytes: 111,
@@ -262,24 +262,51 @@ func TestConfig_ResolvedAggregators(t *testing.T) {
 			}},
 		},
 		{
-			name: "list is authoritative and names default to address",
+			name: "single-entry list may be nameless",
+			config: Config{
+				Aggregators: []AggregatorConnection{{Address: "a:50051", InsecureConnection: true}},
+			},
+			want: []AggregatorConnection{{Address: "a:50051", InsecureConnection: true}},
+		},
+		{
+			name: "multi-aggregator list preserves entries verbatim",
 			config: Config{
 				Aggregators: []AggregatorConnection{
-					{Address: "a:50051", InsecureConnection: true},
-					{Name: "secondary", Address: "b:50051"},
+					{Name: "primary", SecretName: "agg-1", Address: "a:50051", InsecureConnection: true},
+					{Name: "secondary", SecretName: "agg-2", Address: "b:50051"},
 				},
 			},
 			want: []AggregatorConnection{
-				{Name: "a:50051", Address: "a:50051", InsecureConnection: true},
-				{Name: "secondary", Address: "b:50051"},
+				{Name: "primary", SecretName: "agg-1", Address: "a:50051", InsecureConnection: true},
+				{Name: "secondary", SecretName: "agg-2", Address: "b:50051"},
 			},
+		},
+		{
+			name: "multiple aggregators require secret_name",
+			config: Config{
+				Aggregators: []AggregatorConnection{
+					{Name: "primary", SecretName: "agg-1", Address: "a:50051"},
+					{Name: "secondary", Address: "b:50051"},
+				},
+			},
+			errSubstr: "must have a secret_name when multiple aggregators",
+		},
+		{
+			name: "duplicate aggregator secret_names are rejected",
+			config: Config{
+				Aggregators: []AggregatorConnection{
+					{Name: "primary", SecretName: "dup", Address: "a:50051"},
+					{Name: "secondary", SecretName: "dup", Address: "b:50051"},
+				},
+			},
+			errSubstr: "duplicate aggregator secret_name",
 		},
 		{
 			name: "duplicate addresses are rejected",
 			config: Config{
 				Aggregators: []AggregatorConnection{
-					{Address: "a:50051"},
-					{Address: "a:50051"},
+					{Name: "primary", SecretName: "agg-1", Address: "a:50051"},
+					{Name: "secondary", SecretName: "agg-2", Address: "a:50051"},
 				},
 			},
 			errSubstr: "duplicate aggregator address",
@@ -303,6 +330,31 @@ func TestConfig_ResolvedAggregators(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAggregatorCredentialEnvVars(t *testing.T) {
+	tests := []struct {
+		name       string
+		secretName string
+		wantAPIKey string
+		wantSecret string
+	}{
+		{"empty secret_name falls back to defaults", "", "VERIFIER_AGGREGATOR_API_KEY", "VERIFIER_AGGREGATOR_SECRET_KEY"},
+		{"simple secret_name", "primary", "VERIFIER_AGGREGATOR_PRIMARY_API_KEY", "VERIFIER_AGGREGATOR_PRIMARY_SECRET_KEY"},
+		{"hyphenated secret_name is sanitized", "default-aggregator", "VERIFIER_AGGREGATOR_DEFAULT_AGGREGATOR_API_KEY", "VERIFIER_AGGREGATOR_DEFAULT_AGGREGATOR_SECRET_KEY"},
+		{"mixed punctuation is sanitized", "agg.1-ha", "VERIFIER_AGGREGATOR_AGG_1_HA_API_KEY", "VERIFIER_AGGREGATOR_AGG_1_HA_SECRET_KEY"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiKey, secret := AggregatorCredentialEnvVars(tt.secretName)
+			assert.Equal(t, tt.wantAPIKey, apiKey)
+			assert.Equal(t, tt.wantSecret, secret)
+			// Method form delegates to the package function, keyed on SecretName.
+			mAPIKey, mSecret := AggregatorConnection{SecretName: tt.secretName}.AggregatorCredentialEnvVars()
+			assert.Equal(t, tt.wantAPIKey, mAPIKey)
+			assert.Equal(t, tt.wantSecret, mSecret)
 		})
 	}
 }


### PR DESCRIPTION
**Note to reviewers**: the diff looks large but almost 50% of it is test coverage. Unless you're specifically interested in the tests introduced (outlined below in the "Testing" section) its recommended to mark those as "Viewed" in the Files changed view to reduce the code to look at.

## Description

Today, the committee verifier achieves write high-availability by deploying one verifier job per aggregator. Each job carries a single `AggregatorAddress` and the deployment changeset emits N jobs (one per `committee.Aggregators` entry). This is operationally heavy: N job specs (1 per aggregator in the HA setup), more RPC endpoint load (since the same verifier logic is running redundantly), and this has become a source of inconsistency across deployment modes (CL node vs. standalone). The CL node supports multiple jobs, whereas standalone currently supports only one, for reasons of simplicity.

This PR lets a single consolidated verifier job write to multiple aggregators, so operators can collapse those N jobs into one. This also means that standalone and CL mode can achieve identical behavior as far as aggregator HA goes w/ the same committee verifier config.

What changes:

- **Config (backwards compatible).** `commit.Config` gains an `aggregators` list (`[[aggregators]]` array-of-tables, each with address / insecure flag / optional name + message-size limits). The legacy `aggregator_address` is retained: the list wins when set, otherwise a single entry is synthesized from the legacy fields, and setting both is a validation error. Existing production configs are unaffected.
- **Runtime fan-out.** Writes go to all aggregators with **all-must-ack** semantics. An item's durable job completes only when every aggregator acks; retries re-send to all (this is safe because aggregator writes are idempotent). Each aggregator gets its own resilient (circuit-breaker/timeout) + observed stack so one slow/down aggregator can't trip the others. Heartbeats fan out to every aggregator (single-aggregator failure is non-blocking). Disablement rules use a **fail-safe union**, i.e. a message is disabled if any aggregator disables it, and verification is blocked while any source's rules are unknown.
- **Deployment (opt-in, default off).** `ApplyVerifierConfig` and `AddNOPOffchain` gain a `ConsolidateAggregators` flag. Default `false` preserves byte-identical one-job-per-aggregator output. When `true`, one job per NOP is emitted using the `aggregators` list and an aggregator-name-free `verifier_id` (`NewConsolidatedVerifierJobID`). The consolidated job ID still matches `VerifierJobScope`, so flipping the flag lets `RevokeOrphanedJobs` clean up the old per-aggregator jobs.

Because the changeset flag defaults off and the config is additive, runtime + config + changeset land together with zero behavior change. Therefore, this new code can be rolled out w/out any config changes in production and should work out of the box.

Unknowns: 

1. It's unclear whether the changeset that was changed in this PR is the only one that is used across all families. It is probably used by Canton, but EVM might be using a different one.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

Unit tests added and run for every new decision point:

- `go test ./verifier/pkg/commit/`: config precedence (list wins / error if both / synthesize from legacy), duplicate/empty-address rejection, and array-of-tables round-trip under BurntSushi and pelletier.
- `go test ./integration/storageaccess/`: `FanOutWriter.merge` exhaustively table-tested across all per-aggregator outcome combinations (N=1,2,3: success / retryable / non-retryable), heterogeneous batches, error aggregation, and the short-result-slice synthesis path.
- `go test ./integration/pkg/heartbeatclient/`: partial failure is non-blocking; all-fail surfaces a joined error.
- `go test ./integration/pkg/messagerules/`: union semantics (disabled-wins, strict fail-safe on unknown).
- `go test ./deployment/changesets/ ./deployment/shared/`: legacy path emits one job per aggregator (unchanged `verifier_id`/`AggregatorAddress`); consolidated path emits one job per NOP with the aggregators list and an aggregator-name-free `verifier_id`; scope matching detects both.

**NOTE**: the devenv has NOT been updated to use the new config values - waiting on some feedback before diving in and doing that.

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
