### PR TITLE
chore: indexer grpc label

### DIFF
--- a/indexer/cmd/main.go
+++ b/indexer/cmd/main.go
@@ -183,7 +183,7 @@ func createReadersForVerifier(ctx context.Context, lggr logger.Logger, verifierR
 func createReader(lggr logger.Logger, cfg *config.VerifierConfig, indexerMonitoring common.IndexerMonitoring) (*readers.ResilientReader, error) {
 	switch cfg.Type {
 	case config.ReaderTypeAggregator:
-		return readers.NewAggregatorReader(cfg.Address, lggr, cfg.Since, hmac.ClientConfig{
+		return readers.NewAggregatorReader(cfg.Label(), cfg.Address, lggr, cfg.Since, hmac.ClientConfig{
 			APIKey: cfg.APIKey,
 			Secret: cfg.Secret,
 		}, cfg.InsecureConnection, config.EffectiveMaxResponseBytes(cfg.MaxResponseBytes), indexerMonitoring)
@@ -228,7 +228,7 @@ func createDiscovery(ctx context.Context, lggr logger.Logger, cfg *config.Config
 			persistedSinceValue = int(discCfg.Since)
 		}
 
-		aggregator, err := readers.NewAggregatorReader(discCfg.Address, lggr, int64(persistedSinceValue), hmac.ClientConfig{
+		aggregator, err := readers.NewAggregatorReader(discCfg.Label(), discCfg.Address, lggr, int64(persistedSinceValue), hmac.ClientConfig{
 			APIKey: discCfg.APIKey,
 			Secret: discCfg.Secret,
 		}, discCfg.InsecureConnection, config.EffectiveMaxResponseBytes(discCfg.MaxResponseBytes), monitoring)

--- a/indexer/cmd/replay/main.go
+++ b/indexer/cmd/replay/main.go
@@ -361,7 +361,7 @@ func mustBuildEngine(ctx context.Context, needsDiscoveryReader bool) (*replay.En
 	if needsDiscoveryReader && len(cfg.Discoveries) > 0 {
 		disc := cfg.Discoveries[0]
 		aggFactory = func(since int64) (*readers.ResilientReader, error) {
-			return readers.NewAggregatorReader(disc.Address, lggr, since, hmac.ClientConfig{
+			return readers.NewAggregatorReader(disc.Label(), disc.Address, lggr, since, hmac.ClientConfig{
 				APIKey: disc.APIKey,
 				Secret: disc.Secret,
 			}, disc.InsecureConnection, config.EffectiveMaxResponseBytes(disc.MaxResponseBytes), indexerMonitoring)
@@ -426,7 +426,7 @@ func createVerifierReader(ctx context.Context, lggr logger.Logger, vc *config.Ve
 
 	switch vc.Type {
 	case config.ReaderTypeAggregator:
-		resilientReader, err = readers.NewAggregatorReader(vc.Address, lggr, vc.Since, hmac.ClientConfig{
+		resilientReader, err = readers.NewAggregatorReader(vc.Label(), vc.Address, lggr, vc.Since, hmac.ClientConfig{
 			APIKey: vc.APIKey,
 			Secret: vc.Secret,
 		}, vc.InsecureConnection, config.EffectiveMaxResponseBytes(vc.MaxResponseBytes), mon)

--- a/indexer/pkg/common/metrics.go
+++ b/indexer/pkg/common/metrics.go
@@ -46,8 +46,8 @@ type IndexerMetricLabeler interface {
 	RecordCircuitBreakerStatus(ctx context.Context, status bool)
 	// RecordGRPCPayloadSize records the gRPC wire-level payload size in bytes.
 	// direction is "recv" for received payloads, "send" for sent payloads.
-	RecordGRPCPayloadSize(ctx context.Context, method, direction string, sizeBytes int)
+	RecordGRPCPayloadSize(ctx context.Context, target, method, direction string, sizeBytes int)
 	// IncrementGRPCErrors increments the counter for gRPC errors by status code.
 	// code should be the gRPC status code string (e.g. "ResourceExhausted", "Internal").
-	IncrementGRPCErrors(ctx context.Context, code, method string)
+	IncrementGRPCErrors(ctx context.Context, target, code, method string)
 }

--- a/indexer/pkg/common/metrics.go
+++ b/indexer/pkg/common/metrics.go
@@ -45,9 +45,11 @@ type IndexerMetricLabeler interface {
 	// RecordCircuitBreakerStatus records the status of the circuit breaker.
 	RecordCircuitBreakerStatus(ctx context.Context, status bool)
 	// RecordGRPCPayloadSize records the gRPC wire-level payload size in bytes.
+	// target identifies the remote gRPC server (DiscoveryConfig.Label() or VerifierConfig.Label()).
 	// direction is "recv" for received payloads, "send" for sent payloads.
 	RecordGRPCPayloadSize(ctx context.Context, target, method, direction string, sizeBytes int)
 	// IncrementGRPCErrors increments the counter for gRPC errors by status code.
+	// target identifies the remote gRPC server (DiscoveryConfig.Label() or VerifierConfig.Label()).
 	// code should be the gRPC status code string (e.g. "ResourceExhausted", "Internal").
 	IncrementGRPCErrors(ctx context.Context, target, code, method string)
 }

--- a/indexer/pkg/config/config.go
+++ b/indexer/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -139,12 +140,22 @@ const (
 // DiscoveryConfig allows you to change the discovery system used by the indexer.
 type DiscoveryConfig struct {
 	AggregatorReaderConfig
+	Name         string `toml:"Name"`
 	PollInterval int    `toml:"PollInterval"`
 	Timeout      int    `toml:"Timeout"`
 	NtpServer    string `toml:"NtpServer"`
 	// MaxResponseBytes is the maximum response size in bytes the client will accept.
 	// 0 uses DefaultMaxResponseBytes (4MB).
 	MaxResponseBytes int `toml:"MaxResponseBytes"`
+}
+
+// Label returns the value used to identify this discovery component in logs and metrics:
+// Name when set, otherwise Address.
+func (d DiscoveryConfig) Label() string {
+	if strings.TrimSpace(d.Name) != "" {
+		return d.Name
+	}
+	return d.Address
 }
 
 type VerifierConfig struct {
@@ -160,6 +171,22 @@ type VerifierConfig struct {
 	MaxResponseBytes int `toml:"MaxResponseBytes"`
 	AggregatorReaderConfig
 	RestReaderConfig
+}
+
+// Label returns the value used to identify this discovery component in logs and metrics:
+// Name when set, otherwise Address.
+func (v VerifierConfig) Label() string {
+	if strings.TrimSpace(v.Name) != "" {
+		return v.Name
+	}
+	switch v.Type {
+	case ReaderTypeAggregator:
+		return v.Address
+	case ReaderTypeRest:
+		return v.BaseURL
+	}
+	// unreachable
+	return ""
 }
 
 // ReaderType is the type of reader to use (aggregator).

--- a/indexer/pkg/config/config.go
+++ b/indexer/pkg/config/config.go
@@ -152,8 +152,8 @@ type DiscoveryConfig struct {
 // Label returns the value used to identify this discovery component in logs and metrics:
 // Name when set, otherwise Address.
 func (d DiscoveryConfig) Label() string {
-	if strings.TrimSpace(d.Name) != "" {
-		return d.Name
+	if name := strings.TrimSpace(d.Name); name != "" {
+		return name
 	}
 	return d.Address
 }
@@ -173,11 +173,11 @@ type VerifierConfig struct {
 	RestReaderConfig
 }
 
-// Label returns the value used to identify this discovery component in logs and metrics:
-// Name when set, otherwise Address.
+// Label returns the value used to identify this verifier component in logs and metrics:
+// Name when set, otherwise Address (aggregator) or BaseURL (rest).
 func (v VerifierConfig) Label() string {
-	if strings.TrimSpace(v.Name) != "" {
-		return v.Name
+	if name := strings.TrimSpace(v.Name); name != "" {
+		return name
 	}
 	switch v.Type {
 	case ReaderTypeAggregator:

--- a/indexer/pkg/monitoring/metrics.go
+++ b/indexer/pkg/monitoring/metrics.go
@@ -282,17 +282,19 @@ func (c *IndexerMetricLabeler) RecordCircuitBreakerStatus(ctx context.Context, s
 	c.im.circuitBreakerStatus.Record(ctx, gaugeValue, metric.WithAttributes(otelLabels...))
 }
 
-func (c *IndexerMetricLabeler) RecordGRPCPayloadSize(ctx context.Context, method, direction string, sizeBytes int) {
+func (c *IndexerMetricLabeler) RecordGRPCPayloadSize(ctx context.Context, target, method, direction string, sizeBytes int) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.im.grpcPayloadSizeBytes.Record(ctx, int64(sizeBytes), metric.WithAttributes([]attribute.KeyValue{
+		attribute.String("target", target),
 		attribute.String("method", method),
 		attribute.String("direction", direction),
 	}...), metric.WithAttributes(otelLabels...))
 }
 
-func (c *IndexerMetricLabeler) IncrementGRPCErrors(ctx context.Context, code, method string) {
+func (c *IndexerMetricLabeler) IncrementGRPCErrors(ctx context.Context, target, code, method string) {
 	otelLabels := beholder.OtelAttributes(c.Labels).AsStringAttributes()
 	c.im.grpcErrorsTotal.Add(ctx, 1, metric.WithAttributes([]attribute.KeyValue{
+		attribute.String("target", target),
 		attribute.String("code", code),
 		attribute.String("method", method),
 	}...), metric.WithAttributes(otelLabels...))

--- a/indexer/pkg/monitoring/noop.go
+++ b/indexer/pkg/monitoring/noop.go
@@ -45,8 +45,8 @@ func (n *NoopIndexerMetricLabeler) RecordTimeToIndex(ctx context.Context, latenc
 func (n *NoopIndexerMetricLabeler) RecordCircuitBreakerStatus(ctx context.Context, status bool) {
 }
 
-func (n *NoopIndexerMetricLabeler) RecordGRPCPayloadSize(_ context.Context, _, _ string, _ int) {
+func (n *NoopIndexerMetricLabeler) RecordGRPCPayloadSize(ctx context.Context, target, method, direction string, sizeBytes int) {
 }
 
-func (n *NoopIndexerMetricLabeler) IncrementGRPCErrors(_ context.Context, _, _ string) {
+func (n *NoopIndexerMetricLabeler) IncrementGRPCErrors(ctx context.Context, target, code, method string) {
 }

--- a/indexer/pkg/readers/aggregator_reader.go
+++ b/indexer/pkg/readers/aggregator_reader.go
@@ -11,8 +11,8 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
-func NewAggregatorReader(address string, lggr logger.Logger, since int64, hmacConfig hmac.ClientConfig, insecure bool, maxRecvMsgSizeBytes int, m common.IndexerMonitoring) (*ResilientReader, error) {
-	reader, err := storageaccess.NewAggregatorReader(address, lggr, since, &hmacConfig, insecure, maxRecvMsgSizeBytes, grpcClientDialOptions(m.Metrics())...)
+func NewAggregatorReader(name, address string, lggr logger.Logger, since int64, hmacConfig hmac.ClientConfig, insecure bool, maxRecvMsgSizeBytes int, m common.IndexerMonitoring) (*ResilientReader, error) {
+	reader, err := storageaccess.NewAggregatorReader(address, lggr, since, &hmacConfig, insecure, maxRecvMsgSizeBytes, grpcClientDialOptions(name, m.Metrics())...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create aggregator reader: %w", err)
 	}

--- a/indexer/pkg/readers/grpc_stats_handler.go
+++ b/indexer/pkg/readers/grpc_stats_handler.go
@@ -19,11 +19,12 @@ type grpcMethodKey struct{}
 // End events capture gRPC status codes including transport-level errors such as ResourceExhausted
 // when an aggregator response exceeds the client's configured MaxRecvMsgSize.
 type grpcClientStatsHandler struct {
-	m common.IndexerMetricLabeler
+	target string
+	m      common.IndexerMetricLabeler
 }
 
-func newGRPCClientStatsHandler(m common.IndexerMetricLabeler) *grpcClientStatsHandler {
-	return &grpcClientStatsHandler{m: m}
+func newGRPCClientStatsHandler(target string, m common.IndexerMetricLabeler) *grpcClientStatsHandler {
+	return &grpcClientStatsHandler{target: target, m: m}
 }
 
 func (h *grpcClientStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
@@ -38,14 +39,14 @@ func (h *grpcClientStatsHandler) HandleRPC(ctx context.Context, s stats.RPCStats
 
 	switch st := s.(type) {
 	case *stats.OutPayload:
-		h.m.RecordGRPCPayloadSize(ctx, method, "send", st.WireLength)
+		h.m.RecordGRPCPayloadSize(ctx, h.target, method, "send", st.WireLength)
 	case *stats.InPayload:
-		h.m.RecordGRPCPayloadSize(ctx, method, "recv", st.WireLength)
+		h.m.RecordGRPCPayloadSize(ctx, h.target, method, "recv", st.WireLength)
 	case *stats.End:
 		if st.Error != nil {
 			code := status.Code(st.Error)
 			if code != codes.OK {
-				h.m.IncrementGRPCErrors(ctx, code.String(), method)
+				h.m.IncrementGRPCErrors(ctx, h.target, code.String(), method)
 			}
 		}
 	}
@@ -58,8 +59,8 @@ func (h *grpcClientStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagIn
 func (h *grpcClientStatsHandler) HandleConn(_ context.Context, _ stats.ConnStats) {}
 
 // grpcClientDialOptions returns the gRPC dial options for monitoring payload sizes and error counts.
-func grpcClientDialOptions(m common.IndexerMetricLabeler) []grpc.DialOption {
+func grpcClientDialOptions(target string, m common.IndexerMetricLabeler) []grpc.DialOption {
 	return []grpc.DialOption{
-		grpc.WithStatsHandler(newGRPCClientStatsHandler(m)),
+		grpc.WithStatsHandler(newGRPCClientStatsHandler(target, m)),
 	}
 }

--- a/indexer/pkg/readers/grpc_stats_handler_test.go
+++ b/indexer/pkg/readers/grpc_stats_handler_test.go
@@ -117,3 +117,13 @@ func TestGRPCClientDialOptions(t *testing.T) {
 	opts := grpcClientDialOptions("", m)
 	assert.Len(t, opts, 1)
 }
+
+func TestGRPCClientStatsHandler_TargetThreadedThrough(t *testing.T) {
+	const target = "my-aggregator"
+	m := mocks.NewMockIndexerMetricLabeler(t)
+	m.EXPECT().RecordGRPCPayloadSize(mock.Anything, target, testMethod, "send", 100).Once()
+
+	h := newGRPCClientStatsHandler(target, m)
+	ctx := h.TagRPC(context.Background(), &stats.RPCTagInfo{FullMethodName: testMethod})
+	h.HandleRPC(ctx, &stats.OutPayload{WireLength: 100})
+}

--- a/indexer/pkg/readers/grpc_stats_handler_test.go
+++ b/indexer/pkg/readers/grpc_stats_handler_test.go
@@ -17,29 +17,29 @@ const testMethod = "/pkg.Service/Method"
 
 func taggedCtx(t *testing.T) context.Context {
 	t.Helper()
-	h := newGRPCClientStatsHandler(mocks.NewMockIndexerMetricLabeler(t))
+	h := newGRPCClientStatsHandler("", mocks.NewMockIndexerMetricLabeler(t))
 	return h.TagRPC(context.Background(), &stats.RPCTagInfo{FullMethodName: testMethod})
 }
 
 func TestGRPCClientStatsHandler_TagRPC(t *testing.T) {
-	h := newGRPCClientStatsHandler(mocks.NewMockIndexerMetricLabeler(t))
+	h := newGRPCClientStatsHandler("", mocks.NewMockIndexerMetricLabeler(t))
 	ctx := h.TagRPC(context.Background(), &stats.RPCTagInfo{FullMethodName: testMethod})
 	assert.Equal(t, testMethod, ctx.Value(grpcMethodKey{}))
 }
 
 func TestGRPCClientStatsHandler_HandleRPC_OutPayload(t *testing.T) {
 	m := mocks.NewMockIndexerMetricLabeler(t)
-	m.EXPECT().RecordGRPCPayloadSize(mock.Anything, testMethod, "send", 1024).Once()
+	m.EXPECT().RecordGRPCPayloadSize(mock.Anything, "", testMethod, "send", 1024).Once()
 
-	h := newGRPCClientStatsHandler(m)
+	h := newGRPCClientStatsHandler("", m)
 	h.HandleRPC(taggedCtx(t), &stats.OutPayload{WireLength: 1024})
 }
 
 func TestGRPCClientStatsHandler_HandleRPC_InPayload(t *testing.T) {
 	m := mocks.NewMockIndexerMetricLabeler(t)
-	m.EXPECT().RecordGRPCPayloadSize(mock.Anything, testMethod, "recv", 2048).Once()
+	m.EXPECT().RecordGRPCPayloadSize(mock.Anything, "", testMethod, "recv", 2048).Once()
 
-	h := newGRPCClientStatsHandler(m)
+	h := newGRPCClientStatsHandler("", m)
 	h.HandleRPC(taggedCtx(t), &stats.InPayload{WireLength: 2048})
 }
 
@@ -57,9 +57,9 @@ func TestGRPCClientStatsHandler_HandleRPC_End_NonOKError(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := mocks.NewMockIndexerMetricLabeler(t)
-			m.EXPECT().IncrementGRPCErrors(mock.Anything, tc.code.String(), testMethod).Once()
+			m.EXPECT().IncrementGRPCErrors(mock.Anything, "", tc.code.String(), testMethod).Once()
 
-			h := newGRPCClientStatsHandler(m)
+			h := newGRPCClientStatsHandler("", m)
 			h.HandleRPC(taggedCtx(t), &stats.End{Error: status.Error(tc.code, "error")})
 		})
 	}
@@ -69,7 +69,7 @@ func TestGRPCClientStatsHandler_HandleRPC_End_NoError(t *testing.T) {
 	m := mocks.NewMockIndexerMetricLabeler(t)
 	// No metric calls expected on success.
 
-	h := newGRPCClientStatsHandler(m)
+	h := newGRPCClientStatsHandler("", m)
 	h.HandleRPC(taggedCtx(t), &stats.End{Error: nil})
 }
 
@@ -77,16 +77,16 @@ func TestGRPCClientStatsHandler_HandleRPC_End_OKError(t *testing.T) {
 	m := mocks.NewMockIndexerMetricLabeler(t)
 	// codes.OK wrapped as an error should not increment the error counter.
 
-	h := newGRPCClientStatsHandler(m)
+	h := newGRPCClientStatsHandler("", m)
 	h.HandleRPC(taggedCtx(t), &stats.End{Error: status.Error(codes.OK, "ok")})
 }
 
 func TestGRPCClientStatsHandler_HandleRPC_UnknownMethod(t *testing.T) {
 	m := mocks.NewMockIndexerMetricLabeler(t)
 	// Context without a tagged method — method falls back to empty string.
-	m.EXPECT().RecordGRPCPayloadSize(mock.Anything, "", "send", 512).Once()
+	m.EXPECT().RecordGRPCPayloadSize(mock.Anything, "", "", "send", 512).Once()
 
-	h := newGRPCClientStatsHandler(m)
+	h := newGRPCClientStatsHandler("", m)
 	h.HandleRPC(context.Background(), &stats.OutPayload{WireLength: 512})
 }
 
@@ -94,26 +94,26 @@ func TestGRPCClientStatsHandler_HandleRPC_IgnoredEvents(t *testing.T) {
 	m := mocks.NewMockIndexerMetricLabeler(t)
 	// Begin, InHeader, OutHeader — no metric calls expected.
 
-	h := newGRPCClientStatsHandler(m)
+	h := newGRPCClientStatsHandler("", m)
 	h.HandleRPC(taggedCtx(t), &stats.Begin{})
 	h.HandleRPC(taggedCtx(t), &stats.InHeader{})
 	h.HandleRPC(taggedCtx(t), &stats.OutHeader{})
 }
 
 func TestGRPCClientStatsHandler_TagConn(t *testing.T) {
-	h := newGRPCClientStatsHandler(mocks.NewMockIndexerMetricLabeler(t))
+	h := newGRPCClientStatsHandler("", mocks.NewMockIndexerMetricLabeler(t))
 	ctx := h.TagConn(context.Background(), &stats.ConnTagInfo{})
 	assert.Equal(t, context.Background(), ctx)
 }
 
 func TestGRPCClientStatsHandler_HandleConn(t *testing.T) {
-	h := newGRPCClientStatsHandler(mocks.NewMockIndexerMetricLabeler(t))
+	h := newGRPCClientStatsHandler("", mocks.NewMockIndexerMetricLabeler(t))
 	// Must not panic.
 	h.HandleConn(context.Background(), &stats.ConnBegin{})
 }
 
 func TestGRPCClientDialOptions(t *testing.T) {
 	m := mocks.NewMockIndexerMetricLabeler(t)
-	opts := grpcClientDialOptions(m)
+	opts := grpcClientDialOptions("", m)
 	assert.Len(t, opts, 1)
 }

--- a/internal/mocks/mock_IndexerMetricLabeler.go
+++ b/internal/mocks/mock_IndexerMetricLabeler.go
@@ -89,9 +89,9 @@ func (_c *MockIndexerMetricLabeler_IncrementActiveRequestsCounter_Call) RunAndRe
 	return _c
 }
 
-// IncrementGRPCErrors provides a mock function with given fields: ctx, code, method
-func (_m *MockIndexerMetricLabeler) IncrementGRPCErrors(ctx context.Context, code string, method string) {
-	_m.Called(ctx, code, method)
+// IncrementGRPCErrors provides a mock function with given fields: ctx, target, code, method
+func (_m *MockIndexerMetricLabeler) IncrementGRPCErrors(ctx context.Context, target string, code string, method string) {
+	_m.Called(ctx, target, code, method)
 }
 
 // MockIndexerMetricLabeler_IncrementGRPCErrors_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IncrementGRPCErrors'
@@ -101,15 +101,16 @@ type MockIndexerMetricLabeler_IncrementGRPCErrors_Call struct {
 
 // IncrementGRPCErrors is a helper method to define mock.On call
 //   - ctx context.Context
+//   - target string
 //   - code string
 //   - method string
-func (_e *MockIndexerMetricLabeler_Expecter) IncrementGRPCErrors(ctx interface{}, code interface{}, method interface{}) *MockIndexerMetricLabeler_IncrementGRPCErrors_Call {
-	return &MockIndexerMetricLabeler_IncrementGRPCErrors_Call{Call: _e.mock.On("IncrementGRPCErrors", ctx, code, method)}
+func (_e *MockIndexerMetricLabeler_Expecter) IncrementGRPCErrors(ctx interface{}, target interface{}, code interface{}, method interface{}) *MockIndexerMetricLabeler_IncrementGRPCErrors_Call {
+	return &MockIndexerMetricLabeler_IncrementGRPCErrors_Call{Call: _e.mock.On("IncrementGRPCErrors", ctx, target, code, method)}
 }
 
-func (_c *MockIndexerMetricLabeler_IncrementGRPCErrors_Call) Run(run func(ctx context.Context, code string, method string)) *MockIndexerMetricLabeler_IncrementGRPCErrors_Call {
+func (_c *MockIndexerMetricLabeler_IncrementGRPCErrors_Call) Run(run func(ctx context.Context, target string, code string, method string)) *MockIndexerMetricLabeler_IncrementGRPCErrors_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
 	})
 	return _c
 }
@@ -119,7 +120,7 @@ func (_c *MockIndexerMetricLabeler_IncrementGRPCErrors_Call) Return() *MockIndex
 	return _c
 }
 
-func (_c *MockIndexerMetricLabeler_IncrementGRPCErrors_Call) RunAndReturn(run func(context.Context, string, string)) *MockIndexerMetricLabeler_IncrementGRPCErrors_Call {
+func (_c *MockIndexerMetricLabeler_IncrementGRPCErrors_Call) RunAndReturn(run func(context.Context, string, string, string)) *MockIndexerMetricLabeler_IncrementGRPCErrors_Call {
 	_c.Run(run)
 	return _c
 }
@@ -259,9 +260,9 @@ func (_c *MockIndexerMetricLabeler_RecordCircuitBreakerStatus_Call) RunAndReturn
 	return _c
 }
 
-// RecordGRPCPayloadSize provides a mock function with given fields: ctx, method, direction, sizeBytes
-func (_m *MockIndexerMetricLabeler) RecordGRPCPayloadSize(ctx context.Context, method string, direction string, sizeBytes int) {
-	_m.Called(ctx, method, direction, sizeBytes)
+// RecordGRPCPayloadSize provides a mock function with given fields: ctx, target, method, direction, sizeBytes
+func (_m *MockIndexerMetricLabeler) RecordGRPCPayloadSize(ctx context.Context, target string, method string, direction string, sizeBytes int) {
+	_m.Called(ctx, target, method, direction, sizeBytes)
 }
 
 // MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordGRPCPayloadSize'
@@ -271,16 +272,17 @@ type MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call struct {
 
 // RecordGRPCPayloadSize is a helper method to define mock.On call
 //   - ctx context.Context
+//   - target string
 //   - method string
 //   - direction string
 //   - sizeBytes int
-func (_e *MockIndexerMetricLabeler_Expecter) RecordGRPCPayloadSize(ctx interface{}, method interface{}, direction interface{}, sizeBytes interface{}) *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call {
-	return &MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call{Call: _e.mock.On("RecordGRPCPayloadSize", ctx, method, direction, sizeBytes)}
+func (_e *MockIndexerMetricLabeler_Expecter) RecordGRPCPayloadSize(ctx interface{}, target interface{}, method interface{}, direction interface{}, sizeBytes interface{}) *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call {
+	return &MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call{Call: _e.mock.On("RecordGRPCPayloadSize", ctx, target, method, direction, sizeBytes)}
 }
 
-func (_c *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call) Run(run func(ctx context.Context, method string, direction string, sizeBytes int)) *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call {
+func (_c *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call) Run(run func(ctx context.Context, target string, method string, direction string, sizeBytes int)) *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(int))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(int))
 	})
 	return _c
 }
@@ -290,7 +292,7 @@ func (_c *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call) Return() *MockInd
 	return _c
 }
 
-func (_c *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call) RunAndReturn(run func(context.Context, string, string, int)) *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call {
+func (_c *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call) RunAndReturn(run func(context.Context, string, string, string, int)) *MockIndexerMetricLabeler_RecordGRPCPayloadSize_Call {
 	_c.Run(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
  - Add `Name` field to `DiscoveryConfig` (aggregator reader config); expose as `Label()` falling back to `Address` when unset.
  - Thread label through gRPC stats handler and metrics so aggregator connections are distinguishable in logs and metrics.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing
`just rebuild-all`
`just obs up`
checking [indexer_grpc_payload_size_bytes_count](http://localhost:3000/explore?schemaVersion=1&panes=%7B%22hwh%22:%7B%22datasource%22:%22victoriametrics%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22indexer_grpc_payload_size_bytes_count%7B%7D%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22victoriametrics%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
