### PR TITLE
Skip JD chain support validation for non-EVM executor adapters

### DIFF
--- a/deployment/adapters/executor_config.go
+++ b/deployment/adapters/executor_config.go
@@ -15,4 +15,10 @@ type ExecutorConfigAdapter interface {
 	// BuildChainConfig builds the executor chain configuration for the given chain selector
 	// and qualifier from addresses recorded in the datastore.
 	BuildChainConfig(ds datastore.DataStore, chainSelector uint64, qualifier string) (executor.ChainConfiguration, error)
+	// RequiresNodeChainSupportInJD reports whether ApplyExecutorConfig must verify that
+	// target NOPs have this chain registered in JD (ListNodeChainConfigs) before proposing
+	// ccvexecutor job specs. EVM chains require JD registration; families such as Canton
+	// that push destination blocks onto existing EVM executor jobs may return false until
+	// JD node chain configs exist for that family.
+	RequiresNodeChainSupportInJD() bool
 }

--- a/deployment/adapters/executor_config.go
+++ b/deployment/adapters/executor_config.go
@@ -19,15 +19,13 @@ type ExecutorConfigAdapter interface {
 
 // ExecutorNodeChainJDSupport is an optional extension of ExecutorConfigAdapter.
 // Implement it to opt out of JD node chain support validation in ApplyExecutorConfig.
-//
-// RequiresNodeChainSupportInJD reports whether ApplyExecutorConfig must verify that
-// target NOPs have this chain registered in JD (ListNodeChainConfigs) before proposing
-// ccvexecutor job specs. EVM chains require JD registration; families such as Canton
-// that push destination blocks onto existing EVM executor jobs may return false until
-// JD node chain configs exist for that family.
-//
 // Adapters that do not implement ExecutorNodeChainJDSupport default to true (require JD).
 type ExecutorNodeChainJDSupport interface {
+	// RequiresNodeChainSupportInJD reports whether ApplyExecutorConfig must verify that
+	// target NOPs have this chain registered in JD (ListNodeChainConfigs) before proposing
+	// ccvexecutor job specs. EVM chains require JD registration; families such as Canton
+	// that push destination blocks onto existing EVM executor jobs may return false until
+	// JD node chain configs exist for that family.
 	RequiresNodeChainSupportInJD() bool
 }
 

--- a/deployment/adapters/executor_config.go
+++ b/deployment/adapters/executor_config.go
@@ -15,10 +15,27 @@ type ExecutorConfigAdapter interface {
 	// BuildChainConfig builds the executor chain configuration for the given chain selector
 	// and qualifier from addresses recorded in the datastore.
 	BuildChainConfig(ds datastore.DataStore, chainSelector uint64, qualifier string) (executor.ChainConfiguration, error)
-	// RequiresNodeChainSupportInJD reports whether ApplyExecutorConfig must verify that
-	// target NOPs have this chain registered in JD (ListNodeChainConfigs) before proposing
-	// ccvexecutor job specs. EVM chains require JD registration; families such as Canton
-	// that push destination blocks onto existing EVM executor jobs may return false until
-	// JD node chain configs exist for that family.
+}
+
+// ExecutorNodeChainJDSupport is an optional extension of ExecutorConfigAdapter.
+// Implement it to opt out of JD node chain support validation in ApplyExecutorConfig.
+//
+// RequiresNodeChainSupportInJD reports whether ApplyExecutorConfig must verify that
+// target NOPs have this chain registered in JD (ListNodeChainConfigs) before proposing
+// ccvexecutor job specs. EVM chains require JD registration; families such as Canton
+// that push destination blocks onto existing EVM executor jobs may return false until
+// JD node chain configs exist for that family.
+//
+// Adapters that do not implement ExecutorNodeChainJDSupport default to true (require JD).
+type ExecutorNodeChainJDSupport interface {
 	RequiresNodeChainSupportInJD() bool
+}
+
+// ExecutorRequiresNodeChainSupportInJD returns whether the adapter requires JD node chain
+// support validation. Adapters without ExecutorNodeChainJDSupport default to true.
+func ExecutorRequiresNodeChainSupportInJD(adapter ExecutorConfigAdapter) bool {
+	if a, ok := adapter.(ExecutorNodeChainJDSupport); ok {
+		return a.RequiresNodeChainSupportInJD()
+	}
+	return true
 }

--- a/deployment/changesets/apply_executor_config.go
+++ b/deployment/changesets/apply_executor_config.go
@@ -236,7 +236,9 @@ func validateExecutorChainSupport(
 	nopsToValidate []shared.NOPAlias,
 ) error {
 	if e.Offchain == nil {
-		e.Logger.Debugw("Offchain client not available, skipping chain support validation")
+		if e.Logger != nil {
+			e.Logger.Debugw("Offchain client not available, skipping chain support validation")
+		}
 		return nil
 	}
 
@@ -280,7 +282,7 @@ func filterChainsRequiringJDSupport(chains []uint64) ([]uint64, error) {
 		if err != nil {
 			return nil, err
 		}
-		if adapter.RequiresNodeChainSupportInJD() {
+		if adapters.ExecutorRequiresNodeChainSupportInJD(adapter) {
 			filtered = append(filtered, sel)
 		}
 	}

--- a/deployment/changesets/apply_executor_config.go
+++ b/deployment/changesets/apply_executor_config.go
@@ -131,7 +131,7 @@ func ApplyExecutorConfig() deployment.ChangeSetV2[ApplyExecutorConfigInput] {
 		}
 
 		clNOPs := filterCLModeNOPs(nopsToValidate, cfg.NOPs)
-		if err := validateExecutorChainSupport(e, cfg.Pool, clNOPs, selectors); err != nil {
+		if err := validateExecutorChainSupport(e, cfg.Pool, clNOPs); err != nil {
 			return deployment.ChangesetOutput{}, err
 		}
 
@@ -234,7 +234,6 @@ func validateExecutorChainSupport(
 	e deployment.Environment,
 	pool ExecutorPoolInput,
 	nopsToValidate []shared.NOPAlias,
-	deployedChains []uint64,
 ) error {
 	if e.Offchain == nil {
 		e.Logger.Debugw("Offchain client not available, skipping chain support validation")
@@ -254,9 +253,16 @@ func validateExecutorChainSupport(
 	var validationResults []shared.ChainValidationResult
 	for _, nopAlias := range nopsToValidate {
 		requiredChains := requiredChainsForExecutorNOP(nopAlias, pool)
+		jdRequiredChains, err := filterChainsRequiringJDSupport(requiredChains)
+		if err != nil {
+			return err
+		}
+		if len(jdRequiredChains) == 0 {
+			continue
+		}
 		result := shared.ValidateNOPChainSupport(
 			string(nopAlias),
-			requiredChains,
+			jdRequiredChains,
 			supportedChains[string(nopAlias)],
 		)
 		if result != nil {
@@ -265,6 +271,20 @@ func validateExecutorChainSupport(
 	}
 
 	return shared.FormatChainValidationError(validationResults)
+}
+
+func filterChainsRequiringJDSupport(chains []uint64) ([]uint64, error) {
+	filtered := make([]uint64, 0, len(chains))
+	for _, sel := range chains {
+		adapter, err := adapters.GetExecutorRegistry().Get(sel)
+		if err != nil {
+			return nil, err
+		}
+		if adapter.RequiresNodeChainSupportInJD() {
+			filtered = append(filtered, sel)
+		}
+	}
+	return filtered, nil
 }
 
 func requiredChainsForExecutorNOP(nopAlias shared.NOPAlias, pool ExecutorPoolInput) []uint64 {

--- a/deployment/changesets/apply_executor_config_jd_test.go
+++ b/deployment/changesets/apply_executor_config_jd_test.go
@@ -1,0 +1,75 @@
+package changesets
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	ccvadapters "github.com/smartcontractkit/chainlink-ccv/deployment/adapters"
+	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
+	"github.com/smartcontractkit/chainlink-ccv/executor"
+	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
+)
+
+type jdMockExecutorAdapter struct {
+	requiresJD bool
+}
+
+var _ ccvadapters.ExecutorConfigAdapter = (*jdMockExecutorAdapter)(nil)
+
+func (m *jdMockExecutorAdapter) GetDeployedChains(_ datastore.DataStore, _ string) []uint64 {
+	return nil
+}
+
+func (m *jdMockExecutorAdapter) RequiresNodeChainSupportInJD() bool {
+	return m.requiresJD
+}
+
+func (m *jdMockExecutorAdapter) BuildChainConfig(_ datastore.DataStore, _ uint64, _ string) (executor.ChainConfiguration, error) {
+	return executor.ChainConfiguration{
+		DestinationChainConfig: chainaccess.DestinationChainConfig{
+			OffRampAddress: "0xoff",
+			RmnAddress:     "0xrmn",
+		},
+		DefaultExecutorAddress: "0xexec",
+	}, nil
+}
+
+func TestFilterChainsRequiringJDSupport_FiltersPerAdapter(t *testing.T) {
+	evmSel := chainsel.TEST_90000001.Selector
+	aptosSel := chainsel.TEST_90000002.Selector
+
+	ccvadapters.GetExecutorRegistry().Register(chainsel.FamilyEVM, &jdMockExecutorAdapter{requiresJD: true})
+	ccvadapters.GetExecutorRegistry().Register(chainsel.FamilyAptos, &jdMockExecutorAdapter{requiresJD: false})
+
+	filtered, err := filterChainsRequiringJDSupport([]uint64{evmSel, aptosSel})
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{evmSel}, filtered)
+}
+
+func TestValidateExecutorChainSupport_SkipsJDWhenOffchainNil(t *testing.T) {
+	evmSel := chainsel.TEST_90000001.Selector
+	aptosSel := chainsel.TEST_90000002.Selector
+
+	pool := ExecutorPoolInput{
+		ChainConfigs: map[uint64]ChainExecutorPoolMembership{
+			evmSel: {
+				NOPAliases:        []shared.NOPAlias{"nop1"},
+				ExecutionInterval: 5 * time.Second,
+			},
+			aptosSel: {
+				NOPAliases:        []shared.NOPAlias{"nop1"},
+				ExecutionInterval: 5 * time.Second,
+			},
+		},
+	}
+
+	err := validateExecutorChainSupport(deployment.Environment{}, pool, []shared.NOPAlias{"nop1"})
+	require.NoError(t, err)
+}

--- a/deployment/changesets/apply_executor_config_jd_test.go
+++ b/deployment/changesets/apply_executor_config_jd_test.go
@@ -17,18 +17,12 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 )
 
-type jdMockExecutorAdapter struct {
-	requiresJD bool
-}
+type jdMockExecutorAdapter struct{}
 
 var _ ccvadapters.ExecutorConfigAdapter = (*jdMockExecutorAdapter)(nil)
 
 func (m *jdMockExecutorAdapter) GetDeployedChains(_ datastore.DataStore, _ string) []uint64 {
 	return nil
-}
-
-func (m *jdMockExecutorAdapter) RequiresNodeChainSupportInJD() bool {
-	return m.requiresJD
 }
 
 func (m *jdMockExecutorAdapter) BuildChainConfig(_ datastore.DataStore, _ uint64, _ string) (executor.ChainConfiguration, error) {
@@ -41,21 +35,32 @@ func (m *jdMockExecutorAdapter) BuildChainConfig(_ datastore.DataStore, _ uint64
 	}, nil
 }
 
+type jdMockExecutorAdapterSkipJD struct {
+	jdMockExecutorAdapter
+}
+
+var _ ccvadapters.ExecutorNodeChainJDSupport = (*jdMockExecutorAdapterSkipJD)(nil)
+
+func (m *jdMockExecutorAdapterSkipJD) RequiresNodeChainSupportInJD() bool {
+	return false
+}
+
 func TestFilterChainsRequiringJDSupport_FiltersPerAdapter(t *testing.T) {
 	evmSel := chainsel.TEST_90000001.Selector
-	aptosSel := chainsel.TEST_90000002.Selector
+	// TEST_90000002 is also EVM; use a different family to exercise per-adapter filtering.
+	nonJDSel := chainsel.SOLANA_DEVNET.Selector
 
-	ccvadapters.GetExecutorRegistry().Register(chainsel.FamilyEVM, &jdMockExecutorAdapter{requiresJD: true})
-	ccvadapters.GetExecutorRegistry().Register(chainsel.FamilyAptos, &jdMockExecutorAdapter{requiresJD: false})
+	ccvadapters.GetExecutorRegistry().Register(chainsel.FamilyEVM, &jdMockExecutorAdapter{})
+	ccvadapters.GetExecutorRegistry().Register(chainsel.FamilySolana, &jdMockExecutorAdapterSkipJD{})
 
-	filtered, err := filterChainsRequiringJDSupport([]uint64{evmSel, aptosSel})
+	filtered, err := filterChainsRequiringJDSupport([]uint64{evmSel, nonJDSel})
 	require.NoError(t, err)
 	assert.Equal(t, []uint64{evmSel}, filtered)
 }
 
 func TestValidateExecutorChainSupport_SkipsJDWhenOffchainNil(t *testing.T) {
 	evmSel := chainsel.TEST_90000001.Selector
-	aptosSel := chainsel.TEST_90000002.Selector
+	nonJDSel := chainsel.SOLANA_DEVNET.Selector
 
 	pool := ExecutorPoolInput{
 		ChainConfigs: map[uint64]ChainExecutorPoolMembership{
@@ -63,7 +68,7 @@ func TestValidateExecutorChainSupport_SkipsJDWhenOffchainNil(t *testing.T) {
 				NOPAliases:        []shared.NOPAlias{"nop1"},
 				ExecutionInterval: 5 * time.Second,
 			},
-			aptosSel: {
+			nonJDSel: {
 				NOPAliases:        []shared.NOPAlias{"nop1"},
 				ExecutionInterval: 5 * time.Second,
 			},

--- a/deployment/changesets/apply_verifier_config.go
+++ b/deployment/changesets/apply_verifier_config.go
@@ -594,7 +594,9 @@ func validateVerifierChainSupport(
 	committee CommitteeInput,
 ) error {
 	if e.Offchain == nil {
-		e.Logger.Debugw("Offchain client not available, skipping chain support validation")
+		if e.Logger != nil {
+			e.Logger.Debugw("Offchain client not available, skipping chain support validation")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Adds RequiresNodeChainSupportInJD() to ExecutorConfigAdapter so ApplyExecutorConfig can skip JD ListNodeChainConfigs validation per chain family, instead of requiring a Canton-specific wrapper changeset that duplicated the entire Apply path and skipped JD validation for the whole executor pool.

Fixes the Canton executor rollout case: Canton destination blocks must land on existing EVM ccvexecutor jobs before Canton node chain configs exist in JD. EVM chains in the same pool are still validated against JD.

Tracks [CCIP-11846](https://smartcontract-it.atlassian.net/browse/CCIP-11846).

## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date


[CCIP-11846]: https://smartcontract-it.atlassian.net/browse/CCIP-11846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ