### PR TITLE
victoria traces + otlp viz

### DIFF
--- a/build/devenv/cli/ccv.go
+++ b/build/devenv/cli/ccv.go
@@ -987,6 +987,9 @@ func init() {
 	// on-chain monitoring
 	rootCmd.AddCommand(monitorContractsCmd)
 	rootCmd.AddCommand(txInfoCmd)
+
+	// viz / tracing
+	rootCmd.AddCommand(pushMockTraceCmd)
 	txInfoCmd.Flags().String("env", "env-out.toml", "Select environment file to use (defaults to env-out.toml)")
 
 	// contract management

--- a/build/devenv/cli/push_trace.go
+++ b/build/devenv/cli/push_trace.go
@@ -1,0 +1,359 @@
+package cli
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-ccv/build/devenv/cli/viz"
+)
+
+// pushMockTraceCmd pushes a synthetic CCIP message trace to an OTLP collector.
+//
+// Each phase re-sends ALL spans visible at that cutoff, with content trimmed to that point.
+// Span IDs are stable across phases — VictoriaTraces merges successive versions of each span.
+// A new random messageId (= traceId) is generated each run so pushes don't collide.
+//
+// Span timeline (ms from t0):
+//
+//	root:       0 – 13100   finalization: 0 – 4000
+//	verification: 4000 – 7800
+//	nop-1: 4050–5250  nop-2: 4100–5700  nop-3: 4250–6100
+//	nop-4: 4300–9200  nop-5/aggregator: 4000–6100
+//	token-verifier: 4400–7800
+//	indexer.poll_agg: 6000–6300  indexer.ingest: 6000–8000  indexer.poll_tv: 7100–8000
+//	execution: 8000–13100  executor-1: 8000–15000  executor-2: 13000–13100
+//
+// Phases (cutoffs in ms from t0):
+//
+//	  0 ms — root OPEN, finalization OPEN
+//	3750 ms — root OPEN, finalization OPEN (+context log)
+//	4500 ms — root OPEN, finalization CLOSED; verification+all nops+aggregator+tv OPEN
+//	6500 ms — +nop-1/2/3/5/aggregator/indexer.poll_agg CLOSED; nop-4/tv/ingest OPEN
+//	9300 ms — +verification/tv/indexer all CLOSED, nop-4 CLOSED; execution+executor-1 OPEN
+//	15000 ms — everything CLOSED (executor-2 appears, executor-1 closed)
+var pushMockTraceCmd = &cobra.Command{
+	Use:   "push-mock-trace",
+	Short: "Incrementally push a synthetic CCIP trace to OTLP (tests VictoriaTraces dedup/merge)",
+	RunE:  runPushMockTrace,
+}
+
+func init() {
+	pushMockTraceCmd.Flags().String("endpoint", "localhost:4317", "OTLP gRPC endpoint")
+	pushMockTraceCmd.Flags().Duration("interval", 30*time.Second, "Interval between phase pushes")
+	pushMockTraceCmd.Flags().Bool("dump", false, "Print each OTLP request as JSON before sending")
+	pushMockTraceCmd.Flags().Bool("full", false, "Send only the final complete trace in one shot")
+}
+
+// phaseCutoffsMs are the wall-clock offsets (ms from t0) used as snapshot cutoffs.
+// Each push sends all spans that have started by the cutoff, trimmed to that moment.
+var phaseCutoffsMs = []int64{0, 3750, 4500, 6500, 9300, 15000}
+
+func runPushMockTrace(cmd *cobra.Command, _ []string) error {
+	endpoint, _ := cmd.Flags().GetString("endpoint")
+	interval, _ := cmd.Flags().GetDuration("interval")
+	dump, _ := cmd.Flags().GetBool("dump")
+	full, _ := cmd.Flags().GetBool("full")
+
+	ctx := cmd.Context()
+
+	messageID := randomMessageID()
+	fmt.Printf("trace messageId: %s\n", messageID)
+
+	client := otlptracegrpc.NewClient(
+		otlptracegrpc.WithInsecure(),
+		otlptracegrpc.WithEndpoint(endpoint),
+	)
+	if err := client.Start(ctx); err != nil {
+		return fmt.Errorf("start OTLP client: %w", err)
+	}
+	defer func() { _ = client.Stop(ctx) }()
+
+	t0micros := viz.MustMicros("2026-06-01T15:48:29Z")
+	trace := replaceMessageID(viz.BuildTrace(), messageID)
+
+	cutoffs := phaseCutoffsMs
+	if full {
+		cutoffs = phaseCutoffsMs[len(phaseCutoffsMs)-1:]
+	}
+
+	marshaler := protojson.MarshalOptions{Multiline: true}
+
+	for i, cutoffMs := range cutoffs {
+		resourceSpans := buildMutablePhaseSpans(trace, t0micros, cutoffMs, messageID)
+
+		totalSpans := 0
+		for _, rs := range resourceSpans {
+			for _, ss := range rs.ScopeSpans {
+				totalSpans += len(ss.Spans)
+			}
+		}
+
+		if dump {
+			fmt.Printf("=== phase %d/%d (+%dms, %d spans) ===\n",
+				i+1, len(cutoffs), cutoffMs, totalSpans)
+			for _, rs := range resourceSpans {
+				b, err := marshaler.Marshal(proto.Message(rs))
+				if err == nil {
+					fmt.Println(string(b))
+				}
+			}
+			fmt.Println()
+		}
+
+		if err := client.UploadTraces(ctx, resourceSpans); err != nil {
+			return fmt.Errorf("phase %d/%d upload failed: %w", i+1, len(cutoffs), err)
+		}
+
+		fmt.Printf("phase %d/%d pushed — +%dms, %d spans\n", i+1, len(cutoffs), cutoffMs, totalSpans)
+
+		if i < len(cutoffs)-1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(interval):
+			}
+		}
+	}
+
+	fmt.Println("all phases pushed")
+	return nil
+}
+
+// buildMutablePhaseSpans returns all spans that have started by cutoffMs.
+// Each span's end time is 0 (open) if still running at the cutoff, or its final end time if done.
+// Events after the cutoff are excluded.
+func buildMutablePhaseSpans(trace viz.Trace, t0micros, cutoffMs int64, messageID string) []*tracepb.ResourceSpans {
+	msToMicros := int64(time.Millisecond / time.Microsecond)
+	cutoffMicros := t0micros + cutoffMs*msToMicros
+	traceIDBytes := mustDecodeHex(messageID[2:34]) // first 16 bytes
+
+	byProcess := map[string][]viz.Span{}
+	for _, s := range trace.Spans {
+		if s.StartTime <= cutoffMicros {
+			byProcess[s.ProcessID] = append(byProcess[s.ProcessID], s)
+		}
+	}
+
+	var resourceSpans []*tracepb.ResourceSpans
+	for pid, spans := range byProcess {
+		proc := trace.Processes[pid]
+
+		otlpSpans := make([]*tracepb.Span, 0, len(spans))
+		for _, s := range spans {
+			finalEndMicros := s.StartTime + s.Duration
+			open := finalEndMicros > cutoffMicros
+
+			var endTimeNano uint64
+			if !open {
+				endTimeNano = uint64(finalEndMicros) * 1000
+			}
+
+			otlpSpans = append(otlpSpans, &tracepb.Span{
+				TraceId:           traceIDBytes,
+				SpanId:            mustDecodeHex(s.SpanID),
+				ParentSpanId:      parentSpanIDBytes(s.References),
+				Name:              s.OperationName,
+				Kind:              spanKindFromTags(s.Tags),
+				StartTimeUnixNano: uint64(s.StartTime) * 1000,
+				EndTimeUnixNano:   endTimeNano,
+				Attributes:        tagsToAttrs(s.Tags),
+				Events:            eventsUpTo(s.Logs, cutoffMicros),
+				Status:            spanStatus(s.Tags, open),
+			})
+		}
+
+		resourceSpans = append(resourceSpans, &tracepb.ResourceSpans{
+			Resource: &resourcepb.Resource{
+				Attributes: []*commonpb.KeyValue{
+					strAttrOTLP("service.name", proc.ServiceName),
+				},
+			},
+			ScopeSpans: []*tracepb.ScopeSpans{{Spans: otlpSpans}},
+		})
+	}
+
+	return resourceSpans
+}
+
+// eventsUpTo returns only events whose timestamp is <= cutoffMicros.
+func eventsUpTo(logs []viz.SpanLog, cutoffMicros int64) []*tracepb.Span_Event {
+	var events []*tracepb.Span_Event
+	for _, l := range logs {
+		if l.Timestamp > cutoffMicros {
+			break
+		}
+		name := ""
+		attrs := make([]*commonpb.KeyValue, 0, len(l.Fields))
+		for _, f := range l.Fields {
+			if f.Key == "event" {
+				if s, ok := f.Value.(string); ok {
+					name = s
+				}
+				continue
+			}
+			attrs = append(attrs, kvToAttr(f))
+		}
+		events = append(events, &tracepb.Span_Event{
+			TimeUnixNano: uint64(l.Timestamp) * 1000,
+			Name:         name,
+			Attributes:   attrs,
+		})
+	}
+	return events
+}
+
+// replaceMessageID substitutes the hardcoded viz.MessageID with a dynamic one
+// in all TraceID fields, references, tags, and event payloads.
+func replaceMessageID(trace viz.Trace, newID string) viz.Trace {
+	trace.TraceID = newID
+	for i := range trace.Spans {
+		s := &trace.Spans[i]
+		s.TraceID = newID
+		for j := range s.References {
+			s.References[j].TraceID = newID
+		}
+		for j := range s.Tags {
+			if v, ok := s.Tags[j].Value.(string); ok {
+				s.Tags[j].Value = strings.ReplaceAll(v, viz.MessageID, newID)
+			}
+		}
+		for j := range s.Logs {
+			for k := range s.Logs[j].Fields {
+				f := &s.Logs[j].Fields[k]
+				if v, ok := f.Value.(string); ok {
+					f.Value = strings.ReplaceAll(v, viz.MessageID, newID)
+				}
+			}
+		}
+	}
+	return trace
+}
+
+// randomMessageID returns a random 32-byte value as an 0x-prefixed hex string,
+// matching the CCIP messageId format.
+func randomMessageID() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("rand.Read: %v", err))
+	}
+	return "0x" + hex.EncodeToString(b)
+}
+
+func parentSpanIDBytes(refs []viz.Reference) []byte {
+	for _, r := range refs {
+		if r.RefType == "CHILD_OF" {
+			return mustDecodeHex(r.SpanID)
+		}
+	}
+	return nil
+}
+
+func spanKindFromTags(tags []viz.KeyValue) tracepb.Span_SpanKind {
+	for _, t := range tags {
+		if t.Key == "span.kind" {
+			switch t.Value {
+			case "server":
+				return tracepb.Span_SPAN_KIND_SERVER
+			case "client":
+				return tracepb.Span_SPAN_KIND_CLIENT
+			case "internal":
+				return tracepb.Span_SPAN_KIND_INTERNAL
+			case "consumer":
+				return tracepb.Span_SPAN_KIND_CONSUMER
+			case "producer":
+				return tracepb.Span_SPAN_KIND_PRODUCER
+			}
+		}
+	}
+	return tracepb.Span_SPAN_KIND_INTERNAL
+}
+
+func tagsToAttrs(tags []viz.KeyValue) []*commonpb.KeyValue {
+	attrs := make([]*commonpb.KeyValue, 0, len(tags))
+	for _, t := range tags {
+		if t.Key == "span.kind" {
+			continue
+		}
+		attrs = append(attrs, kvToAttr(t))
+	}
+	return attrs
+}
+
+func spanStatus(tags []viz.KeyValue, open bool) *tracepb.Status {
+	if open {
+		return &tracepb.Status{Code: tracepb.Status_STATUS_CODE_UNSET}
+	}
+	for _, t := range tags {
+		if t.Key == "error" {
+			if v, ok := t.Value.(bool); ok && v {
+				return &tracepb.Status{
+					Code:    tracepb.Status_STATUS_CODE_ERROR,
+					Message: errorMessage(tags),
+				}
+			}
+		}
+	}
+	return &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK}
+}
+
+func errorMessage(tags []viz.KeyValue) string {
+	for _, t := range tags {
+		if t.Key == "error.message" {
+			if s, ok := t.Value.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func kvToAttr(kv viz.KeyValue) *commonpb.KeyValue {
+	var val *commonpb.AnyValue
+	switch kv.Type {
+	case "bool":
+		if v, ok := kv.Value.(bool); ok {
+			val = &commonpb.AnyValue{Value: &commonpb.AnyValue_BoolValue{BoolValue: v}}
+		}
+	case "int64":
+		switch v := kv.Value.(type) {
+		case int:
+			val = &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: int64(v)}}
+		case int64:
+			val = &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: v}}
+		case float64:
+			val = &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: int64(v)}}
+		}
+	}
+	if val == nil {
+		s := fmt.Sprintf("%v", kv.Value)
+		val = &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: s}}
+	}
+	return &commonpb.KeyValue{Key: kv.Key, Value: val}
+}
+
+func strAttrOTLP(k, v string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{
+		Key:   k,
+		Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: v}},
+	}
+}
+
+func mustDecodeHex(s string) []byte {
+	s = strings.TrimPrefix(s, "0x")
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(fmt.Sprintf("invalid hex %q: %v", s, err))
+	}
+	return b
+}

--- a/build/devenv/cli/push_trace.go
+++ b/build/devenv/cli/push_trace.go
@@ -42,7 +42,7 @@ var pushMockTraceCmd = &cobra.Command{
 
 func init() {
 	pushMockTraceCmd.Flags().String("endpoint", "localhost:4317", "OTLP gRPC endpoint")
-	pushMockTraceCmd.Flags().Duration("interval", 30*time.Second, "Interval between phase pushes")
+	pushMockTraceCmd.Flags().Duration("interval", 0, "Interval between phase pushes")
 	pushMockTraceCmd.Flags().Bool("dump", false, "Print each OTLP request as JSON before sending")
 	pushMockTraceCmd.Flags().Bool("full", false, "Send all spans in one shot")
 	pushMockTraceCmd.Flags().String("t0", "", "Trace start time in RFC3339 format (default: now)")
@@ -51,6 +51,8 @@ func init() {
 // phaseCutoffsMs are the upper bounds (ms from t0) for each incremental push window.
 // A span is delivered in the first phase where currentCutoff >= span.endMs.
 var phaseCutoffsMs = []int64{0, 3750, 4500, 6500, 9300, 15000}
+
+const DASHBOARD_URL = "http://localhost:3000/d/cfq49j4bs3k00c/ccip-message-flow-viz?&var-message_id=%s&var-trace_id=%s"
 
 func runPushMockTrace(cmd *cobra.Command, _ []string) error {
 	endpoint, _ := cmd.Flags().GetString("endpoint")
@@ -74,9 +76,10 @@ func runPushMockTrace(cmd *cobra.Command, _ []string) error {
 		newT0 = time.Now()
 	}
 
-	fmt.Printf("trace messageId: %s\n", messageID)
-	fmt.Printf("trace traceId:   0x%s\n", messageID[2:34])
-	fmt.Printf("trace t0:        %s\n", newT0.UTC().Format(time.RFC3339))
+	fmt.Printf("messageId: %s\n", messageID)
+	fmt.Printf("traceId:   %s\n", messageID[2:34])
+	fmt.Printf("trace t0:                  %s\n", newT0.UTC().Format(time.RFC3339))
+	fmt.Printf("Dashboard (check in ~30s): %s\n", fmt.Sprintf(DASHBOARD_URL, messageID, messageID[2:34]))
 
 	client := otlptracegrpc.NewClient(
 		otlptracegrpc.WithInsecure(),
@@ -114,23 +117,23 @@ func runPushMockTrace(cmd *cobra.Command, _ []string) error {
 
 		if totalSpans == 0 {
 			fmt.Printf("phase %d/%d — +%dms: nothing completed yet\n", i+1, len(cutoffs), cutoffMs)
-		} else {
-			if dump {
-				fmt.Printf("=== phase %d/%d (+%dms, %d spans) ===\n", i+1, len(cutoffs), cutoffMs, totalSpans)
-				for _, rs := range resourceSpans {
-					b, err := marshaler.Marshal(proto.Message(rs))
-					if err == nil {
-						fmt.Println(bytesFieldsToHex(string(b)))
-					}
-				}
-				fmt.Println()
-			}
-
-			if err := client.UploadTraces(ctx, resourceSpans); err != nil {
-				return fmt.Errorf("phase %d/%d upload failed: %w", i+1, len(cutoffs), err)
-			}
-			fmt.Printf("phase %d/%d pushed — +%dms, %d spans\n", i+1, len(cutoffs), cutoffMs, totalSpans)
+			continue
 		}
+		if dump {
+			fmt.Printf("=== phase %d/%d (+%dms, %d spans) ===\n", i+1, len(cutoffs), cutoffMs, totalSpans)
+			for _, rs := range resourceSpans {
+				b, err := marshaler.Marshal(proto.Message(rs))
+				if err == nil {
+					fmt.Println(bytesFieldsToHex(string(b)))
+				}
+			}
+			fmt.Println()
+		}
+
+		if err := client.UploadTraces(ctx, resourceSpans); err != nil {
+			return fmt.Errorf("phase %d/%d upload failed: %w", i+1, len(cutoffs), err)
+		}
+		fmt.Printf("phase %d/%d pushed — +%dms, %d spans\n", i+1, len(cutoffs), cutoffMs, totalSpans)
 
 		if i < len(cutoffs)-1 {
 			select {
@@ -161,7 +164,7 @@ func buildIncrementalPhaseSpans(trace viz.Trace, t0micros, prevCutoffMs, cutoffM
 		}
 	}
 
-	var resourceSpans []*tracepb.ResourceSpans
+	resourceSpans := make([]*tracepb.ResourceSpans, 0, len(byProcess))
 	for pid, spans := range byProcess {
 		proc := trace.Processes[pid]
 

--- a/build/devenv/cli/push_trace.go
+++ b/build/devenv/cli/push_trace.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -20,28 +22,18 @@ import (
 
 // pushMockTraceCmd pushes a synthetic CCIP message trace to an OTLP collector.
 //
-// Each phase re-sends ALL spans visible at that cutoff, with content trimmed to that point.
-// Span IDs are stable across phases — VictoriaTraces merges successive versions of each span.
-// A new random messageId (= traceId) is generated each run so pushes don't collide.
+// Each span is sent exactly ONCE, in its fully completed final form, when its end time
+// falls within the current phase window (prevCutoff, currentCutoff]. No span is ever
+// re-sent or mutated. A new random traceId (messageId) is generated each run.
 //
-// Span timeline (ms from t0):
+// Span end times (ms from t0) — which phase delivers each span:
 //
-//	root:       0 – 13100   finalization: 0 – 4000
-//	verification: 4000 – 7800
-//	nop-1: 4050–5250  nop-2: 4100–5700  nop-3: 4250–6100
-//	nop-4: 4300–9200  nop-5/aggregator: 4000–6100
-//	token-verifier: 4400–7800
-//	indexer.poll_agg: 6000–6300  indexer.ingest: 6000–8000  indexer.poll_tv: 7100–8000
-//	execution: 8000–13100  executor-1: 8000–15000  executor-2: 13000–13100
+//	phase 3 (+4500ms):  finalization(4000)
+//	phase 4 (+6500ms):  nop-1(5250) nop-2(5700) nop-3/5/aggregator(6100) indexer.poll_agg(6300)
+//	phase 5 (+9300ms):  verification/token-verifier(7800) indexer.poll_tv/ingest(8000) nop-4(9200)
+//	phase 6 (+15000ms): root/execution/executor-2(13100) executor-1(15000)
 //
-// Phases (cutoffs in ms from t0):
-//
-//	  0 ms — root OPEN, finalization OPEN
-//	3750 ms — root OPEN, finalization OPEN (+context log)
-//	4500 ms — root OPEN, finalization CLOSED; verification+all nops+aggregator+tv OPEN
-//	6500 ms — +nop-1/2/3/5/aggregator/indexer.poll_agg CLOSED; nop-4/tv/ingest OPEN
-//	9300 ms — +verification/tv/indexer all CLOSED, nop-4 CLOSED; execution+executor-1 OPEN
-//	15000 ms — everything CLOSED (executor-2 appears, executor-1 closed)
+// Phases 1 (+0ms) and 2 (+3750ms) have no completed spans — interval still fires.
 var pushMockTraceCmd = &cobra.Command{
 	Use:   "push-mock-trace",
 	Short: "Incrementally push a synthetic CCIP trace to OTLP (tests VictoriaTraces dedup/merge)",
@@ -52,11 +44,12 @@ func init() {
 	pushMockTraceCmd.Flags().String("endpoint", "localhost:4317", "OTLP gRPC endpoint")
 	pushMockTraceCmd.Flags().Duration("interval", 30*time.Second, "Interval between phase pushes")
 	pushMockTraceCmd.Flags().Bool("dump", false, "Print each OTLP request as JSON before sending")
-	pushMockTraceCmd.Flags().Bool("full", false, "Send only the final complete trace in one shot")
+	pushMockTraceCmd.Flags().Bool("full", false, "Send all spans in one shot")
+	pushMockTraceCmd.Flags().String("t0", "", "Trace start time in RFC3339 format (default: now)")
 }
 
-// phaseCutoffsMs are the wall-clock offsets (ms from t0) used as snapshot cutoffs.
-// Each push sends all spans that have started by the cutoff, trimmed to that moment.
+// phaseCutoffsMs are the upper bounds (ms from t0) for each incremental push window.
+// A span is delivered in the first phase where currentCutoff >= span.endMs.
 var phaseCutoffsMs = []int64{0, 3750, 4500, 6500, 9300, 15000}
 
 func runPushMockTrace(cmd *cobra.Command, _ []string) error {
@@ -64,11 +57,26 @@ func runPushMockTrace(cmd *cobra.Command, _ []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	dump, _ := cmd.Flags().GetBool("dump")
 	full, _ := cmd.Flags().GetBool("full")
+	t0Str, _ := cmd.Flags().GetString("t0")
 
 	ctx := cmd.Context()
 
 	messageID := randomMessageID()
+
+	var newT0 time.Time
+	if t0Str != "" {
+		parsed, err := time.Parse(time.RFC3339, t0Str)
+		if err != nil {
+			return fmt.Errorf("invalid --t0 %q: %w", t0Str, err)
+		}
+		newT0 = parsed
+	} else {
+		newT0 = time.Now()
+	}
+
 	fmt.Printf("trace messageId: %s\n", messageID)
+	fmt.Printf("trace traceId:   0x%s\n", messageID[2:34])
+	fmt.Printf("trace t0:        %s\n", newT0.UTC().Format(time.RFC3339))
 
 	client := otlptracegrpc.NewClient(
 		otlptracegrpc.WithInsecure(),
@@ -79,8 +87,11 @@ func runPushMockTrace(cmd *cobra.Command, _ []string) error {
 	}
 	defer func() { _ = client.Stop(ctx) }()
 
-	t0micros := viz.MustMicros("2026-06-01T15:48:29Z")
-	trace := replaceMessageID(viz.BuildTrace(), messageID)
+	hardcodedT0 := viz.MustMicros("2026-06-01T15:48:29Z")
+	t0micros := newT0.UnixMicro()
+	delta := t0micros - hardcodedT0
+
+	trace := shiftTraceTime(replaceMessageID(viz.BuildTrace(), messageID), delta)
 
 	cutoffs := phaseCutoffsMs
 	if full {
@@ -88,9 +99,11 @@ func runPushMockTrace(cmd *cobra.Command, _ []string) error {
 	}
 
 	marshaler := protojson.MarshalOptions{Multiline: true}
+	prevCutoffMs := int64(-1)
 
 	for i, cutoffMs := range cutoffs {
-		resourceSpans := buildMutablePhaseSpans(trace, t0micros, cutoffMs, messageID)
+		resourceSpans := buildIncrementalPhaseSpans(trace, t0micros, prevCutoffMs, cutoffMs, messageID)
+		prevCutoffMs = cutoffMs
 
 		totalSpans := 0
 		for _, rs := range resourceSpans {
@@ -99,23 +112,25 @@ func runPushMockTrace(cmd *cobra.Command, _ []string) error {
 			}
 		}
 
-		if dump {
-			fmt.Printf("=== phase %d/%d (+%dms, %d spans) ===\n",
-				i+1, len(cutoffs), cutoffMs, totalSpans)
-			for _, rs := range resourceSpans {
-				b, err := marshaler.Marshal(proto.Message(rs))
-				if err == nil {
-					fmt.Println(string(b))
+		if totalSpans == 0 {
+			fmt.Printf("phase %d/%d — +%dms: nothing completed yet\n", i+1, len(cutoffs), cutoffMs)
+		} else {
+			if dump {
+				fmt.Printf("=== phase %d/%d (+%dms, %d spans) ===\n", i+1, len(cutoffs), cutoffMs, totalSpans)
+				for _, rs := range resourceSpans {
+					b, err := marshaler.Marshal(proto.Message(rs))
+					if err == nil {
+						fmt.Println(bytesFieldsToHex(string(b)))
+					}
 				}
+				fmt.Println()
 			}
-			fmt.Println()
-		}
 
-		if err := client.UploadTraces(ctx, resourceSpans); err != nil {
-			return fmt.Errorf("phase %d/%d upload failed: %w", i+1, len(cutoffs), err)
+			if err := client.UploadTraces(ctx, resourceSpans); err != nil {
+				return fmt.Errorf("phase %d/%d upload failed: %w", i+1, len(cutoffs), err)
+			}
+			fmt.Printf("phase %d/%d pushed — +%dms, %d spans\n", i+1, len(cutoffs), cutoffMs, totalSpans)
 		}
-
-		fmt.Printf("phase %d/%d pushed — +%dms, %d spans\n", i+1, len(cutoffs), cutoffMs, totalSpans)
 
 		if i < len(cutoffs)-1 {
 			select {
@@ -130,17 +145,18 @@ func runPushMockTrace(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// buildMutablePhaseSpans returns all spans that have started by cutoffMs.
-// Each span's end time is 0 (open) if still running at the cutoff, or its final end time if done.
-// Events after the cutoff are excluded.
-func buildMutablePhaseSpans(trace viz.Trace, t0micros, cutoffMs int64, messageID string) []*tracepb.ResourceSpans {
+// buildIncrementalPhaseSpans returns spans whose end time falls in (prevCutoffMs, cutoffMs].
+// Each span is sent in final complete form with all events — it will never be re-sent.
+func buildIncrementalPhaseSpans(trace viz.Trace, t0micros, prevCutoffMs, cutoffMs int64, messageID string) []*tracepb.ResourceSpans {
 	msToMicros := int64(time.Millisecond / time.Microsecond)
-	cutoffMicros := t0micros + cutoffMs*msToMicros
-	traceIDBytes := mustDecodeHex(messageID[2:34]) // first 16 bytes
+	prevEndMicros := t0micros + prevCutoffMs*msToMicros
+	endMicros := t0micros + cutoffMs*msToMicros
+	traceIDBytes := mustDecodeHex(messageID[2:34]) // first 16 bytes of messageId as traceId
 
 	byProcess := map[string][]viz.Span{}
 	for _, s := range trace.Spans {
-		if s.StartTime <= cutoffMicros {
+		spanEndMicros := s.StartTime + s.Duration
+		if spanEndMicros > prevEndMicros && spanEndMicros <= endMicros {
 			byProcess[s.ProcessID] = append(byProcess[s.ProcessID], s)
 		}
 	}
@@ -151,14 +167,6 @@ func buildMutablePhaseSpans(trace viz.Trace, t0micros, cutoffMs int64, messageID
 
 		otlpSpans := make([]*tracepb.Span, 0, len(spans))
 		for _, s := range spans {
-			finalEndMicros := s.StartTime + s.Duration
-			open := finalEndMicros > cutoffMicros
-
-			var endTimeNano uint64
-			if !open {
-				endTimeNano = uint64(finalEndMicros) * 1000
-			}
-
 			otlpSpans = append(otlpSpans, &tracepb.Span{
 				TraceId:           traceIDBytes,
 				SpanId:            mustDecodeHex(s.SpanID),
@@ -166,10 +174,10 @@ func buildMutablePhaseSpans(trace viz.Trace, t0micros, cutoffMs int64, messageID
 				Name:              s.OperationName,
 				Kind:              spanKindFromTags(s.Tags),
 				StartTimeUnixNano: uint64(s.StartTime) * 1000,
-				EndTimeUnixNano:   endTimeNano,
+				EndTimeUnixNano:   uint64(s.StartTime+s.Duration) * 1000,
 				Attributes:        tagsToAttrs(s.Tags),
-				Events:            eventsUpTo(s.Logs, cutoffMicros),
-				Status:            spanStatus(s.Tags, open),
+				Events:            allEvents(s.Logs),
+				Status:            spanStatus(s.Tags, false),
 			})
 		}
 
@@ -186,13 +194,10 @@ func buildMutablePhaseSpans(trace viz.Trace, t0micros, cutoffMs int64, messageID
 	return resourceSpans
 }
 
-// eventsUpTo returns only events whose timestamp is <= cutoffMicros.
-func eventsUpTo(logs []viz.SpanLog, cutoffMicros int64) []*tracepb.Span_Event {
-	var events []*tracepb.Span_Event
+// allEvents converts all span logs to OTLP events with no time filtering.
+func allEvents(logs []viz.SpanLog) []*tracepb.Span_Event {
+	events := make([]*tracepb.Span_Event, 0, len(logs))
 	for _, l := range logs {
-		if l.Timestamp > cutoffMicros {
-			break
-		}
 		name := ""
 		attrs := make([]*commonpb.KeyValue, 0, len(l.Fields))
 		for _, f := range l.Fields {
@@ -211,6 +216,18 @@ func eventsUpTo(logs []viz.SpanLog, cutoffMicros int64) []*tracepb.Span_Event {
 		})
 	}
 	return events
+}
+
+// shiftTraceTime adds deltaUs microseconds to every span StartTime and log Timestamp.
+func shiftTraceTime(trace viz.Trace, deltaUs int64) viz.Trace {
+	for i := range trace.Spans {
+		s := &trace.Spans[i]
+		s.StartTime += deltaUs
+		for j := range s.Logs {
+			s.Logs[j].Timestamp += deltaUs
+		}
+	}
+	return trace
 }
 
 // replaceMessageID substitutes the hardcoded viz.MessageID with a dynamic one
@@ -240,8 +257,7 @@ func replaceMessageID(trace viz.Trace, newID string) viz.Trace {
 	return trace
 }
 
-// randomMessageID returns a random 32-byte value as an 0x-prefixed hex string,
-// matching the CCIP messageId format.
+// randomMessageID returns a random 32-byte value as a 0x-prefixed hex string.
 func randomMessageID() string {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
@@ -347,6 +363,24 @@ func strAttrOTLP(k, v string) *commonpb.KeyValue {
 		Key:   k,
 		Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: v}},
 	}
+}
+
+// bytesFieldsToHex converts base64-encoded byte fields in protojson output to hex strings.
+// Covers traceId, spanId, and parentSpanId.
+var reBase64Bytes = regexp.MustCompile(`"(traceId|spanId|parentSpanId)":\s*"([A-Za-z0-9+/]+=*)"`)
+
+func bytesFieldsToHex(j string) string {
+	return reBase64Bytes.ReplaceAllStringFunc(j, func(match string) string {
+		sub := reBase64Bytes.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		raw, err := base64.StdEncoding.DecodeString(sub[2])
+		if err != nil {
+			return match
+		}
+		return fmt.Sprintf(`"%s":  "0x%s"`, sub[1], hex.EncodeToString(raw))
+	})
 }
 
 func mustDecodeHex(s string) []byte {

--- a/build/devenv/cli/viz/trace.go
+++ b/build/devenv/cli/viz/trace.go
@@ -1,0 +1,947 @@
+// Package viz provides synthetic CCIP message trace data for local dev and testing.
+// The trace represents a complete CCIP message lifecycle:
+// finalization → committee verification (quorum) → aggregation → token verification → indexing → execution.
+package viz
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	MessageID = "0x1fedb7ff3a17716f4f3beb2c8e2f3558a76fba88f69fc5f9de5578f5f434a1f2"
+)
+
+type Trace struct {
+	TraceID   string             `json:"traceID"`
+	Spans     []Span             `json:"spans"`
+	Processes map[string]Process `json:"processes"`
+	Warnings  any                `json:"warnings"`
+}
+
+type Span struct {
+	TraceID       string      `json:"traceID"`
+	SpanID        string      `json:"spanID"`
+	OperationName string      `json:"operationName"`
+	References    []Reference `json:"references"`
+	StartTime     int64       `json:"startTime"`
+	Duration      int64       `json:"duration"`
+	ProcessID     string      `json:"processID"`
+	Warnings      []string    `json:"warnings,omitempty"`
+	Tags          []KeyValue  `json:"tags"`
+	Logs          []SpanLog   `json:"logs"`
+}
+
+type Reference struct {
+	RefType string `json:"refType"`
+	TraceID string `json:"traceID"`
+	SpanID  string `json:"spanID"`
+}
+
+type Process struct {
+	ServiceName string     `json:"serviceName"`
+	Tags        []KeyValue `json:"tags"`
+}
+
+type SpanLog struct {
+	Timestamp int64      `json:"timestamp"`
+	Fields    []KeyValue `json:"fields"`
+}
+
+type KeyValue struct {
+	Key   string `json:"key"`
+	Type  string `json:"type"`
+	Value any    `json:"value"`
+}
+
+type CCIPMessageSent struct {
+	Data                any       `json:"data"`
+	Sender              string    `json:"sender"`
+	Version             int       `json:"version"`
+	DestBlob            any       `json:"destBlob"`
+	FeeToken            string    `json:"feeToken"`
+	Receipts            []Receipt `json:"receipts"`
+	Receiver            string    `json:"receiver"`
+	MessageID           string    `json:"messageId"`
+	TokenAmounts        []any     `json:"tokenAmounts"`
+	FinalityDepth       int       `json:"finalityDepth"`
+	OnRampAddress       string    `json:"onRampAddress"`
+	EncodedMessage      string    `json:"encodedMessage"`
+	OffRampAddress      string    `json:"offRampAddress"`
+	SequenceNumber      int       `json:"sequenceNumber"`
+	DestChainSelector   string    `json:"destChainSelector"`
+	ExecutionGasLimit   int       `json:"executionGasLimit"`
+	CCVAndExecutorHash  string    `json:"ccvAndExecutorHash"`
+	CCIPReceiveGasLimit int       `json:"ccipReceiveGasLimit"`
+	SourceChainSelector string    `json:"sourceChainSelector"`
+}
+
+type Receipt struct {
+	Issuer            string `json:"issuer"`
+	ExtraArgs         string `json:"extraArgs"`
+	DestGasLimit      int    `json:"destGasLimit"`
+	FeeTokenAmount    string `json:"feeTokenAmount"`
+	DestBytesOverhead int    `json:"destBytesOverhead"`
+}
+
+type ExecutionStateChanged struct {
+	State               int    `json:"state"`
+	MessageID           string `json:"messageId"`
+	ReturnData          string `json:"returnData"`
+	MessageNumber       int    `json:"messageNumber"`
+	SourceChainSelector string `json:"sourceChainSelector"`
+}
+
+func BuildTrace() Trace {
+	t0 := MustMicros("2026-06-01T15:48:29Z")
+
+	msg := CCIPMessageSentData()
+	stateChanged := ExecutionStateChangedData()
+
+	return Trace{
+		TraceID: MessageID,
+		Spans: []Span{
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000001",
+				OperationName: "ccip.message",
+				References:    []Reference{},
+				StartTime:     t0,
+				Duration:      Millis(13100),
+				ProcessID:     "p1",
+				Warnings: []string{
+					"mock trace",
+					"hardcoded CCIP trace",
+					"contains synthetic warnings and errors for UI/testing",
+					"committee-verifier/nop-4 span ends after its parent verification span",
+					"executor-1 span ends after parent execution span",
+				},
+				Tags: []KeyValue{
+					StrTag("span.kind", "server"),
+					StrTag("service.version", "mock-ccip-jaeger-v1"),
+					StrTag("ccip.message_id", MessageID),
+					IntTag("ccip.sequence_number", msg.SequenceNumber),
+					StrTag("ccip.source_chain_selector", msg.SourceChainSelector),
+					StrTag("ccip.dest_chain_selector", msg.DestChainSelector),
+					StrTag("ccip.sender", msg.Sender),
+					StrTag("ccip.receiver", msg.Receiver),
+					StrTag("ccip.on_ramp", msg.OnRampAddress),
+					StrTag("ccip.off_ramp", msg.OffRampAddress),
+					StrTag("ccip.fee_token", msg.FeeToken),
+					IntTag("ccip.receipts_count", len(msg.Receipts)),
+					IntTag("ccip.execution_gas_limit", msg.ExecutionGasLimit),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0, []KeyValue{
+						StrTag("event", "trace.started"),
+						StrTag("message", "CCIP message lifecycle started"),
+					}),
+					SpanLogEntry(t0, []KeyValue{
+						StrTag("event", "CCIPMessageSent"),
+						StrTag("payload", MustJSONString(msg)),
+					}),
+					SpanLogEntry(t0+Millis(13100), []KeyValue{
+						StrTag("event", "trace.completed"),
+						StrTag("message", "CCIP message lifecycle completed"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000002",
+				OperationName: "ccip.finalization",
+				References:    ChildOf("0000000000000001"),
+				StartTime:     t0,
+				Duration:      Seconds(4),
+				ProcessID:     "p2",
+				Warnings: []string{
+					"finalityDepth is 0; finalization span is synthetic",
+				},
+				Tags: []KeyValue{
+					StrTag("span.kind", "internal"),
+					StrTag("phase", "finalization"),
+					StrTag("ccip.message_id", MessageID),
+					IntTag("ccip.finality_depth", msg.FinalityDepth),
+					StrTag("blockchain.source_chain_selector", msg.SourceChainSelector),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0, []KeyValue{
+						StrTag("event", "finalization.started"),
+						StrTag("message", "Waiting for source-chain finality"),
+					}),
+					SpanLogEntry(t0+Seconds(1), []KeyValue{
+						StrTag("event", "context"),
+						StrTag("source_chain_selector", msg.SourceChainSelector),
+						IntTag("sequence_number", msg.SequenceNumber),
+						IntTag("finality_depth", msg.FinalityDepth),
+					}),
+					SpanLogEntry(t0+Seconds(4), []KeyValue{
+						StrTag("event", "finalization.completed"),
+						StrTag("message", "Message considered finalized for mock trace"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000003",
+				OperationName: "ccip.verification",
+				References:    ChildOf("0000000000000001"),
+				StartTime:     t0 + Seconds(4),
+				Duration:      Millis(3800),
+				ProcessID:     "p1",
+				Warnings: []string{
+					"committee-verifier/nop-5 did not submit",
+					"committee-verifier/nop-4 submitted an error after quorum was reached",
+					"child span committee-verifier/nop-4 ends after parent verification span",
+				},
+				Tags: []KeyValue{
+					StrTag("span.kind", "internal"),
+					StrTag("phase", "verification"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("verification.status", "success"),
+					StrTag("verification.quorum.status", "reached"),
+					IntTag("verification.quorum.required", 3),
+					IntTag("verification.committee.total", 5),
+					IntTag("verification.committee.successful", 3),
+					IntTag("verification.committee.failed", 1),
+					IntTag("verification.committee.missing", 1),
+					StrTag("verification.quorum_reached_by", "nop-1,nop-2,nop-3"),
+					StrTag("verification.missing_nops", "nop-5"),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Seconds(4), []KeyValue{
+						StrTag("event", "verification.started"),
+						StrTag("message", "Starting message verification"),
+					}),
+					SpanLogEntry(t0+Millis(6100), []KeyValue{
+						StrTag("event", "committee.quorum_reached"),
+						StrTag("message", "Committee quorum reached after 3 successful submissions"),
+						IntTag("successful_submissions", 3),
+						IntTag("required_submissions", 3),
+						StrTag("nodes", "nop-1,nop-2,nop-3"),
+					}),
+					SpanLogEntry(t0+Millis(6100), []KeyValue{
+						StrTag("event", "aggregator.report_pushed"),
+						StrTag("message", "Aggregator pushed merkle root report after quorum"),
+					}),
+					SpanLogEntry(t0+Millis(7800), []KeyValue{
+						StrTag("event", "verification.completed"),
+						StrTag("message", "Verification completed; token verifier pushed result to storage"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000011",
+				OperationName: "committee-verifier.verify/nop-1",
+				References:    ChildOf("0000000000000003"),
+				StartTime:     t0 + Millis(4050),
+				Duration:      Millis(1200),
+				ProcessID:     "p3",
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "verification"),
+					StrTag("verifier.type", "committee-verifier"),
+					StrTag("verifier.node_id", "nop-1"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("source_chain.fetch.status", "success"),
+					StrTag("verification.checks.status", "success"),
+					StrTag("signature.status", "signed"),
+					StrTag("aggregator.push.status", "success"),
+					BoolTag("verification.contributed_to_quorum", true),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(4050), []KeyValue{
+						StrTag("event", "committee_verifier.started"),
+						StrTag("node_id", "nop-1"),
+					}),
+					SpanLogEntry(t0+Millis(4300), []KeyValue{
+						StrTag("event", "source_chain.data_fetched"),
+						StrTag("node_id", "nop-1"),
+						StrTag("source_chain_selector", msg.SourceChainSelector),
+					}),
+					SpanLogEntry(t0+Millis(4700), []KeyValue{
+						StrTag("event", "message.checked"),
+						StrTag("node_id", "nop-1"),
+						StrTag("checks.status", "success"),
+					}),
+					SpanLogEntry(t0+Millis(4850), []KeyValue{
+						StrTag("event", "message.signed"),
+						StrTag("node_id", "nop-1"),
+						StrTag("signature", "0xnop1_signature_mock"),
+					}),
+					SpanLogEntry(t0+Millis(5250), []KeyValue{
+						StrTag("event", "aggregator.pushed"),
+						StrTag("node_id", "nop-1"),
+						StrTag("push.status", "accepted"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000012",
+				OperationName: "committee-verifier.verify/nop-2",
+				References:    ChildOf("0000000000000003"),
+				StartTime:     t0 + Millis(4100),
+				Duration:      Millis(1600),
+				ProcessID:     "p3",
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "verification"),
+					StrTag("verifier.type", "committee-verifier"),
+					StrTag("verifier.node_id", "nop-2"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("source_chain.fetch.status", "success"),
+					StrTag("verification.checks.status", "success"),
+					StrTag("signature.status", "signed"),
+					StrTag("aggregator.push.status", "success"),
+					BoolTag("verification.contributed_to_quorum", true),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(4100), []KeyValue{
+						StrTag("event", "committee_verifier.started"),
+						StrTag("node_id", "nop-2"),
+					}),
+					SpanLogEntry(t0+Millis(4600), []KeyValue{
+						StrTag("event", "source_chain.data_fetched"),
+						StrTag("node_id", "nop-2"),
+						StrTag("source_chain_selector", msg.SourceChainSelector),
+					}),
+					SpanLogEntry(t0+Millis(5100), []KeyValue{
+						StrTag("event", "message.checked"),
+						StrTag("node_id", "nop-2"),
+						StrTag("checks.status", "success"),
+					}),
+					SpanLogEntry(t0+Millis(5300), []KeyValue{
+						StrTag("event", "message.signed"),
+						StrTag("node_id", "nop-2"),
+						StrTag("signature", "0xnop2_signature_mock"),
+					}),
+					SpanLogEntry(t0+Millis(5700), []KeyValue{
+						StrTag("event", "aggregator.pushed"),
+						StrTag("node_id", "nop-2"),
+						StrTag("push.status", "accepted"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000013",
+				OperationName: "committee-verifier.verify/nop-3",
+				References:    ChildOf("0000000000000003"),
+				StartTime:     t0 + Millis(4250),
+				Duration:      Millis(1850),
+				ProcessID:     "p3",
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "verification"),
+					StrTag("verifier.type", "committee-verifier"),
+					StrTag("verifier.node_id", "nop-3"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("source_chain.fetch.status", "success"),
+					StrTag("verification.checks.status", "success"),
+					StrTag("signature.status", "signed"),
+					StrTag("aggregator.push.status", "success"),
+					BoolTag("verification.quorum_trigger", true),
+					BoolTag("verification.contributed_to_quorum", true),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(4250), []KeyValue{
+						StrTag("event", "committee_verifier.started"),
+						StrTag("node_id", "nop-3"),
+					}),
+					SpanLogEntry(t0+Millis(5000), []KeyValue{
+						StrTag("event", "source_chain.data_fetched"),
+						StrTag("node_id", "nop-3"),
+						StrTag("source_chain_selector", msg.SourceChainSelector),
+					}),
+					SpanLogEntry(t0+Millis(5450), []KeyValue{
+						StrTag("event", "message.checked"),
+						StrTag("node_id", "nop-3"),
+						StrTag("checks.status", "success"),
+					}),
+					SpanLogEntry(t0+Millis(5800), []KeyValue{
+						StrTag("event", "message.signed"),
+						StrTag("node_id", "nop-3"),
+						StrTag("signature", "0xnop3_signature_mock"),
+					}),
+					SpanLogEntry(t0+Millis(6100), []KeyValue{
+						StrTag("event", "aggregator.pushed"),
+						StrTag("node_id", "nop-3"),
+						StrTag("push.status", "accepted"),
+					}),
+					SpanLogEntry(t0+Millis(6100), []KeyValue{
+						StrTag("event", "committee.quorum_reached"),
+						StrTag("node_id", "nop-3"),
+						IntTag("successful_submissions", 3),
+						IntTag("required_submissions", 3),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000014",
+				OperationName: "committee-verifier.verify/nop-4",
+				References:    ChildOf("0000000000000003"),
+				StartTime:     t0 + Millis(4300),
+				Duration:      Millis(4900),
+				ProcessID:     "p3",
+				Warnings: []string{
+					"submitted error after committee quorum was already reached",
+					"span ends after parent verification span",
+				},
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "verification"),
+					StrTag("verifier.type", "committee-verifier"),
+					StrTag("verifier.node_id", "nop-4"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("source_chain.fetch.status", "success"),
+					StrTag("verification.checks.status", "failed"),
+					StrTag("aggregator.push.status", "error"),
+					BoolTag("verification.after_quorum", true),
+					BoolTag("verification.contributed_to_quorum", false),
+					BoolTag("error", true),
+					StrTag("error.kind", "CommitteeVerifierError"),
+					StrTag("error.message", "Invalid source-chain data proof"),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(4300), []KeyValue{
+						StrTag("event", "committee_verifier.started"),
+						StrTag("node_id", "nop-4"),
+					}),
+					SpanLogEntry(t0+Millis(5400), []KeyValue{
+						StrTag("event", "source_chain.data_fetched"),
+						StrTag("node_id", "nop-4"),
+						StrTag("source_chain_selector", msg.SourceChainSelector),
+					}),
+					SpanLogEntry(t0+Millis(8700), []KeyValue{
+						StrTag("event", "verification.error"),
+						StrTag("node_id", "nop-4"),
+						StrTag("message", "Invalid source-chain data proof"),
+					}),
+					SpanLogEntry(t0+Millis(9200), []KeyValue{
+						StrTag("event", "aggregator.pushed"),
+						StrTag("node_id", "nop-4"),
+						StrTag("push.status", "rejected"),
+						StrTag("message", "Rejected after quorum had already been reached"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000015",
+				OperationName: "committee-verifier.verify/nop-5",
+				References:    ChildOf("0000000000000003"),
+				StartTime:     t0 + Millis(4000),
+				Duration:      Millis(2100),
+				ProcessID:     "p3",
+				Warnings: []string{
+					"synthetic placeholder span for missing committee submission",
+					"nop-5 did not submit anything",
+				},
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "verification"),
+					StrTag("verifier.type", "committee-verifier"),
+					StrTag("verifier.node_id", "nop-5"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("submission.status", "missing"),
+					BoolTag("verification.contributed_to_quorum", false),
+					BoolTag("error", true),
+					StrTag("error.kind", "CommitteeVerifierMissingSubmission"),
+					StrTag("error.message", "Committee verifier did not submit before verification completed"),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(6100), []KeyValue{
+						StrTag("event", "committee_verifier.missing_submission"),
+						StrTag("node_id", "nop-5"),
+						StrTag("message", "No submission observed before verification finished"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000021",
+				OperationName: "token-verifier.usdc.verify/nop-tv",
+				References:    ChildOf("0000000000000003"),
+				StartTime:     t0 + Millis(4400),
+				Duration:      Millis(3400),
+				ProcessID:     "p5",
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "verification"),
+					StrTag("verifier.type", "token-verifier"),
+					StrTag("verifier.node_id", "nop-tv"),
+					StrTag("token.symbol", "USDC"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("source_chain.fetch.status", "success"),
+					StrTag("usdc.api.poll.status", "success"),
+					StrTag("storage.push.status", "success"),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(4400), []KeyValue{
+						StrTag("event", "token_verifier.started"),
+						StrTag("node_id", "nop-tv"),
+						StrTag("token", "USDC"),
+					}),
+					SpanLogEntry(t0+Millis(4700), []KeyValue{
+						StrTag("event", "message.read"),
+						StrTag("node_id", "nop-tv"),
+						StrTag("message_id", MessageID),
+					}),
+					SpanLogEntry(t0+Millis(5400), []KeyValue{
+						StrTag("event", "source_chain.data_fetched"),
+						StrTag("node_id", "nop-tv"),
+						StrTag("source_chain_selector", msg.SourceChainSelector),
+					}),
+					SpanLogEntry(t0+Millis(6200), []KeyValue{
+						StrTag("event", "usdc.api.poll.started"),
+						StrTag("node_id", "nop-tv"),
+					}),
+					SpanLogEntry(t0+Millis(7600), []KeyValue{
+						StrTag("event", "usdc.api.poll.completed"),
+						StrTag("node_id", "nop-tv"),
+						StrTag("usdc.status", "confirmed"),
+					}),
+					SpanLogEntry(t0+Millis(7700), []KeyValue{
+						StrTag("event", "token_verifier.pushing_to_storage"),
+						StrTag("node_id", "nop-tv"),
+						StrTag("message", "Pushing USDC attestation result to token verifier storage"),
+					}),
+					SpanLogEntry(t0+Millis(7800), []KeyValue{
+						StrTag("event", "token_verifier.pushed_to_storage"),
+						StrTag("node_id", "nop-tv"),
+						StrTag("message", "USDC attestation result stored"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000022",
+				OperationName: "aggregator.collect",
+				References:    ChildOf("0000000000000003"),
+				StartTime:     t0 + Millis(4000),
+				Duration:      Millis(2100),
+				ProcessID:     "p6",
+				Tags: []KeyValue{
+					StrTag("span.kind", "server"),
+					StrTag("phase", "verification"),
+					StrTag("ccip.message_id", MessageID),
+					IntTag("aggregator.quorum.required", 3),
+					IntTag("aggregator.submissions.received", 3),
+					StrTag("aggregator.quorum.status", "reached"),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(4000), []KeyValue{
+						StrTag("event", "aggregator.started"),
+						StrTag("message", "Aggregator listening for committee submissions"),
+					}),
+					SpanLogEntry(t0+Millis(5250), []KeyValue{
+						StrTag("event", "aggregator.submission_received"),
+						StrTag("node_id", "nop-1"),
+						IntTag("submissions_so_far", 1),
+					}),
+					SpanLogEntry(t0+Millis(5700), []KeyValue{
+						StrTag("event", "aggregator.submission_received"),
+						StrTag("node_id", "nop-2"),
+						IntTag("submissions_so_far", 2),
+					}),
+					SpanLogEntry(t0+Millis(6100), []KeyValue{
+						StrTag("event", "aggregator.submission_received"),
+						StrTag("node_id", "nop-3"),
+						IntTag("submissions_so_far", 3),
+					}),
+					SpanLogEntry(t0+Millis(6100), []KeyValue{
+						StrTag("event", "aggregator.quorum_reached"),
+						StrTag("message", "Quorum reached; building merkle root report"),
+						IntTag("successful_submissions", 3),
+						IntTag("required_submissions", 3),
+					}),
+					SpanLogEntry(t0+Millis(6100), []KeyValue{
+						StrTag("event", "aggregator.report_pushed"),
+						StrTag("message", "Merkle root report pushed on-chain"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000041",
+				OperationName: "indexer.poll_aggregator",
+				References:    ChildOf("0000000000000001"),
+				StartTime:     t0 + Millis(6000),
+				Duration:      Millis(300),
+				ProcessID:     "p7",
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "indexing"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("poll.target", "aggregator"),
+					StrTag("poll.result", "report_found"),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(6000), []KeyValue{
+						StrTag("event", "indexer.poll_started"),
+						StrTag("target", "aggregator"),
+					}),
+					SpanLogEntry(t0+Millis(6300), []KeyValue{
+						StrTag("event", "indexer.report_discovered"),
+						StrTag("target", "aggregator"),
+						StrTag("message", "Aggregator merkle root report found in DB"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000042",
+				OperationName: "indexer.poll_token_verifier",
+				References:    ChildOf("0000000000000001"),
+				StartTime:     t0 + Millis(7100),
+				Duration:      Millis(900),
+				ProcessID:     "p7",
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "indexing"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("poll.target", "token-verifier"),
+					StrTag("poll.result", "result_found"),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(7100), []KeyValue{
+						StrTag("event", "indexer.poll_started"),
+						StrTag("target", "token-verifier"),
+					}),
+					SpanLogEntry(t0+Millis(8000), []KeyValue{
+						StrTag("event", "indexer.result_discovered"),
+						StrTag("target", "token-verifier"),
+						StrTag("message", "Token verifier USDC attestation result found in storage"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000043",
+				OperationName: "indexer.ingest",
+				References:    ChildOf("0000000000000001"),
+				StartTime:     t0 + Millis(6000),
+				Duration:      Millis(2000),
+				ProcessID:     "p7",
+				Tags: []KeyValue{
+					StrTag("span.kind", "internal"),
+					StrTag("phase", "indexing"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("ingest.status", "complete"),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(6000), []KeyValue{
+						StrTag("event", "ingest.started"),
+						StrTag("message", "Ingestion started; polling aggregator and token verifier"),
+					}),
+					SpanLogEntry(t0+Millis(6300), []KeyValue{
+						StrTag("event", "ingest.aggregator_report_received"),
+						StrTag("message", "Aggregator merkle root report ingested"),
+					}),
+					SpanLogEntry(t0+Millis(8000), []KeyValue{
+						StrTag("event", "ingest.completed"),
+						StrTag("message", "Token verifier result ingested; signalling execution"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000004",
+				OperationName: "ccip.execution",
+				References:    ChildOf("0000000000000001"),
+				StartTime:     t0 + Millis(8000),
+				Duration:      Millis(5100),
+				ProcessID:     "p4",
+				Warnings: []string{
+					"executor-1 failed with AlreadyExecuted after executor-2 succeeded",
+					"executor-1 span ends after parent execution span",
+				},
+				Tags: []KeyValue{
+					StrTag("span.kind", "consumer"),
+					StrTag("phase", "execution"),
+					StrTag("ccip.message_id", MessageID),
+					IntTag("ccip.message_number", stateChanged.MessageNumber),
+					StrTag("execution.status", "success"),
+					StrTag("execution.successful_executor", "executor-2"),
+					StrTag("execution.failed_executor", "executor-1"),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(8000), []KeyValue{
+						StrTag("event", "execution.started"),
+						StrTag("message", "Execution started after indexer ingestion completed"),
+					}),
+					SpanLogEntry(t0+Millis(13000), []KeyValue{
+						StrTag("event", "executor_2.started"),
+						StrTag("executor", "executor-2"),
+						StrTag("message", "Protocol delay elapsed; second executor started"),
+					}),
+					SpanLogEntry(t0+Millis(13100), []KeyValue{
+						StrTag("event", "ExecutionStateChanged"),
+						StrTag("payload", MustJSONString(stateChanged)),
+					}),
+					SpanLogEntry(t0+Millis(13100), []KeyValue{
+						StrTag("event", "execution.completed"),
+						StrTag("message", "Execution completed; executor-2 succeeded"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000031",
+				OperationName: "executor.execute",
+				References:    ChildOf("0000000000000004"),
+				StartTime:     t0 + Millis(8000),
+				Duration:      Seconds(7),
+				ProcessID:     "p4",
+				Warnings: []string{
+					"executor lost race; message was already executed by executor-2",
+				},
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "execution"),
+					StrTag("executor.id", "executor-1"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("execution.result", "AlreadyExecuted"),
+					BoolTag("error", true),
+					StrTag("error.kind", "AlreadyExecuted"),
+					StrTag("error.message", "Message was already executed by another executor"),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(8000), []KeyValue{
+						StrTag("event", "executor.started"),
+						StrTag("executor", "executor-1"),
+					}),
+					SpanLogEntry(t0+Millis(10900), []KeyValue{
+						StrTag("event", "destination_chain.tx_submitted"),
+						StrTag("executor", "executor-1"),
+						StrTag("tx_hash", "0xexecutor1_mock_tx"),
+					}),
+					SpanLogEntry(t0+Millis(15000), []KeyValue{
+						StrTag("event", "executor.failed"),
+						StrTag("executor", "executor-1"),
+						StrTag("error", "AlreadyExecuted"),
+						StrTag("message", "Message was already executed by executor-2"),
+					}),
+				},
+			},
+			{
+				TraceID:       MessageID,
+				SpanID:        "0000000000000032",
+				OperationName: "executor.execute",
+				References:    ChildOf("0000000000000004"),
+				StartTime:     t0 + Millis(13000),
+				Duration:      Millis(100),
+				ProcessID:     "p4",
+				Tags: []KeyValue{
+					StrTag("span.kind", "client"),
+					StrTag("phase", "execution"),
+					StrTag("executor.id", "executor-2"),
+					StrTag("ccip.message_id", MessageID),
+					StrTag("execution.result", "success"),
+					IntTag("ccip.execution_state", stateChanged.State),
+					StrTag("ccip.return_data", stateChanged.ReturnData),
+					BoolTag("error", false),
+				},
+				Logs: []SpanLog{
+					SpanLogEntry(t0+Millis(13000), []KeyValue{
+						StrTag("event", "executor.started"),
+						StrTag("executor", "executor-2"),
+						StrTag("message", "Executor started after protocol delay"),
+					}),
+					SpanLogEntry(t0+Millis(13050), []KeyValue{
+						StrTag("event", "destination_chain.tx_submitted"),
+						StrTag("executor", "executor-2"),
+						StrTag("tx_hash", "0xexecutor2_mock_tx"),
+					}),
+					SpanLogEntry(t0+Millis(13100), []KeyValue{
+						StrTag("event", "executor.succeeded"),
+						StrTag("executor", "executor-2"),
+						StrTag("message", "Message executed successfully"),
+					}),
+					SpanLogEntry(t0+Millis(13100), []KeyValue{
+						StrTag("event", "ExecutionStateChanged"),
+						StrTag("payload", MustJSONString(stateChanged)),
+					}),
+				},
+			},
+		},
+		Processes: map[string]Process{
+			"p1": {
+				ServiceName: "ccip2.0",
+				Tags: []KeyValue{
+					StrTag("component", "ccip-lifecycle-coordinator"),
+					StrTag("deployment.environment", "local"),
+				},
+			},
+			"p2": {
+				ServiceName: "ethereum-testnet",
+				Tags: []KeyValue{
+					StrTag("component", "source-chain-finalizer"),
+					StrTag("chain.selector", msg.SourceChainSelector),
+				},
+			},
+			"p3": {
+				ServiceName: "committee-verifier",
+				Tags: []KeyValue{
+					StrTag("component", "committee-verifier"),
+					StrTag("committee.nodes", "nop-1,nop-2,nop-3,nop-4,nop-5"),
+				},
+			},
+			"p5": {
+				ServiceName: "token-verifier",
+				Tags: []KeyValue{
+					StrTag("component", "token-verifier"),
+					StrTag("node.id", "nop-tv"),
+				},
+			},
+			"p6": {
+				ServiceName: "aggregator",
+				Tags: []KeyValue{
+					StrTag("component", "committee-aggregator"),
+				},
+			},
+			"p7": {
+				ServiceName: "indexer",
+				Tags: []KeyValue{
+					StrTag("component", "message-indexer"),
+				},
+			},
+			"p4": {
+				ServiceName: "base-testnet",
+				Tags: []KeyValue{
+					StrTag("component", "destination-executor"),
+					StrTag("executors", "executor-1,executor-2"),
+					StrTag("chain.selector", msg.DestChainSelector),
+				},
+			},
+		},
+		Warnings: nil,
+	}
+}
+
+func CCIPMessageSentData() CCIPMessageSent {
+	return CCIPMessageSent{
+		Data:     nil,
+		Sender:   "0x4b431813bcf797bf9bf93890656618ac80a1d5d2",
+		Version:  1,
+		DestBlob: nil,
+		FeeToken: "0x1cd0690ff9a693f5ef2dd976660a8dafc81a109c",
+		Receipts: []Receipt{
+			{
+				Issuer:            "0x2caafd3b4cf606220580c885bd2b448fb93dc03b",
+				ExtraArgs:         "0x",
+				DestGasLimit:      75000,
+				FeeTokenAmount:    "0",
+				DestBytesOverhead: 582,
+			},
+			{
+				Issuer:            "0x6608d995bbde874de5292bfd289643c88d176ed3",
+				ExtraArgs:         "0x",
+				DestGasLimit:      200000,
+				FeeTokenAmount:    "10003901521593420",
+				DestBytesOverhead: 183,
+			},
+			{
+				Issuer:            "0x0aa145a62153190b8f0d3ca00c441e451529f755",
+				ExtraArgs:         "0x",
+				DestGasLimit:      0,
+				FeeTokenAmount:    "100039015215934200",
+				DestBytesOverhead: 0,
+			},
+		},
+		Receiver:       "0x4b431813bcf797bf9bf93890656618ac80a1d5d2",
+		MessageID:      MessageID,
+		TokenAmounts:   []any{},
+		FinalityDepth:  0,
+		OnRampAddress:  "0x0c26ecdac3637d5833cc53663f571df242d36cf5",
+		EncodedMessage: "0x013d6d8f0fa1b00cccf8946d7c5b972a83000000000000001000072c3b000000000000000057f26601394e874c981211a7626034b7130cd6a1b5c61d89ff5e9d15118a7ae3200000000000000000000000000c26ecdac3637d5833cc53663f571df242d36cf514102423a5371944ab99aad7185052f969904c6d65200000000000000000000000004b431813bcf797bf9bf93890656618ac80a1d5d2144b431813bcf797bf9bf93890656618ac80a1d5d2000000000000",
+		OffRampAddress: "0x102423a5371944ab99aad7185052f969904c6d65",
+		SequenceNumber: 16,
+
+		// These exceed JavaScript's safe integer range, so keep them as strings in JSON.
+		DestChainSelector:   "17912061998839310000",
+		SourceChainSelector: "4426351306075016000",
+
+		ExecutionGasLimit:   470075,
+		CCVAndExecutorHash:  "0x57f26601394e874c981211a7626034b7130cd6a1b5c61d89ff5e9d15118a7ae3",
+		CCIPReceiveGasLimit: 0,
+	}
+}
+
+func ExecutionStateChangedData() ExecutionStateChanged {
+	return ExecutionStateChanged{
+		State:               2,
+		MessageID:           MessageID,
+		ReturnData:          "0x",
+		MessageNumber:       16,
+		SourceChainSelector: "4426351306075016000",
+	}
+}
+
+func ChildOf(parentSpanID string) []Reference {
+	return []Reference{
+		{
+			RefType: "CHILD_OF",
+			TraceID: MessageID,
+			SpanID:  parentSpanID,
+		},
+	}
+}
+
+func SpanLogEntry(timestamp int64, fields []KeyValue) SpanLog {
+	return SpanLog{
+		Timestamp: timestamp,
+		Fields:    fields,
+	}
+}
+
+func StrTag(key, value string) KeyValue {
+	return KeyValue{Key: key, Type: "string", Value: value}
+}
+
+func IntTag(key string, value int) KeyValue {
+	return KeyValue{Key: key, Type: "int64", Value: value}
+}
+
+func BoolTag(key string, value bool) KeyValue {
+	return KeyValue{Key: key, Type: "bool", Value: value}
+}
+
+func MustJSONString(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func MustMicros(ts string) int64 {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		panic(err)
+	}
+	return t.UnixMicro()
+}
+
+func Seconds(n int64) int64 {
+	return n * int64(time.Second/time.Microsecond)
+}
+
+func Millis(n int64) int64 {
+	return n * int64(time.Millisecond/time.Microsecond)
+}

--- a/build/devenv/dashboards/message_trace_viz.json
+++ b/build/devenv/dashboards/message_trace_viz.json
@@ -1,0 +1,109 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 4,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "jaeger",
+        "uid": "victoriatraces"
+      },
+      "description": "${message_id:regex:^0x(.{32}).*$}",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 25,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {},
+      "pluginVersion": "11.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "jaeger",
+            "uid": "victoriatraces"
+          },
+          "query": "$trace_id",
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "type": "traces"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "description": "0x...",
+        "label": "message_id",
+        "name": "message_id",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "definition": "query_result(label_replace(vector(1),\"message_id\",\"${message_id}\",\"__name__\", \".*\"))",
+        "name": "trace_id",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(label_replace(vector(1),\"message_id\",\"${message_id}\",\"__name__\", \".*\"))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/message_id=\"0x(?<value>.{32}).*\"/",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CCIP Message Flow Viz",
+  "uid": "cfq49j4bs3k00c",
+  "version": 1,
+  "weekStart": ""
+}

--- a/build/devenv/go.mod
+++ b/build/devenv/go.mod
@@ -455,7 +455,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.58.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.19.0 // indirect
@@ -468,7 +468,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -491,7 +491,7 @@ require (
 	google.golang.org/api v0.241.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/guregu/null.v4 v4.0.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect


### PR DESCRIPTION
## Summary
This PoC pushes mock traces to otel which pushes to VictoriaTraces
<img width="1488" height="802" alt="SCR-20260624-qnqu" src="https://github.com/user-attachments/assets/ace7db69-7db9-4d36-a18d-2368406d9394" />

## Testing
`ccv obs up`
`ccv push-mock-traces` or `ccv push-mock-traces --interval 30s` to check how it renders in incremental updates
Open the dashboard in the link. Traces will appear in ~30s since push

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
