### PR TITLE
integration/storageaccess: always set aggregator_name in metric

### DIFF
--- a/integration/pkg/constructors/committee_verifier.go
+++ b/integration/pkg/constructors/committee_verifier.go
@@ -183,8 +183,6 @@ func NewVerificationCoordinator(
 		}
 	}
 
-	// Checkpoint manager
-	// TODO: these are secrets, probably shouldn't be in config.
 	fanOutWriter, err := storageaccess.NewFanOutAggregatorWriter(
 		writeTargets,
 		cfg.VerifierID,

--- a/integration/pkg/heartbeatclient/fanout_heartbeat_client.go
+++ b/integration/pkg/heartbeatclient/fanout_heartbeat_client.go
@@ -146,5 +146,5 @@ type aggregatorLabeledMonitoring struct {
 }
 
 func (m aggregatorLabeledMonitoring) Metrics() MetricLabeler {
-	return m.inner.Metrics().With("aggregator", m.label)
+	return m.inner.Metrics().With("aggregator_name", m.label)
 }

--- a/integration/storageaccess/fanout_writer.go
+++ b/integration/storageaccess/fanout_writer.go
@@ -85,13 +85,18 @@ func NewFanOutAggregatorWriter(
 			return nil, fmt.Errorf("failed to create aggregator writer for %q: %w", t.Label, err)
 		}
 
-		observed := NewObservedAggregatorWriter(
+		observed, err := NewObservedAggregatorWriter(
 			NewDefaultResilientStorageWriter(aggWriter, logger.With(lggr, "aggregator", t.Label)),
 			verifierID,
 			t.Label,
 			lggr,
 			monitoring,
 		)
+		if err != nil {
+			// Best-effort close anything created so far before returning.
+			_ = f.Close()
+			return nil, fmt.Errorf("failed to create observed aggregator writer for %q: %w", t.Label, err)
+		}
 
 		f.writers = append(f.writers, namedWriter{label: t.Label, writer: observed})
 		f.closers = append(f.closers, aggWriter)

--- a/integration/storageaccess/observed_storage.go
+++ b/integration/storageaccess/observed_storage.go
@@ -2,6 +2,7 @@ package storageaccess
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
@@ -15,9 +16,8 @@ type observedStorageWriter struct {
 	protocol.CCVNodeDataWriter
 
 	verifierID string
-	// aggregatorLabel, when non-empty, scopes this observer to a single aggregator and is
-	// emitted as the "aggregator" label on metrics/logs. Empty means the observer covers the
-	// aggregate (fan-out-wide) outcome.
+	// aggregatorLabel scopes this observer to a single aggregator and is
+	// emitted as the "aggregator_name" label on metrics/logs.
 	aggregatorLabel string
 	lggr            logger.Logger
 	monitoring      verifier.Monitoring
@@ -46,24 +46,27 @@ func NewObservedAggregatorWriter(
 	aggregatorLabel string,
 	lggr logger.Logger,
 	monitoring verifier.Monitoring,
-) protocol.CCVNodeDataWriter {
+) (protocol.CCVNodeDataWriter, error) {
+	if aggregatorLabel == "" {
+		return nil, errors.New("aggregator label is required")
+	}
+
 	return &observedStorageWriter{
 		CCVNodeDataWriter: delegate,
 		verifierID:        verifierID,
 		aggregatorLabel:   aggregatorLabel,
 		lggr:              logger.With(lggr, "aggregator", aggregatorLabel),
 		monitoring:        monitoring,
-	}
+	}, nil
 }
 
 // metrics returns the metric labeler scoped to this observer's verifier_id and (when set)
 // aggregator label.
 func (o *observedStorageWriter) metrics() verifier.MetricLabeler {
-	m := o.monitoring.Metrics().With("verifier_id", o.verifierID)
-	if o.aggregatorLabel != "" {
-		m = m.With("aggregator", o.aggregatorLabel)
-	}
-	return m
+	return o.monitoring.
+		Metrics().
+		With("verifier_id", o.verifierID).
+		With("aggregator_name", o.aggregatorLabel)
 }
 
 func (o *observedStorageWriter) WriteCCVNodeData(ctx context.Context, ccvDataList []protocol.VerifierNodeResult) ([]protocol.WriteResult, error) {


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Metrics follow up to #1184 .

What the metrics look like now (from devenv):

```js
// default-ha-1 aggregator name
verifier_heartbeat_score{aggregator_name="default-ha-1",chain_name="geth-devnet-2",chain_selector="12922642891491394802",csa_public_key="not-configured",exported_job="unknown_service:verifier",host_name="23681ecc1fab",instance="otel-collector:8889",job="otel-collector",os_description="Alpine Linux 3.23.5 (Linux 23681ecc1fab 6.12.72-linuxkit #1 SMP Wed Feb 25 13:21:17 UTC 2026 aarch64)",os_type="linux",service_name="unknown_service:verifier",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.43.0",verifier_id="default-verifier"}
// default aggregator name
verifier_heartbeat_score{aggregator_name="default",chain_name="geth-devnet-2",chain_selector="12922642891491394802",csa_public_key="not-configured",exported_job="unknown_service:verifier",host_name="23681ecc1fab",instance="otel-collector:8889",job="otel-collector",os_description="Alpine Linux 3.23.5 (Linux 23681ecc1fab 6.12.72-linuxkit #1 SMP Wed Feb 25 13:21:17 UTC 2026 aarch64)",os_type="linux",service_name="unknown_service:verifier",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.43.0",verifier_id="default-verifier"}
// fallback to URL
verifier_heartbeat_score{aggregator_name="default-aggregator:50051",chain_name="geth-devnet-2",chain_selector="12922642891491394802",csa_public_key="not-configured",exported_job="unknown_service:verifier",host_name="23681ecc1fab",instance="otel-collector:8889",job="otel-collector",os_description="Alpine Linux 3.23.5 (Linux 23681ecc1fab 6.12.72-linuxkit #1 SMP Wed Feb 25 13:21:17 UTC 2026 aarch64)",os_type="linux",service_name="unknown_service:verifier",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.43.0",verifier_id="default-verifier"}
```

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

Devenv + local observability stack.

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
