### PR TITLE
Fix ConnectAllChainsCanonical

### DIFF
--- a/build/devenv/deploy/deploy.go
+++ b/build/devenv/deploy/deploy.go
@@ -249,15 +249,30 @@ func ConnectAllChainsCanonical(
 			if isKeyPresent(remote, sel) {
 				continue
 			}
-			cfg, err := profile.impl.GetChainLaneProfile(e, sel)
+			// ChainAOverrides configure chain A's leg toward chain B; ChainBOverrides
+			// configure chain B's leg toward chain A. Each leg must use ITS OWN chain's
+			// lane profile. Using chainA's profile for both legs is order-dependent
+			// (profiles is a map) and lets a remote chain's profile leak onto the local
+			// leg — e.g. Solana's DefaultInboundCCVs (bare CommitteeVerifier) overwriting
+			// the EVM offramp's resolver, producing an intermittent CCV mismatch that the
+			// executor reports as "insufficient verifiers".
+			chainACfg, err := profile.impl.GetChainLaneProfile(e, sel)
 			if err != nil {
 				return fmt.Errorf("get chain lane profile for chain %d: %w", sel, err)
+			}
+			remoteProfile, ok := profiles[remote]
+			if !ok {
+				return fmt.Errorf("missing chain profile for remote selector %d (referenced from chain %d)", remote, sel)
+			}
+			chainBCfg, err := remoteProfile.impl.GetChainLaneProfile(e, remote)
+			if err != nil {
+				return fmt.Errorf("get chain lane profile for remote chain %d: %w", remote, err)
 			}
 			pairs[key(sel, remote)] = ccipChangesets.CrossFamilyLanePair{
 				ChainA:          sel,
 				ChainB:          remote,
-				ChainAOverrides: &cfg,
-				ChainBOverrides: &cfg,
+				ChainAOverrides: &chainACfg,
+				ChainBOverrides: &chainBCfg,
 			}
 		}
 	}

--- a/build/devenv/deploy/deploy.go
+++ b/build/devenv/deploy/deploy.go
@@ -249,13 +249,9 @@ func ConnectAllChainsCanonical(
 			if isKeyPresent(remote, sel) {
 				continue
 			}
-			// ChainAOverrides configure chain A's leg toward chain B; ChainBOverrides
-			// configure chain B's leg toward chain A. Each leg must use ITS OWN chain's
-			// lane profile. Using chainA's profile for both legs is order-dependent
-			// (profiles is a map) and lets a remote chain's profile leak onto the local
-			// leg — e.g. Solana's DefaultInboundCCVs (bare CommitteeVerifier) overwriting
-			// the EVM offramp's resolver, producing an intermittent CCV mismatch that the
-			// executor reports as "insufficient verifiers".
+
+			// Get and set chain- and remote-specific overrides to avoid leaking a remote
+			// chain's profile to the local chain
 			chainACfg, err := profile.impl.GetChainLaneProfile(e, sel)
 			if err != nil {
 				return fmt.Errorf("get chain lane profile for chain %d: %w", sel, err)


### PR DESCRIPTION
# Fix intermittent CCV mismatch in `ConnectAllChainsCanonical`

## Problem

Our Solana env.toml creates two solana chains. `ConnectAllChainsCanonical` set both `ChainAOverrides` and `ChainBOverrides` of each `CrossFamilyLanePair` to chain A's `GetChainLaneProfile`. Since `profiles` is a map (random iteration order), the EVM offramp's config for a given Solana source ended up sourced from whichever chain was visited first:

- **EVM first** --> EVM profile --> `DefaultInboundCCVs` unset --> resolves to the **CommitteeVerifierResolver** (what the aggregator advertises) ✅
- **Solana first** --> Solana profile --> `DefaultInboundCCVs = {Type: CommitteeVerifier}` --> resolves (against the EVM datastore) to the **bare CommitteeVerifier** ❌

When the bare verifier won, the executor couldn't match the offramp's required CCV against the aggregator's advertised verifier and failed Solana-->EVM execution with `insufficient verifiers`. In a 1-EVM + 2-Solana mesh this is per-lane, so one Solana source often got the Resolver and the other the bare verifier in the same deploy.

## Fix

- `ChainBOverrides` now uses the remote chain's own `GetChainLaneProfile` instead of chain A's, matching the documented per-leg semantics. The EVM offramp leg always uses the EVM profile (Resolver) regardless of map order.
- I re-ran `TestSolana2EVM` many times before the fix and got failures ~50-70% of the time. I re-ran it after the fix and haven't gotten a failure yet

