### PR TITLE
verifier: cut over to consolidated aggregators

### DIFF
--- a/.github/actions/build-cl/action.yaml
+++ b/.github/actions/build-cl/action.yaml
@@ -8,7 +8,7 @@ runs:
       uses: actions/checkout@v5
       with:
         repository: smartcontractkit/chainlink
-        ref: 7322155e88d1e066bf598962b5478d1d21e32ffe
+        ref: d8038f316d6c58d6bdd018f4b92bc1b03c42f4f1
         path: chainlink-repo
 
     - name: Setup path to go.mod

--- a/build/devenv/components/committeeccv/component.go
+++ b/build/devenv/components/committeeccv/component.go
@@ -221,7 +221,8 @@ func runPhase3Core(
 
 	// Step 2: Launch standalone verifier containers (reads HMAC creds from agg.Out).
 	if err := committeeverifier.LaunchStandaloneVerifiers(
-		verifiers, aggregators, inputs.blockchainOutputs, inputs.jdInfra,
+		verifiers, aggregators, committeeverifier.CommitteeAggregatorNames(inputs.topology),
+		inputs.blockchainOutputs, inputs.jdInfra,
 		chainreg.GetRegistry().GetVerifierModifiers(),
 	); err != nil {
 		return nil, nil, fmt.Errorf("committeeccv: failed to launch standalone verifiers: %w", err)
@@ -618,6 +619,8 @@ func buildVerifierJobSpecEffects(
 				Monitoring:               obs.Monitoring,
 				TargetNOPs:               verNOPAliases,
 				DisableFinalityCheckers:  disableFinalityCheckersPerFamily[family],
+				// Consolidated topology: one verifier job per NOP writing to every aggregator.
+				ConsolidateAggregators: true,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("committeeccv: generating verifier configs for committee %s: %w", committeeName, err)
@@ -642,25 +645,23 @@ func buildVerifierJobSpecEffects(
 					continue
 				}
 
-				allJobSpecs := make([]bootstrap.JobSpec, 0, len(aggNames))
-				for _, aggName := range aggNames {
-					jobSpecID := ccvshared.NewVerifierJobID(ccvshared.NOPAlias(ver.NOPAlias), aggName, ccvshared.VerifierJobScope{CommitteeQualifier: committeeName})
-					job, err := ccvdeployment.GetJob(output.DataStore.Seal(), ccvshared.NOPAlias(ver.NOPAlias), jobSpecID.ToJobID())
-					if err != nil {
-						return nil, fmt.Errorf("committeeccv: getting verifier job spec for %s agg %s: %w", ver.ContainerName, aggName, err)
-					}
-					var spec verifierJobSpec
-					if err := toml.Unmarshal([]byte(job.Spec), &spec); err != nil {
-						return nil, fmt.Errorf("committeeccv: decoding verifier job spec for %s: %w", ver.ContainerName, err)
-					}
-					allJobSpecs = append(allJobSpecs, spec.toBootstrapJobSpec())
+				// Consolidated topology: a single verifier job per NOP writing to all aggregators.
+				jobSpecID := ccvshared.NewConsolidatedVerifierJobID(ccvshared.NOPAlias(ver.NOPAlias), ccvshared.VerifierJobScope{CommitteeQualifier: committeeName})
+				job, err := ccvdeployment.GetJob(output.DataStore.Seal(), ccvshared.NOPAlias(ver.NOPAlias), jobSpecID.ToJobID())
+				if err != nil {
+					return nil, fmt.Errorf("committeeccv: getting consolidated verifier job spec for %s: %w", ver.ContainerName, err)
 				}
+				var spec verifierJobSpec
+				if err := toml.Unmarshal([]byte(job.Spec), &spec); err != nil {
+					return nil, fmt.Errorf("committeeccv: decoding verifier job spec for %s: %w", ver.ContainerName, err)
+				}
+				bootSpec := spec.toBootstrapJobSpec()
+				allJobSpecs := []bootstrap.JobSpec{bootSpec}
 
 				ver.GeneratedJobSpecs = allJobSpecs
 
-				ownedAggIdx := ver.NodeIndex % len(aggNames)
 				var verCfg commit.Config
-				if err := toml.Unmarshal([]byte(allJobSpecs[ownedAggIdx].AppConfig), &verCfg); err != nil {
+				if err := toml.Unmarshal([]byte(bootSpec.AppConfig), &verCfg); err != nil {
 					return nil, fmt.Errorf("committeeccv: parsing verifier config from job spec: %w", err)
 				}
 				configBytes, err := toml.Marshal(verCfg)
@@ -692,7 +693,7 @@ func buildVerifierJobSpecEffects(
 				if loaderErr != nil {
 					return nil, fmt.Errorf("committeeccv: loading chain config for verifier %s: %w", ver.NOPAlias, loaderErr)
 				}
-				baseSpec := allJobSpecs[ver.NodeIndex%len(allJobSpecs)]
+				baseSpec := allJobSpecs[0]
 				jobSpec, specErr := committeeverifier.RebuildVerifierJobSpecWithBlockchainInfos(baseSpec, blockchainInfos)
 				if specErr != nil {
 					return nil, fmt.Errorf("committeeccv: building job spec for verifier %s: %w", ver.NOPAlias, specErr)

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -594,6 +594,8 @@ func generateVerifierJobSpecs(
 				Monitoring:               topology.Monitoring,
 				TargetNOPs:               verNOPAliases,
 				DisableFinalityCheckers:  disableFinalityCheckers,
+				// Consolidated topology: one verifier job per NOP writing to every aggregator.
+				ConsolidateAggregators: true,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate verifier configs for committee %s: %w", committeeName, err)
@@ -607,14 +609,14 @@ func generateVerifierJobSpecs(
 			if err != nil {
 				return nil, err
 			}
+			if len(aggNames) == 0 {
+				return nil, fmt.Errorf("committee %q has no aggregators in topology", committeeName)
+			}
 
-			// In HA topologies (multiple aggregators per committee) enforce a strict
-			// 1:1 verifier-to-aggregator mapping. For single-aggregator committees
-			// this constraint doesn't apply — all verifiers share the one aggregator.
-			if len(aggNames) > 1 {
-				if err := validateStandaloneVerifierNodeIndices(committeeName, committeeVerifiers, len(aggNames)); err != nil {
-					return nil, err
-				}
+			// node_index is now only a per-container identity (the consolidated job writes to all
+			// aggregators), so it just needs to be unique within the committee.
+			if err := validateStandaloneVerifierNodeIndices(committeeName, committeeVerifiers); err != nil {
+				return nil, err
 			}
 
 			for _, ver := range committeeVerifiers {
@@ -622,40 +624,33 @@ func generateVerifierJobSpecs(
 					continue
 				}
 
-				allJobSpecs := make([]bootstrap.JobSpec, 0, len(aggNames))
-				for _, aggName := range aggNames {
-					jobSpecID := ccvshared.NewVerifierJobID(ccvshared.NOPAlias(ver.NOPAlias), aggName, ccvshared.VerifierJobScope{CommitteeQualifier: committeeName})
-					job, err := ccvdeployment.GetJob(output.DataStore.Seal(), ccvshared.NOPAlias(ver.NOPAlias), jobSpecID.ToJobID())
-					if err != nil {
-						return nil, fmt.Errorf("failed to get verifier job spec for %s aggregator %s: %w", ver.ContainerName, aggName, err)
-					}
-
-					// TODO: Use bootstrap.JobSpec in CLD to avoid this conversion here
-					var verifierJobSpec VerifierJobSpec
-					md, err := toml.Decode(job.Spec, &verifierJobSpec)
-					if err != nil {
-						return nil, fmt.Errorf("failed to decode verifier job spec for %s: %w", ver.ContainerName, err)
-					}
-					if len(md.Undecoded()) > 0 {
-						L.Warn().
-							Str("spec", job.Spec).
-							Str("undecoded fields", fmt.Sprintf("%v", md.Undecoded())).
-							Msg("Undecoded fields in executor job spec")
-						return nil, fmt.Errorf("unknown fields in verifier job spec for %s aggregator: %v", ver.ContainerName, md.Undecoded())
-					}
-
-					allJobSpecs = append(allJobSpecs, verifierJobSpec.ToBootstrapJobSpec())
+				// Consolidated topology: a single verifier job per NOP writing to all aggregators.
+				jobSpecID := ccvshared.NewConsolidatedVerifierJobID(ccvshared.NOPAlias(ver.NOPAlias), ccvshared.VerifierJobScope{CommitteeQualifier: committeeName})
+				job, err := ccvdeployment.GetJob(output.DataStore.Seal(), ccvshared.NOPAlias(ver.NOPAlias), jobSpecID.ToJobID())
+				if err != nil {
+					return nil, fmt.Errorf("failed to get consolidated verifier job spec for %s: %w", ver.ContainerName, err)
 				}
 
-				verifierJobSpecs[ver.NOPAlias] = allJobSpecs
-				ver.GeneratedJobSpecs = allJobSpecs
+				// TODO: Use bootstrap.JobSpec in CLD to avoid this conversion here
+				var verifierJobSpec VerifierJobSpec
+				md, err := toml.Decode(job.Spec, &verifierJobSpec)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode verifier job spec for %s: %w", ver.ContainerName, err)
+				}
+				if len(md.Undecoded()) > 0 {
+					L.Warn().
+						Str("spec", job.Spec).
+						Str("undecoded fields", fmt.Sprintf("%v", md.Undecoded())).
+						Msg("Undecoded fields in verifier job spec")
+					return nil, fmt.Errorf("unknown fields in verifier job spec for %s: %v", ver.ContainerName, md.Undecoded())
+				}
 
-				// NodeIndex selects which aggregator this verifier targets. For
-				// single-aggregator committees the modulo collapses to 0, so all
-				// verifiers share the one aggregator — matching the non-HA model.
-				ownedAggIdx := ver.NodeIndex % len(aggNames)
+				bootSpec := verifierJobSpec.ToBootstrapJobSpec()
+				verifierJobSpecs[ver.NOPAlias] = []bootstrap.JobSpec{bootSpec}
+				ver.GeneratedJobSpecs = []bootstrap.JobSpec{bootSpec}
+
 				var verCfg commit.Config
-				if err := toml.Unmarshal([]byte(allJobSpecs[ownedAggIdx].AppConfig), &verCfg); err != nil {
+				if err := toml.Unmarshal([]byte(bootSpec.AppConfig), &verCfg); err != nil {
 					return nil, fmt.Errorf("failed to parse verifier config from job spec: %w", err)
 				}
 
@@ -1107,15 +1102,16 @@ func proposeJobsToExecutors(
 }
 
 func launchStandaloneVerifiers(in *Cfg, blockchainOutputs []*blockchain.Output, jdInfra *jobs.JDInfrastructure) ([]*committeeverifier.Output, error) {
-	// Collect aggregator outputs per committee in insertion order so that NodeIndex maps
-	// each verifier to the correct aggregator. A map[string]*Output would lose duplicates
-	// since HA committees have multiple aggregators under the same committee name.
+	// Collect aggregator outputs per committee in insertion order. The order matches
+	// committee.Aggregators (TOML order plus expansion clones), so it aligns by index with the
+	// topology aggregator names below — used to key each verifier's per-aggregator credentials.
 	aggregatorsByCommittee := make(map[string][]*services.AggregatorOutput)
 	for _, agg := range in.Aggregator {
 		if agg.Out != nil {
 			aggregatorsByCommittee[agg.CommitteeName] = append(aggregatorsByCommittee[agg.CommitteeName], agg.Out)
 		}
 	}
+	topoAggNames := committeeverifier.CommitteeAggregatorNames(in.EnvironmentTopology)
 
 	// Apply defaults to verifiers so that we can use them in the standalone mode.
 	for i := range in.Verifier {
@@ -1137,8 +1133,12 @@ func launchStandaloneVerifiers(in *Cfg, blockchainOutputs []*blockchain.Output, 
 				ver.ContainerName, ver.CommitteeName,
 			)
 		}
-		aggIdx := ver.NodeIndex % len(aggOuts)
-		ver.AggregatorOutput = aggOuts[aggIdx]
+		creds, err := committeeverifier.AggregatorCredentialsForVerifier(ver.ContainerName, aggOuts, topoAggNames[ver.CommitteeName])
+		if err != nil {
+			return nil, err
+		}
+		ver.AggregatorCredentials = creds
+		ver.AggregatorOutput = aggOuts[ver.NodeIndex%len(aggOuts)]
 		out, err := committeeverifier.New(ver, blockchainOutputs, jdInfra, chainreg.GetRegistry().GetVerifierModifiers())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create verifier service: %w", err)
@@ -1263,36 +1263,22 @@ func extractAndValidateDisableFinalityCheckers(committeeName string, verifiers [
 	return disableFinalityCheckersPerFamily, nil
 }
 
-// validateStandaloneVerifierNodeIndices validates that the node_index assignments for
-// standalone verifiers in a single committee are consistent with the number of aggregators.
-func validateStandaloneVerifierNodeIndices(committeeName string, verifiers []*committeeverifier.Input, numAggregators int) error {
+// validateStandaloneVerifierNodeIndices ensures each verifier in a committee has a unique
+// node_index. In the consolidated topology node_index is purely a per-container identity (used for
+// container/config naming) and no longer maps to an aggregator — every verifier writes to all
+// aggregators — so it is decoupled from the aggregator count.
+func validateStandaloneVerifierNodeIndices(committeeName string, verifiers []*committeeverifier.Input) error {
 	seen := make(map[int]string, len(verifiers)) // node_index → container_name
 
 	for _, ver := range verifiers {
-		if ver.NodeIndex >= numAggregators {
-			return fmt.Errorf(
-				"committee %q: verifier %q has node_index=%d but committee only has %d aggregator(s) — "+
-					"node_index must be in [0, %d)",
-				committeeName, ver.ContainerName, ver.NodeIndex, numAggregators, numAggregators,
-			)
-		}
-
 		if existing, dup := seen[ver.NodeIndex]; dup {
 			return fmt.Errorf(
 				"committee %q: verifiers %q and %q both have node_index=%d — "+
-					"each verifier must have a unique node_index so that every aggregator has exactly one writer",
+					"node_index must be unique within a committee",
 				committeeName, existing, ver.ContainerName, ver.NodeIndex,
 			)
 		}
 		seen[ver.NodeIndex] = ver.ContainerName
-	}
-
-	if len(verifiers) != numAggregators {
-		return fmt.Errorf(
-			"committee %q: %d standalone verifier(s) configured but %d aggregator(s) defined — "+
-				"the standalone model requires exactly one verifier per aggregator (1:1 mapping)",
-			committeeName, len(verifiers), numAggregators,
-		)
 	}
 
 	return nil

--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -1133,7 +1133,7 @@ func launchStandaloneVerifiers(in *Cfg, blockchainOutputs []*blockchain.Output, 
 				ver.ContainerName, ver.CommitteeName,
 			)
 		}
-		creds, err := committeeverifier.AggregatorCredentialsForVerifier(ver.ContainerName, aggOuts, topoAggNames[ver.CommitteeName])
+		creds, err := committeeverifier.AggregatorCredentialsForVerifier(ver, aggOuts, topoAggNames[ver.CommitteeName])
 		if err != nil {
 			return nil, err
 		}

--- a/build/devenv/environment_monolith.go
+++ b/build/devenv/environment_monolith.go
@@ -675,14 +675,13 @@ func NewEnvironment() (in *Cfg, err error) {
 		return nil, err
 	}
 
-	// Each verifier owns one aggregator (NodeIndex % numAggs). Select the
-	// corresponding job spec so proposeJobsToStandaloneVerifiers gets a
-	// single spec per container.
+	// Consolidated topology: generateVerifierJobSpecs produces a single job spec per NOP
+	// (writing to all aggregators), so proposeJobsToStandaloneVerifiers gets that one spec.
 	ownedJobSpecs := make(map[string]bootstrap.JobSpec, len(verifierJobSpecs))
 	for _, ver := range in.Verifier {
 		specs := verifierJobSpecs[ver.NOPAlias]
 		if len(specs) > 0 {
-			ownedJobSpecs[ver.NOPAlias] = specs[ver.NodeIndex%len(specs)]
+			ownedJobSpecs[ver.NOPAlias] = specs[0]
 		}
 	}
 

--- a/build/devenv/evm/event_poller.go
+++ b/build/devenv/evm/event_poller.go
@@ -208,7 +208,7 @@ func (p *eventPoller[T]) poll() {
 				delete(p.waitersByMessageID, msgIDKey)
 				p.logger.Info().
 					Uint64("chainSelector", key.chainSelector).
-					Bytes("messageID", key.messageID[:]).
+					Str("messageID", key.messageID.String()).
 					Str("event", p.eventName).
 					Msg("Event received")
 				ch <- result

--- a/build/devenv/evm/impl.go
+++ b/build/devenv/evm/impl.go
@@ -404,7 +404,7 @@ func (m *CCIP17EVM) ConfirmSendOnSource(ctx context.Context, to uint64, key ccip
 	pollerKey := eventKey{chainSelector: to, msgNum: key.SeqNum, messageID: key.MessageID}
 	var resultCh <-chan pollerResult[cciptestinterfaces.MessageSentEvent]
 	if key.MessageID != (protocol.Bytes32{}) {
-		l.Info().Uint64("from", m.chainDetails.ChainSelector).Uint64("to", to).Bytes("messageID", key.MessageID[:]).Msg("Awaiting CCIPMessageSent event")
+		l.Info().Uint64("from", m.chainDetails.ChainSelector).Uint64("to", to).Str("messageID", key.MessageID.String()).Msg("Awaiting CCIPMessageSent event")
 		resultCh = poller.registerByMessageID(ctx, pollerKey)
 	} else {
 		l.Info().Uint64("from", m.chainDetails.ChainSelector).Uint64("to", to).Uint64("seq", key.SeqNum).Msg("Awaiting CCIPMessageSent event")
@@ -442,7 +442,7 @@ func (m *CCIP17EVM) ConfirmExecOnDest(ctx context.Context, from uint64, key ccip
 	pollerKey := eventKey{chainSelector: from, msgNum: key.SeqNum, messageID: key.MessageID}
 	var resultCh <-chan pollerResult[cciptestinterfaces.ExecutionStateChangedEvent]
 	if key.MessageID != (protocol.Bytes32{}) {
-		l.Info().Uint64("from", from).Bytes("messageID", key.MessageID[:]).Msg("Awaiting ExecutionStateChanged event")
+		l.Info().Uint64("from", from).Str("messageID", key.MessageID.String()).Msg("Awaiting ExecutionStateChanged event")
 		resultCh = poller.registerByMessageID(ctx, pollerKey)
 	} else {
 		l.Info().Uint64("from", from).Uint64("to", m.chainDetails.ChainSelector).Uint64("seq", key.SeqNum).Msg("Awaiting ExecutionStateChanged event")

--- a/build/devenv/services/committeeverifier/base.go
+++ b/build/devenv/services/committeeverifier/base.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/jobs"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/util"
+	hmacutil "github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
 	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/commit"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
@@ -96,6 +97,13 @@ type Input struct {
 
 	// AggregatorOutput is optionally set to automatically obtain credentials.
 	AggregatorOutput *services.AggregatorOutput `toml:"-"`
+
+	// AggregatorCredentials maps aggregator topology name -> this verifier's HMAC credentials at
+	// that aggregator. In the consolidated topology the verifier writes to every aggregator, each
+	// with its own credential; the launch code populates this from each aggregator's output. The
+	// runtime reads each via VERIFIER_AGGREGATOR_<SECRETNAME>_API_KEY/SECRET_KEY, where SECRETNAME
+	// is the aggregator's secret_name in the generated config.
+	AggregatorCredentials map[string]hmacutil.Credentials `toml:"-"`
 
 	// GeneratedJobSpecs contains all job specs for this verifier, one per aggregator in the committee.
 	GeneratedJobSpecs []bootstrap.JobSpec `toml:"-"`
@@ -434,8 +442,34 @@ func baseImageRequest(in *Input, envVars map[string]string, bootstrapConfigFileP
 
 func getAggregatorSecrets(in *Input) (map[string]string, error) {
 	envVars := make(map[string]string)
-	var apiKey, secretKey string
 
+	// Per-aggregator credentials (consolidated topology): the verifier writes to every aggregator
+	// in its committee, each with its own credential exposed via VERIFIER_AGGREGATOR_<SECRETNAME>_*.
+	// Credentials are keyed by aggregator topology name; the env var name is derived from the
+	// aggregator's secret_name in the generated config.
+	if len(in.AggregatorCredentials) > 0 {
+		var cfg commit.Config
+		if err := toml.Unmarshal([]byte(in.GeneratedConfig), &cfg); err != nil {
+			return nil, fmt.Errorf("verifier %s: parsing generated config for credentials: %w", in.ContainerName, err)
+		}
+		aggregators, err := cfg.ResolvedAggregators()
+		if err != nil {
+			return nil, fmt.Errorf("verifier %s: resolving aggregators for credentials: %w", in.ContainerName, err)
+		}
+		for _, agg := range aggregators {
+			creds, ok := in.AggregatorCredentials[agg.Name]
+			if !ok {
+				return nil, fmt.Errorf("verifier %s: no HMAC credentials for aggregator %q", in.ContainerName, agg.Name)
+			}
+			apiKeyVar, secretKeyVar := commit.AggregatorCredentialEnvVars(agg.SecretName)
+			envVars[apiKeyVar] = creds.APIKey
+			envVars[secretKeyVar] = creds.Secret
+		}
+		return envVars, nil
+	}
+
+	// Fallback: a single credential under the default (legacy) variables.
+	var apiKey, secretKey string
 	if in.Env != nil && in.Env.AggregatorAPIKey != "" && in.Env.AggregatorSecretKey != "" {
 		apiKey = in.Env.AggregatorAPIKey
 		secretKey = in.Env.AggregatorSecretKey
@@ -448,11 +482,11 @@ func getAggregatorSecrets(in *Input) (map[string]string, error) {
 	}
 
 	if apiKey == "" || secretKey == "" {
-		return nil, fmt.Errorf("failed to get HMAC credentials for verifier %s: no credentials provided via Env or AggregatorOutput", in.ContainerName)
+		return nil, fmt.Errorf("failed to get HMAC credentials for verifier %s: no credentials provided via AggregatorCredentials, Env, or AggregatorOutput", in.ContainerName)
 	}
 
-	envVars["VERIFIER_AGGREGATOR_API_KEY"] = apiKey
-	envVars["VERIFIER_AGGREGATOR_SECRET_KEY"] = secretKey
+	envVars[commit.DefaultAggregatorAPIKeyEnvVar] = apiKey
+	envVars[commit.DefaultAggregatorSecretKeyEnvVar] = secretKey
 
 	return envVars, nil
 }

--- a/build/devenv/services/committeeverifier/base.go
+++ b/build/devenv/services/committeeverifier/base.go
@@ -98,11 +98,11 @@ type Input struct {
 	// AggregatorOutput is optionally set to automatically obtain credentials.
 	AggregatorOutput *services.AggregatorOutput `toml:"-"`
 
-	// AggregatorCredentials maps aggregator topology name -> this verifier's HMAC credentials at
-	// that aggregator. In the consolidated topology the verifier writes to every aggregator, each
-	// with its own credential; the launch code populates this from each aggregator's output. The
-	// runtime reads each via VERIFIER_AGGREGATOR_<SECRETNAME>_API_KEY/SECRET_KEY, where SECRETNAME
-	// is the aggregator's secret_name in the generated config.
+	// AggregatorCredentials maps each aggregator's SecretName -> this verifier's HMAC credentials
+	// at that aggregator. In the consolidated topology the verifier writes to every aggregator,
+	// each with its own credential; the launch code populates this from each aggregator's output.
+	// Keyed by SecretName so base.go can emit VERIFIER_AGGREGATOR_<SECRETNAME>_API_KEY/SECRET_KEY
+	// directly, matching what the runtime reads — no dependency on the generated config.
 	AggregatorCredentials map[string]hmacutil.Credentials `toml:"-"`
 
 	// GeneratedJobSpecs contains all job specs for this verifier, one per aggregator in the committee.
@@ -445,23 +445,12 @@ func getAggregatorSecrets(in *Input) (map[string]string, error) {
 
 	// Per-aggregator credentials (consolidated topology): the verifier writes to every aggregator
 	// in its committee, each with its own credential exposed via VERIFIER_AGGREGATOR_<SECRETNAME>_*.
-	// Credentials are keyed by aggregator topology name; the env var name is derived from the
-	// aggregator's secret_name in the generated config.
+	// AggregatorCredentials is keyed by SecretName, so the env var name is derived directly from
+	// the key — matching what the runtime reads. No dependency on the generated config (which is
+	// produced after the container launches).
 	if len(in.AggregatorCredentials) > 0 {
-		var cfg commit.Config
-		if err := toml.Unmarshal([]byte(in.GeneratedConfig), &cfg); err != nil {
-			return nil, fmt.Errorf("verifier %s: parsing generated config for credentials: %w", in.ContainerName, err)
-		}
-		aggregators, err := cfg.ResolvedAggregators()
-		if err != nil {
-			return nil, fmt.Errorf("verifier %s: resolving aggregators for credentials: %w", in.ContainerName, err)
-		}
-		for _, agg := range aggregators {
-			creds, ok := in.AggregatorCredentials[agg.Name]
-			if !ok {
-				return nil, fmt.Errorf("verifier %s: no HMAC credentials for aggregator %q", in.ContainerName, agg.Name)
-			}
-			apiKeyVar, secretKeyVar := commit.AggregatorCredentialEnvVars(agg.SecretName)
+		for secretName, creds := range in.AggregatorCredentials {
+			apiKeyVar, secretKeyVar := commit.AggregatorCredentialEnvVars(secretName)
 			envVars[apiKeyVar] = creds.APIKey
 			envVars[secretKeyVar] = creds.Secret
 		}

--- a/build/devenv/services/committeeverifier/launch.go
+++ b/build/devenv/services/committeeverifier/launch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/jobs"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services"
 	ccvdeployment "github.com/smartcontractkit/chainlink-ccv/deployment"
+	ccvshared "github.com/smartcontractkit/chainlink-ccv/deployment/shared"
 	hmacutil "github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 )
@@ -37,24 +38,29 @@ func CommitteeAggregatorNames(topology *ccvdeployment.EnvironmentTopology) map[s
 }
 
 // AggregatorCredentialsForVerifier builds the verifier's per-aggregator HMAC credentials, keyed by
-// aggregator topology name. aggOuts and aggNames must be index-aligned (committee aggregator
-// order). Each aggregator issues its own credential for the verifier, so a consolidated verifier
-// (writing to all of them) needs one credential per aggregator.
-func AggregatorCredentialsForVerifier(containerName string, aggOuts []*services.AggregatorOutput, aggNames []string) (map[string]hmacutil.Credentials, error) {
+// each aggregator's SecretName. aggOuts and aggNames (topology aggregator names) must be
+// index-aligned (committee aggregator order). The SecretName is computed the same way the
+// changeset bakes it into the verifier config — NewVerifierJobID(nop, aggName, scope).GetVerifierID()
+// — so the keys match the VERIFIER_AGGREGATOR_<SECRETNAME>_* env vars the runtime reads. Computing
+// it here (rather than parsing the generated config) avoids depending on config generation, which
+// happens after the container is launched.
+func AggregatorCredentialsForVerifier(ver *Input, aggOuts []*services.AggregatorOutput, aggNames []string) (map[string]hmacutil.Credentials, error) {
 	if len(aggNames) != len(aggOuts) {
-		return nil, fmt.Errorf("verifier %q: %d aggregator outputs but %d topology names — cannot map credentials", containerName, len(aggOuts), len(aggNames))
+		return nil, fmt.Errorf("verifier %q: %d aggregator outputs but %d topology names — cannot map credentials", ver.ContainerName, len(aggOuts), len(aggNames))
 	}
+	scope := ccvshared.VerifierJobScope{CommitteeQualifier: ver.CommitteeName}
 	creds := make(map[string]hmacutil.Credentials, len(aggOuts))
 	for i, out := range aggOuts {
-		name := aggNames[i]
-		if name == "" {
-			return nil, fmt.Errorf("verifier %q: aggregator at index %d has no topology name", containerName, i)
+		aggName := aggNames[i]
+		if aggName == "" {
+			return nil, fmt.Errorf("verifier %q: aggregator at index %d has no topology name", ver.ContainerName, i)
 		}
-		c, ok := out.GetCredentialsForClient(containerName)
+		secretName := ccvshared.NewVerifierJobID(ccvshared.NOPAlias(ver.NOPAlias), aggName, scope).GetVerifierID()
+		c, ok := out.GetCredentialsForClient(ver.ContainerName)
 		if !ok {
-			return nil, fmt.Errorf("verifier %q: no HMAC credentials issued by aggregator %q", containerName, name)
+			return nil, fmt.Errorf("verifier %q: no HMAC credentials issued by aggregator %q", ver.ContainerName, aggName)
 		}
-		creds[name] = c
+		creds[secretName] = c
 	}
 	return creds, nil
 }
@@ -93,7 +99,7 @@ func LaunchStandaloneVerifiers(
 		if len(aggOuts) == 0 {
 			return fmt.Errorf("verifier %q (committee %q): no aggregator outputs found", ver.ContainerName, ver.CommitteeName)
 		}
-		creds, err := AggregatorCredentialsForVerifier(ver.ContainerName, aggOuts, committeeAggNames[ver.CommitteeName])
+		creds, err := AggregatorCredentialsForVerifier(ver, aggOuts, committeeAggNames[ver.CommitteeName])
 		if err != nil {
 			return err
 		}

--- a/build/devenv/services/committeeverifier/launch.go
+++ b/build/devenv/services/committeeverifier/launch.go
@@ -12,16 +12,63 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/jobs"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/services"
+	ccvdeployment "github.com/smartcontractkit/chainlink-ccv/deployment"
+	hmacutil "github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 )
 
-// LaunchStandaloneVerifiers starts standalone verifier containers. Each verifier reads HMAC
-// credentials from the matching aggregator output (matched by CommitteeName + NodeIndex).
+// CommitteeAggregatorNames returns, per committee, the ordered topology aggregator names. The
+// order matches the per-committee aggregator outputs (TOML order plus expansion clones), so the
+// two can be zipped by index. Used to key a verifier's per-aggregator credentials by the same
+// name the verifier config carries.
+func CommitteeAggregatorNames(topology *ccvdeployment.EnvironmentTopology) map[string][]string {
+	result := make(map[string][]string)
+	if topology == nil || topology.NOPTopology == nil {
+		return result
+	}
+	for name, committee := range topology.NOPTopology.Committees {
+		names := make([]string, len(committee.Aggregators))
+		for i, a := range committee.Aggregators {
+			names[i] = a.Name
+		}
+		result[name] = names
+	}
+	return result
+}
+
+// AggregatorCredentialsForVerifier builds the verifier's per-aggregator HMAC credentials, keyed by
+// aggregator topology name. aggOuts and aggNames must be index-aligned (committee aggregator
+// order). Each aggregator issues its own credential for the verifier, so a consolidated verifier
+// (writing to all of them) needs one credential per aggregator.
+func AggregatorCredentialsForVerifier(containerName string, aggOuts []*services.AggregatorOutput, aggNames []string) (map[string]hmacutil.Credentials, error) {
+	if len(aggNames) != len(aggOuts) {
+		return nil, fmt.Errorf("verifier %q: %d aggregator outputs but %d topology names — cannot map credentials", containerName, len(aggOuts), len(aggNames))
+	}
+	creds := make(map[string]hmacutil.Credentials, len(aggOuts))
+	for i, out := range aggOuts {
+		name := aggNames[i]
+		if name == "" {
+			return nil, fmt.Errorf("verifier %q: aggregator at index %d has no topology name", containerName, i)
+		}
+		c, ok := out.GetCredentialsForClient(containerName)
+		if !ok {
+			return nil, fmt.Errorf("verifier %q: no HMAC credentials issued by aggregator %q", containerName, name)
+		}
+		creds[name] = c
+	}
+	return creds, nil
+}
+
+// LaunchStandaloneVerifiers starts standalone verifier containers. Each verifier authenticates to
+// every aggregator in its committee with that aggregator's own HMAC credential; committeeAggNames
+// maps committee -> ordered topology aggregator names (zipped by index with the committee's
+// aggregator outputs) so those credentials can be keyed by name.
 // Callers must populate agg.Out (at minimum agg.Out.ClientCredentials) before calling.
 // modifiers is a map from chain family to ReqModifier (obtain via chainreg.GetRegistry().GetVerifierModifiers()).
 func LaunchStandaloneVerifiers(
 	verifiers []*Input,
 	aggregators []*services.AggregatorInput,
+	committeeAggNames map[string][]string,
 	blockchainOutputs []*blockchain.Output,
 	jdInfra *jobs.JDInfrastructure,
 	modifiers map[string]ReqModifier,
@@ -46,6 +93,11 @@ func LaunchStandaloneVerifiers(
 		if len(aggOuts) == 0 {
 			return fmt.Errorf("verifier %q (committee %q): no aggregator outputs found", ver.ContainerName, ver.CommitteeName)
 		}
+		creds, err := AggregatorCredentialsForVerifier(ver.ContainerName, aggOuts, committeeAggNames[ver.CommitteeName])
+		if err != nil {
+			return err
+		}
+		ver.AggregatorCredentials = creds
 		ver.AggregatorOutput = aggOuts[ver.NodeIndex%len(aggOuts)]
 		out, err := New(ver, blockchainOutputs, jdInfra, modifiers)
 		if err != nil {

--- a/changelog/2026-06-22_multi_aggregator_verifier_part2.md
+++ b/changelog/2026-06-22_multi_aggregator_verifier_part2.md
@@ -1,0 +1,71 @@
+# Multi-aggregator committee verifier — Part 2
+
+## Summary
+
+`NewVerificationCoordinator` now accepts per-aggregator HMAC credentials (keyed by
+`AggregatorConnection.SecretName`) instead of a single shared credential. The devenv
+cuts over to the consolidated verifier config so standalone verifiers write to all
+committee aggregators from a single job.
+
+---
+
+## Breaking change: `NewVerificationCoordinator` credential parameter
+
+The `aggregatorSecret *hmac.ClientConfig` parameter is replaced by a map. Each
+aggregator's credential is looked up by `AggregatorConnection.SecretName`; the legacy
+single-aggregator config has an empty `SecretName`, so its credential must be stored
+under the `""` key.
+
+| What | Before | After |
+|------|--------|-------|
+| Parameter | `aggregatorSecret *hmac.ClientConfig` | `aggregatorSecrets map[string]*hmac.ClientConfig` |
+| Lookup | applied to all aggregators | per-aggregator, keyed by `SecretName` |
+| Legacy compat | N/A | empty `SecretName` → key `""` |
+
+Before:
+```go
+vc, err := constructors.NewVerificationCoordinator(
+    lggr, cfg,
+    &hmac.ClientConfig{APIKey: key, Secret: secret},
+    signerAddr, signer, chains, ds,
+)
+```
+
+After:
+```go
+vc, err := constructors.NewVerificationCoordinator(
+    lggr, cfg,
+    map[string]*hmac.ClientConfig{
+        // legacy single-aggregator: key is ""
+        "": {APIKey: key, Secret: secret},
+        // consolidated multi-aggregator: key is AggregatorConnection.SecretName
+        "mycommittee-verifier-1-v1": {APIKey: key1, Secret: secret1},
+    },
+    signerAddr, signer, chains, ds,
+)
+```
+
+**Callers** (e.g. `ccvcommitteeverifier/delegate.go` in chainlink) must migrate to
+`buildAggregatorSecrets` — which resolves credentials from the secrets TOML by matching
+each aggregator's `SecretName` against the stored `VerifierID`.
+
+---
+
+## New: per-aggregator HMAC credentials in devenv
+
+Standalone verifier containers now receive one `VERIFIER_AGGREGATOR_<SECRETNAME>_API_KEY`
+/ `_SECRET_KEY` env var pair per aggregator instead of the single legacy default pair.
+`SecretName` is computed as `NewVerifierJobID(nop, aggName, scope).GetVerifierID()` —
+the same formula the changeset bakes into the verifier config — so no credential
+re-provisioning is needed.
+
+The consolidated job spec (`ConsolidateAggregators: true`) is now the default for all
+devenv modes (monolith and phased/component). Each standalone verifier node owns one
+consolidated spec and writes to every committee aggregator.
+
+---
+
+## Recommended additions
+
+- Unit test for `NewVerificationCoordinator` covering the multi-aggregator secret lookup
+  and the missing-secret error path (flagged as a test gap by the graph).

--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -28,18 +28,16 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/pkg/chains/legacyevm"
 )
 
-// NewVerificationCoordinator builds a verifier coordinator. aggregatorSecret is the HMAC
-// credential used for every configured aggregator.
-//
-// TODO(CCIP-11776 follow-up): for a consolidated job each aggregator authenticates with its own
-// credential, so this should take a per-aggregator map keyed by AggregatorConnection.SecretName.
-// That is a breaking change to the Chainlink-node caller (ccvcommitteeverifier/delegate.go) and
-// lands together with that migration; until then this constructor applies one credential to all
-// aggregators, which is correct for the single-aggregator (legacy) configs in use today.
+// NewVerificationCoordinator builds a verifier coordinator. aggregatorSecrets maps each
+// aggregator's SecretName (AggregatorConnection.SecretName) to its HMAC credential — a consolidated
+// verifier writes to every aggregator, each of which authenticates it with its own credential.
+// Keying by SecretName (rather than position) avoids any ordering contract with
+// cfg.ResolvedAggregators(); the legacy single-aggregator config has an empty SecretName, so its
+// credential is keyed by "".
 func NewVerificationCoordinator(
 	lggr logger.Logger,
 	cfg commit.Config,
-	aggregatorSecret *hmac.ClientConfig,
+	aggregatorSecrets map[string]*hmac.ClientConfig,
 	signingAddress protocol.UnknownAddress,
 	signer verifier.MessageSigner,
 	relayers map[protocol.ChainSelector]legacyevm.Chain,
@@ -155,7 +153,17 @@ func NewVerificationCoordinator(
 		return nil, fmt.Errorf("invalid aggregator configuration: %w", err)
 	}
 
-	// The single provided credential is applied to every aggregator (see the constructor's TODO).
+	// Each aggregator authenticates with its own credential, looked up by SecretName.
+	// resolvedSecrets is index-aligned with resolvedAggregators for the wiring below.
+	resolvedSecrets := make([]*hmac.ClientConfig, len(resolvedAggregators))
+	for i, a := range resolvedAggregators {
+		sec, ok := aggregatorSecrets[a.SecretName]
+		if !ok {
+			return nil, fmt.Errorf("missing aggregator secret for %q (secret_name %q)", a.Label(), a.SecretName)
+		}
+		resolvedSecrets[i] = sec
+	}
+
 	writeTargets := make([]storageaccess.AggregatorTarget, len(resolvedAggregators))
 	heartbeatTargets := make([]heartbeatclient.AggregatorTarget, len(resolvedAggregators))
 	for i, a := range resolvedAggregators {
@@ -163,7 +171,7 @@ func NewVerificationCoordinator(
 			Label:               a.Label(),
 			Address:             a.Address,
 			Insecure:            a.InsecureConnection,
-			HMACConfig:          aggregatorSecret,
+			HMACConfig:          resolvedSecrets[i],
 			MaxSendMsgSizeBytes: a.MaxSendMsgSizeBytes,
 			MaxRecvMsgSizeBytes: a.MaxRecvMsgSizeBytes,
 		}
@@ -171,7 +179,7 @@ func NewVerificationCoordinator(
 			Label:      a.Label(),
 			Address:    a.Address,
 			Insecure:   a.InsecureConnection,
-			HMACConfig: aggregatorSecret,
+			HMACConfig: resolvedSecrets[i],
 		}
 	}
 
@@ -236,12 +244,12 @@ func NewVerificationCoordinator(
 	}
 
 	namedPollers := make([]messagerules.NamedPoller, 0, len(resolvedAggregators))
-	for _, a := range resolvedAggregators {
+	for i, a := range resolvedAggregators {
 		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Label())
 		messageRulesClient, rErr := messagerules.NewGRPCClient(
 			a.Address,
 			aggLggr,
-			aggregatorSecret,
+			resolvedSecrets[i],
 			a.InsecureConnection,
 			a.MaxRecvMsgSizeBytes,
 		)


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Follow up to #1184 

Chainlink PR: https://github.com/smartcontractkit/chainlink/pull/22907

- NewVerificationCoordinator takes map[SecretName]*hmac.ClientConfig
  (one credential per aggregator) instead of a single secret
- devenv emits one consolidated verifier job per NOP (monolith and
  phased paths), dropping the per-aggregator node_index selection;
  node_index validation relaxed to uniqueness within a committee
- standalone containers get per-aggregator creds via
  VERIFIER_AGGREGATOR_<SECRETNAME>_* env vars; CL secret injection
  already keys by the per-aggregator verifier_id (= SecretName)


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

CI has been switched to use the new config paradigm (`Aggregators`) for both standalone and CL mode.


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
