### PR TITLE
integration/storageaccess: aggregator fallback to verifierID

### DIFF
--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -108,7 +108,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 	for i, a := range resolvedAggregators {
 		hmacConfig, hErr := a.ResolveHMACConfig()
 		if hErr != nil {
-			lggr.Errorw("Failed to resolve aggregator credentials", "error", hErr, "aggregator", a.Label())
+			lggr.Errorw("Failed to resolve aggregator credentials", "error", hErr, "aggregator", a.Label(config.VerifierID))
 			return fmt.Errorf("failed to resolve aggregator credentials: %w", hErr)
 		}
 		aggregatorHMACs[i] = hmacConfig
@@ -118,7 +118,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 	heartbeatTargets := make([]heartbeatclient.AggregatorTarget, len(resolvedAggregators))
 	for i, a := range resolvedAggregators {
 		writeTargets[i] = storageaccess.AggregatorTarget{
-			Label:               a.Label(),
+			Label:               a.Label(config.VerifierID),
 			Address:             a.Address,
 			Insecure:            a.InsecureConnection,
 			HMACConfig:          aggregatorHMACs[i],
@@ -126,7 +126,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 			MaxRecvMsgSizeBytes: a.MaxRecvMsgSizeBytes,
 		}
 		heartbeatTargets[i] = heartbeatclient.AggregatorTarget{
-			Label:      a.Label(),
+			Label:      a.Label(config.VerifierID),
 			Address:    a.Address,
 			Insecure:   a.InsecureConnection,
 			HMACConfig: aggregatorHMACs[i],
@@ -257,7 +257,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 	// disables it (fail-safe union), and verification is blocked while any source is unknown.
 	namedPollers := make([]messagerules.NamedPoller, 0, len(resolvedAggregators))
 	for i, a := range resolvedAggregators {
-		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Label())
+		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Label(config.VerifierID))
 		messageRulesClient, rErr := messagerules.NewGRPCClient(
 			a.Address,
 			aggLggr,
@@ -266,8 +266,8 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 			a.MaxRecvMsgSizeBytes,
 		)
 		if rErr != nil {
-			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Label())
-			return fmt.Errorf("failed to create message rules client for %q: %w", a.Label(), rErr)
+			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Label(config.VerifierID))
+			return fmt.Errorf("failed to create message rules client for %q: %w", a.Label(config.VerifierID), rErr)
 		}
 
 		poller, rErr := messagerules.NewPollerService(
@@ -275,13 +275,13 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 			messageRulesPollInterval,
 			messageRulesClientTimeout,
 			aggLggr,
-			verifierMonitoring.Metrics().With("aggregator", a.Label()),
+			verifierMonitoring.Metrics().With("aggregator", a.Label(config.VerifierID)),
 		)
 		if rErr != nil {
-			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Label())
-			return fmt.Errorf("failed to create message rules poller for %q: %w", a.Label(), rErr)
+			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Label(config.VerifierID))
+			return fmt.Errorf("failed to create message rules poller for %q: %w", a.Label(config.VerifierID), rErr)
 		}
-		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Label(), poller))
+		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Label(config.VerifierID), poller))
 	}
 
 	messageRulesPoller, err := messagerules.NewUnionPollerService(

--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -160,7 +160,7 @@ func NewVerificationCoordinator(
 	heartbeatTargets := make([]heartbeatclient.AggregatorTarget, len(resolvedAggregators))
 	for i, a := range resolvedAggregators {
 		writeTargets[i] = storageaccess.AggregatorTarget{
-			Label:               a.Label(),
+			Label:               a.Label(cfg.VerifierID),
 			Address:             a.Address,
 			Insecure:            a.InsecureConnection,
 			HMACConfig:          aggregatorSecret,
@@ -168,7 +168,7 @@ func NewVerificationCoordinator(
 			MaxRecvMsgSizeBytes: a.MaxRecvMsgSizeBytes,
 		}
 		heartbeatTargets[i] = heartbeatclient.AggregatorTarget{
-			Label:      a.Label(),
+			Label:      a.Label(cfg.VerifierID),
 			Address:    a.Address,
 			Insecure:   a.InsecureConnection,
 			HMACConfig: aggregatorSecret,
@@ -237,7 +237,7 @@ func NewVerificationCoordinator(
 
 	namedPollers := make([]messagerules.NamedPoller, 0, len(resolvedAggregators))
 	for _, a := range resolvedAggregators {
-		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Label())
+		aggLggr := logger.With(lggr, "component", "MessageRulesPoller", "aggregator", a.Label(cfg.VerifierID))
 		messageRulesClient, rErr := messagerules.NewGRPCClient(
 			a.Address,
 			aggLggr,
@@ -246,8 +246,8 @@ func NewVerificationCoordinator(
 			a.MaxRecvMsgSizeBytes,
 		)
 		if rErr != nil {
-			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Label())
-			return nil, fmt.Errorf("failed to create message rules client for %q: %w", a.Label(), rErr)
+			lggr.Errorw("Failed to create message rules gRPC client", "error", rErr, "aggregator", a.Label(cfg.VerifierID))
+			return nil, fmt.Errorf("failed to create message rules client for %q: %w", a.Label(cfg.VerifierID), rErr)
 		}
 
 		poller, rErr := messagerules.NewPollerService(
@@ -255,13 +255,13 @@ func NewVerificationCoordinator(
 			messageRulesPollInterval,
 			messageRulesClientTimeout,
 			aggLggr,
-			verifierMonitoring.Metrics().With("aggregator", a.Label()),
+			verifierMonitoring.Metrics().With("aggregator", a.Label(cfg.VerifierID)),
 		)
 		if rErr != nil {
-			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Label())
-			return nil, fmt.Errorf("failed to create message rules poller for %q: %w", a.Label(), rErr)
+			lggr.Errorw("Failed to create message rules poller", "error", rErr, "aggregator", a.Label(cfg.VerifierID))
+			return nil, fmt.Errorf("failed to create message rules poller for %q: %w", a.Label(cfg.VerifierID), rErr)
 		}
-		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Label(), poller))
+		namedPollers = append(namedPollers, messagerules.NewNamedPoller(a.Label(cfg.VerifierID), poller))
 	}
 
 	messageRulesPoller, err := messagerules.NewUnionPollerService(

--- a/integration/storageaccess/observed_storage.go
+++ b/integration/storageaccess/observed_storage.go
@@ -16,8 +16,8 @@ type observedStorageWriter struct {
 
 	verifierID string
 	// aggregatorLabel, when non-empty, scopes this observer to a single aggregator and is
-	// emitted as the "aggregator" label on metrics/logs. Empty means the observer covers the
-	// aggregate (fan-out-wide) outcome.
+	// emitted as the "aggregator" label on metrics/logs.
+	// Empty means the observer will set the "aggregator" label to the verifier_id.
 	aggregatorLabel string
 	lggr            logger.Logger
 	monitoring      verifier.Monitoring
@@ -62,6 +62,8 @@ func (o *observedStorageWriter) metrics() verifier.MetricLabeler {
 	m := o.monitoring.Metrics().With("verifier_id", o.verifierID)
 	if o.aggregatorLabel != "" {
 		m = m.With("aggregator", o.aggregatorLabel)
+	} else {
+		m = m.With("aggregator", o.verifierID)
 	}
 	return m
 }

--- a/integration/storageaccess/observed_storage.go
+++ b/integration/storageaccess/observed_storage.go
@@ -61,9 +61,9 @@ func NewObservedAggregatorWriter(
 func (o *observedStorageWriter) metrics() verifier.MetricLabeler {
 	m := o.monitoring.Metrics().With("verifier_id", o.verifierID)
 	if o.aggregatorLabel != "" {
-		m = m.With("aggregator", o.aggregatorLabel)
+		m = m.With("aggregator_name", o.aggregatorLabel)
 	} else {
-		m = m.With("aggregator", o.verifierID)
+		m = m.With("aggregator_name", o.verifierID)
 	}
 	return m
 }

--- a/verifier/pkg/commit/config.go
+++ b/verifier/pkg/commit/config.go
@@ -45,12 +45,12 @@ type AggregatorConnection struct {
 }
 
 // Label returns the value used to identify this aggregator in logs and metrics:
-// Name when set, otherwise Address.
-func (a AggregatorConnection) Label() string {
+// Name when set, otherwise fallbackName.
+func (a AggregatorConnection) Label(fallbackName string) string {
 	if strings.TrimSpace(a.Name) != "" {
 		return a.Name
 	}
-	return a.Address
+	return fallbackName
 }
 
 const (
@@ -95,18 +95,18 @@ func (a AggregatorConnection) ResolveHMACConfig() (*hmac.ClientConfig, error) {
 
 	apiKey := os.Getenv(apiKeyVar)
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing %s for aggregator %q", apiKeyVar, a.Label())
+		return nil, fmt.Errorf("missing %s for aggregator (name:%q,address:%q)", apiKeyVar, a.Name, a.Address)
 	}
 	if err := hmac.ValidateAPIKey(apiKey); err != nil {
-		return nil, fmt.Errorf("invalid %s for aggregator %q: %w", apiKeyVar, a.Label(), err)
+		return nil, fmt.Errorf("invalid %s for aggregator (name:%q,address:%q): %w", apiKeyVar, a.Name, a.Address, err)
 	}
 
 	secret := os.Getenv(secretKeyVar)
 	if secret == "" {
-		return nil, fmt.Errorf("missing %s for aggregator %q", secretKeyVar, a.Label())
+		return nil, fmt.Errorf("missing %s for aggregator (name:%q,address:%q)", secretKeyVar, a.Name, a.Address)
 	}
 	if err := hmac.ValidateSecret(secret); err != nil {
-		return nil, fmt.Errorf("invalid %s for aggregator %q: %w", secretKeyVar, a.Label(), err)
+		return nil, fmt.Errorf("invalid %s for aggregator (name:%q,address:%q): %w", secretKeyVar, a.Name, a.Address, err)
 	}
 
 	return &hmac.ClientConfig{APIKey: apiKey, Secret: secret}, nil


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

The aggregator label on verifier metrics was previously omitted in the
event that the legacy aggregator_address config was used, since in that
case we were relying on verifier_id.

Update this to set the aggregator label to the same as the verifier_id
label for easier cutover on the metrics side.


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
