### PR TITLE
common/jd: replacement fallback on StartJob failure

### DIFF
--- a/bootstrap/db/migrations/0003_job_store_unique_status.sql
+++ b/bootstrap/db/migrations/0003_job_store_unique_status.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE job_store ADD CONSTRAINT job_store_unique_status UNIQUE (status);
+
+-- +goose Down
+ALTER TABLE job_store DROP CONSTRAINT job_store_unique_status;

--- a/changelog/2026-06-26_jd_lifecycle_replacement_fallback.md
+++ b/changelog/2026-06-26_jd_lifecycle_replacement_fallback.md
@@ -1,0 +1,86 @@
+# JD lifecycle manager: fallback to old job on failed replacement
+
+## Summary
+
+When a replacement job proposal fails to start, the lifecycle manager now
+restarts the previous job automatically rather than leaving the verifier with
+nothing running. The old approved row is preserved in the store throughout the
+replacement attempt so that both in-process restart and process-restart recovery
+work correctly.
+
+---
+
+## Bug fixes
+
+### **`common/jd/lifecycle`**: verifier stalls after a failed replacement proposal
+
+**Before:** When a replacement proposal arrived, the manager stopped the old
+job before calling `StartJob` for the new one. If `StartJob` failed, the old
+job was already gone. The manager entered `WaitingForJob` with no persisted
+record to recover from. JD would not re-push (proposal already acknowledged),
+so the verifier stalled until an operator manually re-proposed.
+
+**After:** The old `approved` row is preserved in the store during a replacement
+(see below). On `StartJob` failure, the manager calls `DeletePendingJob` to
+remove the new pending row, then restarts the old job from the in-memory
+snapshot. If the old job restart also fails, the manager enters `WaitingForJob`
+— but the old `approved` row is still in the DB, so the next process restart
+boots the known-good job automatically.
+
+```mermaid
+sequenceDiagram
+    participant JD
+    participant M as Manager
+    participant S as JobStore
+    participant R as JobRunner
+
+    JD->>M: ProposeJob(newId, newSpec)
+    M->>S: SaveJob(pending)       note: approved row preserved
+    M->>R: StopJob()
+    M->>R: StartJob(newSpec)
+    R-->>M: error
+    M->>S: DeletePendingJob()     note: restore single approved row
+    M->>R: StartJob(oldSpec)      note: restart known-good job
+    Note over M: state stays Running (if restart succeeds)
+```
+
+---
+
+## New: `StoreInterface.DeletePendingJob`
+
+A new method is added to `StoreInterface` (and `PostgresStore`):
+
+```go
+// DeletePendingJob removes only the pending record, leaving any approved
+// record intact. Used to rollback a failed replacement proposal.
+DeletePendingJob(ctx context.Context) error
+```
+
+Any custom implementation of `StoreInterface` must add this method.
+
+---
+
+## Behaviour change: `SaveJob` no longer deletes the approved row
+
+Previously `SaveJob` deleted all rows before inserting the new pending row.
+It now only deletes the `pending` row, preserving any existing `approved` row.
+This is required so a failed replacement can fall back to the old job.
+
+The `LoadJob` tiebreaker — when both rows exist, the `approved` row is returned
+— means a process restart after a failed replacement boots the old job, not the
+stuck pending one.
+
+---
+
+## Migration required
+
+Migration `0003` adds a `UNIQUE(status)` constraint to `job_store`:
+
+```sql
+ALTER TABLE job_store
+    ADD CONSTRAINT job_store_unique_status UNIQUE (status);
+```
+
+This enforces at most one `pending` and one `approved` row at a time, preventing
+accumulation of pending rows from repeated failed replacements. Applied
+automatically on startup via `db.RunMigrations`.

--- a/changelog/2026-06-26_jd_lifecycle_replacement_fallback.md
+++ b/changelog/2026-06-26_jd_lifecycle_replacement_fallback.md
@@ -35,36 +35,44 @@ sequenceDiagram
     participant R as JobRunner
 
     JD->>M: ProposeJob(newId, newSpec)
-    M->>S: SaveJob(pending)       note: approved row preserved
+    M->>S: SavePendingJob()      note: approved row preserved
     M->>R: StopJob()
     M->>R: StartJob(newSpec)
     R-->>M: error
-    M->>S: DeletePendingJob()     note: restore single approved row
-    M->>R: StartJob(oldSpec)      note: restart known-good job
+    M->>S: DeletePendingJob()    note: restore single approved row
+    M->>R: StartJob(oldSpec)     note: restart known-good job
     Note over M: state stays Running (if restart succeeds)
 ```
 
 ---
 
-## New: `StoreInterface.DeletePendingJob`
+## New and renamed `StoreInterface` methods
 
-A new method is added to `StoreInterface` (and `PostgresStore`):
+Three methods are added or renamed. Any custom implementation of `StoreInterface`
+must be updated.
+
+| Old name | New name | Notes |
+|---|---|---|
+| `SaveJob` | `SavePendingJob` | Only replaces the pending row; approved row preserved |
+| `MarkJobApproved` | `AcceptPendingJob` | Returns `(bool, error)`; `bool` is true if a pending row was promoted |
+| `DeleteJob` | `DeleteAllJobs` | Makes "clears everything" semantics explicit |
+| *(new)* | `DeletePendingJob` | Removes only the pending row; used to rollback a failed replacement |
 
 ```go
-// DeletePendingJob removes only the pending record, leaving any approved
-// record intact. Used to rollback a failed replacement proposal.
+SavePendingJob(ctx context.Context, proposalID string, version int64, spec string) error
+AcceptPendingJob(ctx context.Context) (bool, error)
+DeleteAllJobs(ctx context.Context) error
 DeletePendingJob(ctx context.Context) error
 ```
 
-Any custom implementation of `StoreInterface` must add this method.
-
 ---
 
-## Behaviour change: `SaveJob` no longer deletes the approved row
+## Behaviour change: `SavePendingJob` no longer deletes the approved row
 
 Previously `SaveJob` deleted all rows before inserting the new pending row.
-It now only deletes the `pending` row, preserving any existing `approved` row.
-This is required so a failed replacement can fall back to the old job.
+`SavePendingJob` now only replaces the pending row (via `ON CONFLICT (status) DO UPDATE`),
+preserving any existing `approved` row. This is required so a failed replacement
+can fall back to the old job.
 
 The `LoadJob` tiebreaker — when both rows exist, the `approved` row is returned
 — means a process restart after a failed replacement boots the old job, not the

--- a/common/jd/lifecycle/README.md
+++ b/common/jd/lifecycle/README.md
@@ -4,15 +4,89 @@ Package `lifecycle` exports a lifecycle manager for standalone CCVs or executors
 
 ## Architecture
 
+### States
+
 ```mermaid
 stateDiagram-v2
     [*] --> WaitingForJob: Start (no cached job)
-    [*] --> Running: Start (cached job exists)
-    WaitingForJob --> Running: ProposeJob
+    [*] --> WaitingForJob: Start (pending cached job — deferred until JD reconnects)
+    [*] --> Running: Start (approved cached job)
+
+    WaitingForJob --> Running: ProposeJob succeeds
+    WaitingForJob --> WaitingForJob: ProposeJob fails (pending record kept for recovery)
+
+    Running --> Running: ProposeJob replacement succeeds
+    Running --> Running: ProposeJob replacement fails — old job restarted
+    Running --> WaitingForJob: ProposeJob replacement fails AND old job restart fails
     Running --> WaitingForJob: DeleteJob
-    Running --> Running: ProposeJob (replacement)
-    Running --> [*]: Shutdown signal
-    WaitingForJob --> [*]: Shutdown signal
+
+    WaitingForJob --> Running: JD reconnects + pending job retried successfully
+    WaitingForJob --> WaitingForJob: JD reconnects + pending job retry fails
+
+    Running --> [*]: Shutdown
+    WaitingForJob --> [*]: Shutdown
+```
+
+### Proposal handling (happy path)
+
+```mermaid
+sequenceDiagram
+    participant JD
+    participant M as Manager
+    participant S as JobStore
+    participant R as JobRunner
+
+    JD->>M: ProposeJob(id, version, spec)
+    M->>S: SaveJob(pending)
+    opt replacement
+        M->>R: StopJob()
+    end
+    M->>R: StartJob(spec)
+    M->>S: MarkJobApproved()
+    M->>JD: ApproveJob(id, version)
+    Note over M: state = Running
+```
+
+### Replacement failure — fallback to old job
+
+```mermaid
+sequenceDiagram
+    participant JD
+    participant M as Manager
+    participant S as JobStore
+    participant R as JobRunner
+
+    JD->>M: ProposeJob(newId, newVersion, newSpec)
+    M->>S: SaveJob(pending)       note: approved row preserved
+    M->>R: StopJob()
+    M->>R: StartJob(newSpec)
+    R-->>M: error
+    M->>S: DeletePendingJob()     note: restore single approved row
+    M->>R: StartJob(oldSpec)      note: restart known-good job
+    Note over M: state stays Running (if restart succeeds)
+```
+
+### Pending job recovery on restart
+
+```mermaid
+sequenceDiagram
+    participant M as Manager
+    participant S as JobStore
+    participant R as JobRunner
+    participant JD
+
+    M->>S: LoadJob()
+    S-->>M: Job{status=pending}
+    Note over M: set pendingJob — do NOT call StartJob yet
+
+    M->>JD: Connect() (async)
+    JD-->>M: connected → jdConnectedCh fires
+
+    Note over M: retryPendingJob()
+    M->>R: StartJob(spec)
+    M->>S: MarkJobApproved()
+    M->>JD: ApproveJob(id, version)
+    Note over M: state = Running
 ```
 
 ## Implementing JobRunner
@@ -26,6 +100,8 @@ The manager calls `StopJob` before starting a replacement job and when handling 
 
 ## Single job, replacement, and delete
 
-- The manager tracks **at most one job**. A new proposal is treated as a **replacement**: it stops the current job (if any), then starts the new one, persists it, and approves it with JD.
-- **Delete**: only the request whose id matches the current job’s proposal id is applied; others are ignored. After a matching delete, the manager stops the job, clears the store, and goes to `WaitingForJob`.
+- The manager tracks **at most one running job**. A new proposal is a **replacement**: it stops the current job (if any), then starts the new one.
+- **Crash safety (two-phase write):** the proposal is persisted as `pending` before `StartJob` is called and promoted to `approved` only after `StartJob` succeeds. A crash between the two leaves a `pending` record that drives a retry on the next restart + JD reconnect.
+- **Replacement fallback:** if `StartJob` fails for a replacement, the old job is automatically restarted and the `pending` store record is removed, keeping the verifier running on the previous spec. If the old job restart also fails, the manager transitions to `WaitingForJob`.
+- **Delete:** only the request whose id matches the current job's proposal id is applied; others are ignored. After a matching delete the manager stops the job, clears the store, and goes to `WaitingForJob`.
 - **Revoke** requests are received but not acted on (we auto-approve proposals, so revoke is effectively a no-op).

--- a/common/jd/lifecycle/README.md
+++ b/common/jd/lifecycle/README.md
@@ -89,6 +89,31 @@ sequenceDiagram
     Note over M: state = Running
 ```
 
+### Delete
+
+```mermaid
+sequenceDiagram
+    participant JD
+    participant M as Manager
+    participant S as JobStore
+    participant R as JobRunner
+
+    JD->>M: DeleteJob(id)
+    alt id matches current job
+        M->>R: StopJob()
+        M->>S: DeleteJob()
+        Note over M: state = WaitingForJob
+    else id does not match (or no job running)
+        Note over M: ignored
+    end
+```
+
+### Revoke
+
+Revoke requests are received but ignored. The manager auto-approves every
+proposal immediately, so by the time a revoke could arrive the job is already
+running. No state change occurs.
+
 ## Implementing JobRunner
 
 Your service must implement `JobRunner`:

--- a/common/jd/lifecycle/manager.go
+++ b/common/jd/lifecycle/manager.go
@@ -262,8 +262,8 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 
 	// Persist the proposal as pending BEFORE attempting StartJob. This ensures
 	// that a crash between here and MarkJobApproved leaves a recoverable record.
-	// SaveJob only removes the previous pending row; any approved (old) row is preserved.
-	if err := m.jobStore.SaveJob(ctx, proposal.Id, proposal.Version, proposal.Spec); err != nil {
+	// SavePendingJob only removes the previous pending row; any approved (old) row is preserved.
+	if err := m.jobStore.SavePendingJob(ctx, proposal.Id, proposal.Version, proposal.Spec); err != nil {
 		// The job will need to be re-proposed after fixing the error (whatever it may be).
 		m.lggr.Warnw("Failed to persist pending proposal", "error", err)
 	} else {
@@ -305,10 +305,12 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 	}
 
 	// StartJob succeeded - promote the pending record to approved.
-	if err := m.jobStore.MarkJobApproved(ctx); err != nil {
-		m.lggr.Warnw("Failed to mark job as approved in store", "error", err)
+	if promoted, err := m.jobStore.AcceptPendingJob(ctx); err != nil {
+		m.lggr.Warnw("Failed to accept pending job in store", "error", err)
 		// Continue anyway - the job is running. The store record stays 'pending', so the
 		// next restart will retry via the pending recovery path.
+	} else if !promoted {
+		m.lggr.Warnw("AcceptPendingJob reported no pending row — store may be inconsistent")
 	}
 
 	// Update in-memory state
@@ -373,8 +375,10 @@ func (m *Manager) retryPendingJob(job *store.Job) error {
 		return fmt.Errorf("failed to start pending job: %w", err)
 	}
 
-	if err := m.jobStore.MarkJobApproved(ctx); err != nil {
-		m.lggr.Warnw("Failed to mark pending job as approved in store", "error", err)
+	if promoted, err := m.jobStore.AcceptPendingJob(ctx); err != nil {
+		m.lggr.Warnw("Failed to accept pending job in store", "error", err)
+	} else if !promoted {
+		m.lggr.Warnw("AcceptPendingJob reported no pending row — store may be inconsistent")
 	}
 
 	m.mu.Lock()
@@ -420,7 +424,7 @@ func (m *Manager) handleDelete(req *pb.DeleteJobRequest) error {
 			m.mu.Lock()
 			m.pendingJob = nil
 			m.mu.Unlock()
-			if err := m.jobStore.DeleteJob(ctx); err != nil {
+			if err := m.jobStore.DeleteAllJobs(ctx); err != nil {
 				m.lggr.Warnw("Failed to clear pending job", "error", err)
 			}
 			return nil
@@ -444,7 +448,7 @@ func (m *Manager) handleDelete(req *pb.DeleteJobRequest) error {
 	}
 
 	// Clear persisted job
-	if err := m.jobStore.DeleteJob(ctx); err != nil {
+	if err := m.jobStore.DeleteAllJobs(ctx); err != nil {
 		m.lggr.Warnw("Failed to clear persisted job", "error", err)
 		// Continue anyway
 	}

--- a/common/jd/lifecycle/manager.go
+++ b/common/jd/lifecycle/manager.go
@@ -246,8 +246,10 @@ func (m *Manager) eventLoop() {
 
 // handleProposal processes a new job proposal from JD.
 // Order: persist pending → stop old job → start new job → mark approved → approve with JD.
-// If StartJob fails, the pending record in the store survives and drives a retry on next
-// restart + JD reconnect.
+//
+// On StartJob failure with no prior job: the pending store record survives for restart recovery.
+// On StartJob failure during a replacement: the pending record is deleted and the old job is
+// restarted from the in-memory snapshot so the job keeps running.
 func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 	m.lggr.Infow("Handling job proposal",
 		"proposalID", proposal.Id,
@@ -260,6 +262,7 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 
 	// Persist the proposal as pending BEFORE attempting StartJob. This ensures
 	// that a crash between here and MarkJobApproved leaves a recoverable record.
+	// SaveJob only removes the previous pending row; any approved (old) row is preserved.
 	if err := m.jobStore.SaveJob(ctx, proposal.Id, proposal.Version, proposal.Spec); err != nil {
 		// The job will need to be re-proposed after fixing the error (whatever it may be).
 		m.lggr.Warnw("Failed to persist pending proposal", "error", err)
@@ -269,6 +272,7 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 
 	m.mu.Lock()
 	wasRunning := m.state == StateRunning
+	currentJob := m.currentJob // snapshot for fallback; non-nil when wasRunning
 	m.mu.Unlock()
 
 	// If we have a running job, stop it first
@@ -281,6 +285,10 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 
 	// Start the new job
 	if err := m.runner.StartJob(ctx, proposal.Spec); err != nil {
+		if wasRunning {
+			return m.rollbackReplacement(ctx, proposal.Id, err, currentJob)
+		}
+		// No old job to fall back to: leave pending record for restart recovery.
 		m.mu.Lock()
 		m.state = StateWaitingForJob
 		m.currentJob = nil
@@ -327,6 +335,26 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 	)
 
 	return nil
+}
+
+// rollbackReplacement is called when StartJob fails during a proposal replacement.
+// It removes the pending store record and restarts the old job to keep the job running.
+func (m *Manager) rollbackReplacement(ctx context.Context, newProposalID string, startErr error, oldJob *store.Job) error {
+	if delErr := m.jobStore.DeletePendingJob(ctx); delErr != nil {
+		m.lggr.Warnw("Failed to remove pending record during rollback", "error", delErr)
+	}
+	m.lggr.Infow("Restarting previous job after replacement failure",
+		"newProposalID", newProposalID,
+		"fallbackProposalID", oldJob.ProposalID,
+	)
+	if restartErr := m.runner.StartJob(ctx, oldJob.Spec); restartErr != nil {
+		m.lggr.Errorw("Failed to restart previous job after replacement failure", "error", restartErr)
+		m.mu.Lock()
+		m.state = StateWaitingForJob
+		m.currentJob = nil
+		m.mu.Unlock()
+	}
+	return fmt.Errorf("failed to start replacement job: %w", startErr)
 }
 
 // retryPendingJob attempts to start the pending job after JD has reconnected.

--- a/common/jd/lifecycle/manager_test.go
+++ b/common/jd/lifecycle/manager_test.go
@@ -362,7 +362,7 @@ func TestManager_Start_PendingCachedJob_RetriedOnJDConnect(t *testing.T) {
 	}
 	jobStore := mocks.NewMockStoreInterface(t)
 	jobStore.EXPECT().LoadJob(mock.Anything).Return(pendingJob, nil)
-	jobStore.EXPECT().MarkJobApproved(mock.Anything).Return(nil).Maybe()
+	jobStore.EXPECT().AcceptPendingJob(mock.Anything).Return(true, nil).Maybe()
 
 	runner := mocks.NewMockJobRunner(t)
 	runner.EXPECT().StartJob(mock.Anything, pendingJob.Spec).Return(nil).Maybe()
@@ -437,8 +437,8 @@ func TestManager_EventLoop_Proposal_StartsJobAndApproves(t *testing.T) {
 
 	jobStore := mocks.NewMockStoreInterface(t)
 	jobStore.EXPECT().LoadJob(mock.Anything).Return(nil, store.ErrNoJob)
-	jobStore.EXPECT().SaveJob(mock.Anything, "proposal-1", int64(2), `{"spec":"new"}`).Return(nil).Maybe()
-	jobStore.EXPECT().MarkJobApproved(mock.Anything).Return(nil).Maybe()
+	jobStore.EXPECT().SavePendingJob(mock.Anything, "proposal-1", int64(2), `{"spec":"new"}`).Return(nil).Maybe()
+	jobStore.EXPECT().AcceptPendingJob(mock.Anything).Return(true, nil).Maybe()
 
 	runner := mocks.NewMockJobRunner(t)
 	runner.EXPECT().StartJob(mock.Anything, `{"spec":"new"}`).Return(nil).Maybe()
@@ -479,9 +479,9 @@ func TestManager_EventLoop_Delete_StopsJobAndClearsState(t *testing.T) {
 
 	jobStore := mocks.NewMockStoreInterface(t)
 	jobStore.EXPECT().LoadJob(mock.Anything).Return(nil, store.ErrNoJob)
-	jobStore.EXPECT().SaveJob(mock.Anything, "proposal-1", int64(1), `{"spec":"job1"}`).Return(nil).Maybe()
-	jobStore.EXPECT().MarkJobApproved(mock.Anything).Return(nil).Maybe()
-	jobStore.EXPECT().DeleteJob(mock.Anything).Return(nil).Maybe()
+	jobStore.EXPECT().SavePendingJob(mock.Anything, "proposal-1", int64(1), `{"spec":"job1"}`).Return(nil).Maybe()
+	jobStore.EXPECT().AcceptPendingJob(mock.Anything).Return(true, nil).Maybe()
+	jobStore.EXPECT().DeleteAllJobs(mock.Anything).Return(nil).Maybe()
 
 	runner := mocks.NewMockJobRunner(t)
 	runner.EXPECT().StartJob(mock.Anything, `{"spec":"job1"}`).Return(nil).Maybe()
@@ -524,8 +524,8 @@ func TestManager_EventLoop_Delete_DifferentJob_Ignored(t *testing.T) {
 
 	jobStore := mocks.NewMockStoreInterface(t)
 	jobStore.EXPECT().LoadJob(mock.Anything).Return(nil, store.ErrNoJob)
-	jobStore.EXPECT().SaveJob(mock.Anything, "proposal-1", int64(1), `{"spec":"job1"}`).Return(nil).Maybe()
-	jobStore.EXPECT().MarkJobApproved(mock.Anything).Return(nil).Maybe()
+	jobStore.EXPECT().SavePendingJob(mock.Anything, "proposal-1", int64(1), `{"spec":"job1"}`).Return(nil).Maybe()
+	jobStore.EXPECT().AcceptPendingJob(mock.Anything).Return(true, nil).Maybe()
 	// DeleteJob should not be called (delete was for different id)
 
 	runner := mocks.NewMockJobRunner(t)
@@ -578,7 +578,7 @@ func TestManager_EventLoop_Proposal_Replacement_StartFails_FallsBackToOldJob(t *
 	}
 	jobStore := mocks.NewMockStoreInterface(t)
 	jobStore.EXPECT().LoadJob(mock.Anything).Return(cachedJob, nil)
-	jobStore.EXPECT().SaveJob(mock.Anything, "new-id", int64(2), `{"spec":"new"}`).Return(nil).Maybe()
+	jobStore.EXPECT().SavePendingJob(mock.Anything, "new-id", int64(2), `{"spec":"new"}`).Return(nil).Maybe()
 	jobStore.EXPECT().DeletePendingJob(mock.Anything).Return(nil).Maybe()
 
 	runner := mocks.NewMockJobRunner(t)
@@ -630,7 +630,7 @@ func TestManager_EventLoop_Proposal_Replacement_StartFails_OldJobRestartAlsoFail
 	}
 	jobStore := mocks.NewMockStoreInterface(t)
 	jobStore.EXPECT().LoadJob(mock.Anything).Return(cachedJob, nil)
-	jobStore.EXPECT().SaveJob(mock.Anything, "new-id", int64(2), `{"spec":"new"}`).Return(nil).Maybe()
+	jobStore.EXPECT().SavePendingJob(mock.Anything, "new-id", int64(2), `{"spec":"new"}`).Return(nil).Maybe()
 	jobStore.EXPECT().DeletePendingJob(mock.Anything).Return(nil).Maybe()
 
 	runner := mocks.NewMockJobRunner(t)

--- a/common/jd/lifecycle/manager_test.go
+++ b/common/jd/lifecycle/manager_test.go
@@ -558,6 +558,108 @@ func TestManager_EventLoop_Delete_DifferentJob_Ignored(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestManager_EventLoop_Proposal_Replacement_StartFails_FallsBackToOldJob verifies that when a
+// replacement proposal's StartJob fails, the manager deletes the pending record, restarts the
+// old job, and remains in the Running state.
+func TestManager_EventLoop_Proposal_Replacement_StartFails_FallsBackToOldJob(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	jdClient := newChanClient(t)
+	jdClient.EXPECT().Connect(mock.Anything).Return(nil)
+	jdClient.EXPECT().Close().Return(nil).Maybe()
+	jdClient.EXPECT().ApproveJob(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	cachedJob := &store.Job{
+		ProposalID: "old-id",
+		Version:    1,
+		Spec:       `{"spec":"old"}`,
+		Status:     store.JobStatusApproved,
+	}
+	jobStore := mocks.NewMockStoreInterface(t)
+	jobStore.EXPECT().LoadJob(mock.Anything).Return(cachedJob, nil)
+	jobStore.EXPECT().SaveJob(mock.Anything, "new-id", int64(2), `{"spec":"new"}`).Return(nil).Maybe()
+	jobStore.EXPECT().DeletePendingJob(mock.Anything).Return(nil).Maybe()
+
+	runner := mocks.NewMockJobRunner(t)
+	// Initial start of cached job.
+	runner.EXPECT().StartJob(mock.Anything, `{"spec":"old"}`).Return(nil).Times(2) // initial + fallback restart
+	runner.EXPECT().StopJob(mock.Anything).Return(nil).Maybe()
+	// Replacement attempt fails.
+	runner.EXPECT().StartJob(mock.Anything, `{"spec":"new"}`).Return(errors.New("start failed")).Maybe()
+
+	m, err := NewManager(Config{
+		JDClient: jdClient,
+		JobStore: jobStore,
+		Runner:   runner,
+		Logger:   logger.Test(t),
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Start(ctx))
+	assert.Equal(t, StateRunning, m.GetState())
+
+	jdClient.proposalCh <- &pb.ProposeJobRequest{
+		Id:      "new-id",
+		Version: 2,
+		Spec:    `{"spec":"new"}`,
+	}
+
+	// Give event loop time to process the failed replacement and fallback.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, StateRunning, m.GetState())
+
+	require.NoError(t, m.Stop())
+}
+
+// TestManager_EventLoop_Proposal_Replacement_StartFails_OldJobRestartAlsoFails verifies that
+// when both the replacement StartJob and the old-job restart fail, the manager transitions to
+// WaitingForJob.
+func TestManager_EventLoop_Proposal_Replacement_StartFails_OldJobRestartAlsoFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	jdClient := newChanClient(t)
+	jdClient.EXPECT().Connect(mock.Anything).Return(nil)
+	jdClient.EXPECT().Close().Return(nil).Maybe()
+
+	cachedJob := &store.Job{
+		ProposalID: "old-id",
+		Version:    1,
+		Spec:       `{"spec":"old"}`,
+		Status:     store.JobStatusApproved,
+	}
+	jobStore := mocks.NewMockStoreInterface(t)
+	jobStore.EXPECT().LoadJob(mock.Anything).Return(cachedJob, nil)
+	jobStore.EXPECT().SaveJob(mock.Anything, "new-id", int64(2), `{"spec":"new"}`).Return(nil).Maybe()
+	jobStore.EXPECT().DeletePendingJob(mock.Anything).Return(nil).Maybe()
+
+	runner := mocks.NewMockJobRunner(t)
+	runner.EXPECT().StartJob(mock.Anything, `{"spec":"old"}`).Return(nil).Once() // initial start
+	runner.EXPECT().StopJob(mock.Anything).Return(nil).Maybe()
+	runner.EXPECT().StartJob(mock.Anything, `{"spec":"new"}`).Return(errors.New("start failed")).Maybe()
+	runner.EXPECT().StartJob(mock.Anything, `{"spec":"old"}`).Return(errors.New("restart failed")).Maybe() // fallback fails
+
+	m, err := NewManager(Config{
+		JDClient: jdClient,
+		JobStore: jobStore,
+		Runner:   runner,
+		Logger:   logger.Test(t),
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Start(ctx))
+	assert.Equal(t, StateRunning, m.GetState())
+
+	jdClient.proposalCh <- &pb.ProposeJobRequest{
+		Id:      "new-id",
+		Version: 2,
+		Spec:    `{"spec":"new"}`,
+	}
+
+	require.Eventually(t, func() bool { return m.GetState() == StateWaitingForJob }, tests.WaitTimeout(t), 50*time.Millisecond)
+
+	require.NoError(t, m.Stop())
+}
+
 func TestManager_Stop_WithoutStart_ReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/common/jd/store/pg.go
+++ b/common/jd/store/pg.go
@@ -67,26 +67,32 @@ func (s *PostgresStore) SavePendingJob(ctx context.Context, proposalID string, v
 
 // AcceptPendingJob promotes the pending record to approved, replacing any old approved record.
 // Returns true if a pending record was promoted, false if none existed.
-// Two separate statements are required: PostgreSQL data-modifying CTEs use the same snapshot
-// for both the CTE and the main query, so a combined DELETE+UPDATE CTE would violate the
-// UNIQUE(status) constraint even though the net result would be valid.
+// The DELETE and UPDATE run in a transaction so that a failure on the UPDATE rolls back the
+// DELETE — preventing the approved row from being silently lost.
+// A data-modifying CTE cannot be used instead because PostgreSQL CTEs share the same snapshot,
+// causing the UPDATE to see the approved row as still present and violate UNIQUE(status).
 func (s *PostgresStore) AcceptPendingJob(ctx context.Context) (bool, error) {
-	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store WHERE status = 'approved'`)
-	if err != nil {
-		return false, fmt.Errorf("failed to remove old approved job: %w", err)
-	}
+	var promoted bool
+	err := sqlutil.TransactDataSource(ctx, s.ds, nil, func(tx sqlutil.DataSource) error {
+		_, err := tx.ExecContext(ctx, `DELETE FROM job_store WHERE status = 'approved'`)
+		if err != nil {
+			return fmt.Errorf("failed to remove old approved job: %w", err)
+		}
 
-	result, err := s.ds.ExecContext(ctx,
-		`UPDATE job_store SET status = 'approved', updated_at = NOW() WHERE status = 'pending'`,
-	)
-	if err != nil {
-		return false, fmt.Errorf("failed to accept pending job: %w", err)
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("failed to get rows affected: %w", err)
-	}
-	return rows > 0, nil
+		result, err := tx.ExecContext(ctx,
+			`UPDATE job_store SET status = 'approved', updated_at = NOW() WHERE status = 'pending'`,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to accept pending job: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+		promoted = rows > 0
+		return nil
+	})
+	return promoted, err
 }
 
 // LoadJob retrieves the active job from the store.

--- a/common/jd/store/pg.go
+++ b/common/jd/store/pg.go
@@ -44,47 +44,44 @@ func NewPostgresStore(ds sqlutil.DataSource) *PostgresStore {
 	return &PostgresStore{ds: ds}
 }
 
-// SaveJob persists a new proposal as pending.
-// Any existing pending row is replaced; any existing approved row is preserved so that
-// a failed replacement can fall back to the old job on restart.
-func (s *PostgresStore) SaveJob(ctx context.Context, proposalID string, version int64, spec string) error {
-	// Only remove a previous pending row — the approved row (old job) must survive
-	// until the new job is confirmed running via MarkJobApproved.
-	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store WHERE status = 'pending'`)
-	if err != nil {
-		return fmt.Errorf("failed to clear pending job: %w", err)
-	}
-
-	_, err = s.ds.ExecContext(ctx,
+// SavePendingJob persists a new proposal as pending.
+// Any existing pending row is replaced via ON CONFLICT; any existing approved row is preserved
+// so that a failed replacement can fall back to the old job on restart.
+func (s *PostgresStore) SavePendingJob(ctx context.Context, proposalID string, version int64, spec string) error {
+	_, err := s.ds.ExecContext(ctx,
 		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
-		 VALUES ($1, $2, $3, 'pending', NOW(), NOW())`,
+		 VALUES ($1, $2, $3, 'pending', NOW(), NOW())
+		 ON CONFLICT (status) DO UPDATE SET
+		     proposal_id = EXCLUDED.proposal_id,
+		     version     = EXCLUDED.version,
+		     spec        = EXCLUDED.spec,
+		     updated_at  = NOW()
+		 WHERE job_store.status = 'pending'`,
 		proposalID, version, spec,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to save job: %w", err)
+		return fmt.Errorf("failed to save pending job: %w", err)
 	}
-
 	return nil
 }
 
-// MarkJobApproved promotes the pending record to approved, atomically replacing the old
-// approved record (if any). Called after StartJob succeeds during a replacement.
-func (s *PostgresStore) MarkJobApproved(ctx context.Context) error {
-	// Remove the old approved row first so the unique(status) constraint allows the update.
-	// A crash between the two statements leaves only a pending row → pending recovery path on restart.
-	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store WHERE status = 'approved'`)
-	if err != nil {
-		return fmt.Errorf("failed to remove old approved job: %w", err)
-	}
-
-	_, err = s.ds.ExecContext(ctx,
-		`UPDATE job_store SET status = 'approved', updated_at = NOW() WHERE status = 'pending'`,
+// AcceptPendingJob promotes the pending record to approved, atomically replacing any old
+// approved record. Returns true if a pending record was promoted, false if none existed.
+func (s *PostgresStore) AcceptPendingJob(ctx context.Context) (bool, error) {
+	result, err := s.ds.ExecContext(ctx,
+		`WITH deleted AS (
+		     DELETE FROM job_store WHERE status = 'approved'
+		 )
+		 UPDATE job_store SET status = 'approved', updated_at = NOW() WHERE status = 'pending'`,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to mark job approved: %w", err)
+		return false, fmt.Errorf("failed to accept pending job: %w", err)
 	}
-
-	return nil
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	return rows > 0, nil
 }
 
 // LoadJob retrieves the active job from the store.
@@ -96,7 +93,7 @@ func (s *PostgresStore) LoadJob(ctx context.Context) (*Job, error) {
 	err := s.ds.SelectContext(ctx, &rows,
 		`SELECT proposal_id, version, spec, status, created_at, updated_at
 		 FROM job_store
-		 ORDER BY CASE WHEN status = 'approved' THEN 0 ELSE 1 END, id DESC
+		 ORDER BY (status = 'approved') DESC, id DESC
 		 LIMIT 1`,
 	)
 	if err != nil {
@@ -133,12 +130,12 @@ func (s *PostgresStore) HasJob(ctx context.Context) (bool, error) {
 	return counts[0] > 0, nil
 }
 
-// DeleteJob removes all persisted job records.
+// DeleteAllJobs removes all persisted job records.
 // Called when JD sends a delete request.
-func (s *PostgresStore) DeleteJob(ctx context.Context) error {
+func (s *PostgresStore) DeleteAllJobs(ctx context.Context) error {
 	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store`)
 	if err != nil {
-		return fmt.Errorf("failed to delete job: %w", err)
+		return fmt.Errorf("failed to delete jobs: %w", err)
 	}
 	return nil
 }

--- a/common/jd/store/pg.go
+++ b/common/jd/store/pg.go
@@ -65,14 +65,19 @@ func (s *PostgresStore) SavePendingJob(ctx context.Context, proposalID string, v
 	return nil
 }
 
-// AcceptPendingJob promotes the pending record to approved, atomically replacing any old
-// approved record. Returns true if a pending record was promoted, false if none existed.
+// AcceptPendingJob promotes the pending record to approved, replacing any old approved record.
+// Returns true if a pending record was promoted, false if none existed.
+// Two separate statements are required: PostgreSQL data-modifying CTEs use the same snapshot
+// for both the CTE and the main query, so a combined DELETE+UPDATE CTE would violate the
+// UNIQUE(status) constraint even though the net result would be valid.
 func (s *PostgresStore) AcceptPendingJob(ctx context.Context) (bool, error) {
+	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store WHERE status = 'approved'`)
+	if err != nil {
+		return false, fmt.Errorf("failed to remove old approved job: %w", err)
+	}
+
 	result, err := s.ds.ExecContext(ctx,
-		`WITH deleted AS (
-		     DELETE FROM job_store WHERE status = 'approved'
-		 )
-		 UPDATE job_store SET status = 'approved', updated_at = NOW() WHERE status = 'pending'`,
+		`UPDATE job_store SET status = 'approved', updated_at = NOW() WHERE status = 'pending'`,
 	)
 	if err != nil {
 		return false, fmt.Errorf("failed to accept pending job: %w", err)

--- a/common/jd/store/pg.go
+++ b/common/jd/store/pg.go
@@ -36,20 +36,23 @@ type PostgresStore struct {
 		spec TEXT NOT NULL,
 		status TEXT NOT NULL DEFAULT 'approved' CHECK (status IN ('pending', 'approved')),
 		created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-		updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+		CONSTRAINT job_store_unique_status UNIQUE (status)
 	);
 */
 func NewPostgresStore(ds sqlutil.DataSource) *PostgresStore {
 	return &PostgresStore{ds: ds}
 }
 
-// SaveJob persists a job spec as pending, replacing any existing job.
-// Only one job should be active at a time.
+// SaveJob persists a new proposal as pending.
+// Any existing pending row is replaced; any existing approved row is preserved so that
+// a failed replacement can fall back to the old job on restart.
 func (s *PostgresStore) SaveJob(ctx context.Context, proposalID string, version int64, spec string) error {
-	// Delete any existing jobs first (we only keep one)
-	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store`)
+	// Only remove a previous pending row — the approved row (old job) must survive
+	// until the new job is confirmed running via MarkJobApproved.
+	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store WHERE status = 'pending'`)
 	if err != nil {
-		return fmt.Errorf("failed to clear existing jobs: %w", err)
+		return fmt.Errorf("failed to clear pending job: %w", err)
 	}
 
 	_, err = s.ds.ExecContext(ctx,
@@ -64,24 +67,37 @@ func (s *PostgresStore) SaveJob(ctx context.Context, proposalID string, version 
 	return nil
 }
 
-// MarkJobApproved transitions the stored job's status from pending to approved.
+// MarkJobApproved promotes the pending record to approved, atomically replacing the old
+// approved record (if any). Called after StartJob succeeds during a replacement.
 func (s *PostgresStore) MarkJobApproved(ctx context.Context) error {
-	_, err := s.ds.ExecContext(ctx,
-		`UPDATE job_store SET status = 'approved', updated_at = NOW()`,
+	// Remove the old approved row first so the unique(status) constraint allows the update.
+	// A crash between the two statements leaves only a pending row → pending recovery path on restart.
+	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store WHERE status = 'approved'`)
+	if err != nil {
+		return fmt.Errorf("failed to remove old approved job: %w", err)
+	}
+
+	_, err = s.ds.ExecContext(ctx,
+		`UPDATE job_store SET status = 'approved', updated_at = NOW() WHERE status = 'pending'`,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to mark job approved: %w", err)
 	}
+
 	return nil
 }
 
-// LoadJob retrieves the current job spec from the store.
+// LoadJob retrieves the active job from the store.
+// When both an approved and a pending row exist (failed replacement), the approved row
+// is returned so the known-good job starts on restart.
 // Returns ErrNoJob if no job is found.
 func (s *PostgresStore) LoadJob(ctx context.Context) (*Job, error) {
 	var rows []jobRow
 	err := s.ds.SelectContext(ctx, &rows,
 		`SELECT proposal_id, version, spec, status, created_at, updated_at
-		 FROM job_store ORDER BY id DESC LIMIT 1`,
+		 FROM job_store
+		 ORDER BY CASE WHEN status = 'approved' THEN 0 ELSE 1 END, id DESC
+		 LIMIT 1`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load job: %w", err)
@@ -117,12 +133,22 @@ func (s *PostgresStore) HasJob(ctx context.Context) (bool, error) {
 	return counts[0] > 0, nil
 }
 
-// DeleteJob removes the persisted job from the store.
-// This is called when JD sends a delete request.
+// DeleteJob removes all persisted job records.
+// Called when JD sends a delete request.
 func (s *PostgresStore) DeleteJob(ctx context.Context) error {
 	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store`)
 	if err != nil {
 		return fmt.Errorf("failed to delete job: %w", err)
+	}
+	return nil
+}
+
+// DeletePendingJob removes only the pending record, leaving any approved record intact.
+// Called to rollback a failed replacement proposal.
+func (s *PostgresStore) DeletePendingJob(ctx context.Context) error {
+	_, err := s.ds.ExecContext(ctx, `DELETE FROM job_store WHERE status = 'pending'`)
+	if err != nil {
+		return fmt.Errorf("failed to delete pending job: %w", err)
 	}
 	return nil
 }

--- a/common/jd/store/pg_test.go
+++ b/common/jd/store/pg_test.go
@@ -292,6 +292,80 @@ func TestPostgresStore_AcceptPendingJob_WithTwoRows(t *testing.T) {
 	assert.Equal(t, 1, counts[0])
 }
 
+// TestPostgresStore_AcceptPendingJob_WhenEmpty verifies that AcceptPendingJob is a no-op
+// when there are no rows, returning false without error.
+func TestPostgresStore_AcceptPendingJob_WhenEmpty(t *testing.T) {
+	s, _, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	promoted, err := s.AcceptPendingJob(ctx)
+	require.NoError(t, err)
+	assert.False(t, promoted)
+}
+
+// TestPostgresStore_AcceptPendingJob_OnlyApprovedRow documents that calling AcceptPendingJob
+// when only an approved row exists deletes it and returns false — the job is lost.
+// This cannot happen via normal manager flow but is a footgun callers should be aware of.
+func TestPostgresStore_AcceptPendingJob_OnlyApprovedRow(t *testing.T) {
+	s, _, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, s.SavePendingJob(ctx, "proposal-1", 1, `{}`))
+	_, err := s.AcceptPendingJob(ctx)
+	require.NoError(t, err)
+
+	// Now only an approved row remains — call AcceptPendingJob again with no pending row.
+	promoted, err := s.AcceptPendingJob(ctx)
+	require.NoError(t, err)
+	assert.False(t, promoted)
+
+	// The approved row has been deleted — store is now empty.
+	_, err = s.LoadJob(ctx)
+	assert.ErrorIs(t, err, ErrNoJob)
+}
+
+// TestPostgresStore_SavePendingJob_WithBothRows verifies that SavePendingJob updates the
+// existing pending row in-place when both rows exist, leaving the approved row untouched.
+func TestPostgresStore_SavePendingJob_WithBothRows(t *testing.T) {
+	s, ds, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := ds.ExecContext(ctx,
+		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
+		 VALUES ('approved-job', 1, '{"v":1}', 'approved', NOW(), NOW())`)
+	require.NoError(t, err)
+	_, err = ds.ExecContext(ctx,
+		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
+		 VALUES ('old-pending', 2, '{"v":2}', 'pending', NOW(), NOW())`)
+	require.NoError(t, err)
+
+	// SavePendingJob should update the pending row, not insert a third row.
+	require.NoError(t, s.SavePendingJob(ctx, "new-pending", 3, `{"v":3}`))
+
+	// Approved row is untouched.
+	job, err := s.LoadJob(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "approved-job", job.ProposalID)
+	assert.Equal(t, JobStatusApproved, job.Status)
+
+	// Exactly two rows in total (no third row inserted).
+	var counts []int
+	require.NoError(t, ds.SelectContext(ctx, &counts, `SELECT COUNT(*) FROM job_store`))
+	assert.Equal(t, 2, counts[0])
+
+	// Pending row reflects the new values.
+	var pending []jobRow
+	require.NoError(t, ds.SelectContext(ctx, &pending,
+		`SELECT proposal_id, version, spec, status, created_at, updated_at
+		 FROM job_store WHERE status = 'pending'`))
+	require.Len(t, pending, 1)
+	assert.Equal(t, "new-pending", pending[0].ProposalID)
+	assert.Equal(t, int64(3), pending[0].Version)
+}
+
 func TestPostgresStore_DeletePendingJob_OnlyPendingRow(t *testing.T) {
 	s, _, cleanup := setupPostgresStore(t)
 	defer cleanup()

--- a/common/jd/store/pg_test.go
+++ b/common/jd/store/pg_test.go
@@ -120,7 +120,7 @@ func TestPostgresStore_SaveAndLoadJob(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNoJob)
 
-	err = s.SaveJob(ctx, "proposal-1", 1, `{"type":"ccv"}`)
+	err = s.SavePendingJob(ctx, "proposal-1", 1, `{"type":"ccv"}`)
 	require.NoError(t, err)
 
 	job, err := s.LoadJob(ctx)
@@ -132,18 +132,19 @@ func TestPostgresStore_SaveAndLoadJob(t *testing.T) {
 	assert.Equal(t, JobStatusPending, job.Status)
 }
 
-func TestPostgresStore_MarkJobApproved(t *testing.T) {
+func TestPostgresStore_AcceptPendingJob(t *testing.T) {
 	s, _, cleanup := setupPostgresStore(t)
 	defer cleanup()
 	ctx := context.Background()
 
-	require.NoError(t, s.SaveJob(ctx, "proposal-1", 1, `{"type":"ccv"}`))
+	require.NoError(t, s.SavePendingJob(ctx, "proposal-1", 1, `{"type":"ccv"}`))
 
 	job, err := s.LoadJob(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, JobStatusPending, job.Status)
 
-	require.NoError(t, s.MarkJobApproved(ctx))
+	_, err = s.AcceptPendingJob(ctx)
+	require.NoError(t, err)
 
 	job, err = s.LoadJob(ctx)
 	require.NoError(t, err)
@@ -155,8 +156,8 @@ func TestPostgresStore_SaveReplacesExistingJob(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
-	require.NoError(t, s.SaveJob(ctx, "proposal-1", 1, `{"v":1}`))
-	require.NoError(t, s.SaveJob(ctx, "proposal-2", 2, `{"v":2}`))
+	require.NoError(t, s.SavePendingJob(ctx, "proposal-1", 1, `{"v":1}`))
+	require.NoError(t, s.SavePendingJob(ctx, "proposal-2", 2, `{"v":2}`))
 
 	job, err := s.LoadJob(ctx)
 	require.NoError(t, err)
@@ -175,38 +176,38 @@ func TestPostgresStore_HasJob(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, has)
 
-	require.NoError(t, s.SaveJob(ctx, "p1", 1, "spec"))
+	require.NoError(t, s.SavePendingJob(ctx, "p1", 1, "spec"))
 	has, err = s.HasJob(ctx)
 	require.NoError(t, err)
 	assert.True(t, has)
 
-	require.NoError(t, s.DeleteJob(ctx))
+	require.NoError(t, s.DeleteAllJobs(ctx))
 	has, err = s.HasJob(ctx)
 	require.NoError(t, err)
 	assert.False(t, has)
 }
 
-func TestPostgresStore_DeleteJob(t *testing.T) {
+func TestPostgresStore_DeleteAllJobs(t *testing.T) {
 	s, _, cleanup := setupPostgresStore(t)
 	defer cleanup()
 	ctx := context.Background()
 
-	require.NoError(t, s.SaveJob(ctx, "proposal-1", 1, `{}`))
-	require.NoError(t, s.DeleteJob(ctx))
+	require.NoError(t, s.SavePendingJob(ctx, "proposal-1", 1, `{}`))
+	require.NoError(t, s.DeleteAllJobs(ctx))
 
 	_, err := s.LoadJob(ctx)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNoJob)
 
-	require.NoError(t, s.DeleteJob(ctx))
+	require.NoError(t, s.DeleteAllJobs(ctx))
 }
 
-func TestPostgresStore_DeleteJob_WhenEmpty(t *testing.T) {
+func TestPostgresStore_DeleteAllJobs_WhenEmpty(t *testing.T) {
 	s, _, cleanup := setupPostgresStore(t)
 	defer cleanup()
 	ctx := context.Background()
 
-	require.NoError(t, s.DeleteJob(ctx))
+	require.NoError(t, s.DeleteAllJobs(ctx))
 }
 
 func TestPostgresStore_NewPostgresStore(t *testing.T) {
@@ -224,11 +225,12 @@ func TestPostgresStore_SavePreservesApprovedRow(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
-	require.NoError(t, s.SaveJob(ctx, "proposal-1", 1, `{"v":1}`))
-	require.NoError(t, s.MarkJobApproved(ctx))
+	require.NoError(t, s.SavePendingJob(ctx, "proposal-1", 1, `{"v":1}`))
+	_, err := s.AcceptPendingJob(ctx)
+	require.NoError(t, err)
 
 	// Save a replacement proposal — approved row must survive.
-	require.NoError(t, s.SaveJob(ctx, "proposal-2", 2, `{"v":2}`))
+	require.NoError(t, s.SavePendingJob(ctx, "proposal-2", 2, `{"v":2}`))
 
 	// LoadJob should return the approved (old) row.
 	job, err := s.LoadJob(ctx)
@@ -260,9 +262,9 @@ func TestPostgresStore_LoadJob_PrefersApproved(t *testing.T) {
 	assert.Equal(t, JobStatusApproved, job.Status)
 }
 
-// TestPostgresStore_MarkJobApproved_WithTwoRows verifies that MarkJobApproved correctly
+// TestPostgresStore_AcceptPendingJob_WithTwoRows verifies that AcceptPendingJob correctly
 // deletes the old approved row and promotes the pending row when both exist.
-func TestPostgresStore_MarkJobApproved_WithTwoRows(t *testing.T) {
+func TestPostgresStore_AcceptPendingJob_WithTwoRows(t *testing.T) {
 	s, ds, cleanup := setupPostgresStore(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -276,7 +278,8 @@ func TestPostgresStore_MarkJobApproved_WithTwoRows(t *testing.T) {
 		 VALUES ('new-job', 2, '{"v":2}', 'pending', NOW(), NOW())`)
 	require.NoError(t, err)
 
-	require.NoError(t, s.MarkJobApproved(ctx))
+	_, err = s.AcceptPendingJob(ctx)
+	require.NoError(t, err)
 
 	job, err := s.LoadJob(ctx)
 	require.NoError(t, err)
@@ -294,7 +297,7 @@ func TestPostgresStore_DeletePendingJob_OnlyPendingRow(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
-	require.NoError(t, s.SaveJob(ctx, "proposal-1", 1, `{}`))
+	require.NoError(t, s.SavePendingJob(ctx, "proposal-1", 1, `{}`))
 	require.NoError(t, s.DeletePendingJob(ctx))
 
 	_, err := s.LoadJob(ctx)

--- a/common/jd/store/pg_test.go
+++ b/common/jd/store/pg_test.go
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS job_store (
 	spec TEXT NOT NULL,
 	status TEXT NOT NULL DEFAULT 'approved' CHECK (status IN ('pending', 'approved')),
 	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	CONSTRAINT job_store_unique_status UNIQUE (status)
 );
 `
 
@@ -214,4 +215,118 @@ func TestPostgresStore_NewPostgresStore(t *testing.T) {
 
 	store := NewPostgresStore(ds)
 	require.NotNil(t, store)
+}
+
+// TestPostgresStore_SavePreservesApprovedRow verifies that saving a new pending proposal
+// does not delete an existing approved row (needed for replacement fallback).
+func TestPostgresStore_SavePreservesApprovedRow(t *testing.T) {
+	s, _, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, s.SaveJob(ctx, "proposal-1", 1, `{"v":1}`))
+	require.NoError(t, s.MarkJobApproved(ctx))
+
+	// Save a replacement proposal — approved row must survive.
+	require.NoError(t, s.SaveJob(ctx, "proposal-2", 2, `{"v":2}`))
+
+	// LoadJob should return the approved (old) row.
+	job, err := s.LoadJob(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "proposal-1", job.ProposalID)
+	assert.Equal(t, JobStatusApproved, job.Status)
+}
+
+// TestPostgresStore_LoadJob_PrefersApproved verifies that when both rows exist,
+// the approved row is returned (drives restart to the known-good job).
+func TestPostgresStore_LoadJob_PrefersApproved(t *testing.T) {
+	s, ds, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Insert both rows directly to set up the two-row state.
+	_, err := ds.ExecContext(ctx,
+		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
+		 VALUES ('approved-job', 1, '{"v":1}', 'approved', NOW(), NOW())`)
+	require.NoError(t, err)
+	_, err = ds.ExecContext(ctx,
+		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
+		 VALUES ('pending-job', 2, '{"v":2}', 'pending', NOW(), NOW())`)
+	require.NoError(t, err)
+
+	job, err := s.LoadJob(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "approved-job", job.ProposalID)
+	assert.Equal(t, JobStatusApproved, job.Status)
+}
+
+// TestPostgresStore_MarkJobApproved_WithTwoRows verifies that MarkJobApproved correctly
+// deletes the old approved row and promotes the pending row when both exist.
+func TestPostgresStore_MarkJobApproved_WithTwoRows(t *testing.T) {
+	s, ds, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := ds.ExecContext(ctx,
+		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
+		 VALUES ('old-job', 1, '{"v":1}', 'approved', NOW(), NOW())`)
+	require.NoError(t, err)
+	_, err = ds.ExecContext(ctx,
+		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
+		 VALUES ('new-job', 2, '{"v":2}', 'pending', NOW(), NOW())`)
+	require.NoError(t, err)
+
+	require.NoError(t, s.MarkJobApproved(ctx))
+
+	job, err := s.LoadJob(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "new-job", job.ProposalID)
+	assert.Equal(t, JobStatusApproved, job.Status)
+
+	// Only one row should remain.
+	var counts []int
+	require.NoError(t, ds.SelectContext(ctx, &counts, `SELECT COUNT(*) FROM job_store`))
+	assert.Equal(t, 1, counts[0])
+}
+
+func TestPostgresStore_DeletePendingJob_OnlyPendingRow(t *testing.T) {
+	s, _, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, s.SaveJob(ctx, "proposal-1", 1, `{}`))
+	require.NoError(t, s.DeletePendingJob(ctx))
+
+	_, err := s.LoadJob(ctx)
+	assert.ErrorIs(t, err, ErrNoJob)
+}
+
+func TestPostgresStore_DeletePendingJob_WithBothRows(t *testing.T) {
+	s, ds, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := ds.ExecContext(ctx,
+		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
+		 VALUES ('approved-job', 1, '{"v":1}', 'approved', NOW(), NOW())`)
+	require.NoError(t, err)
+	_, err = ds.ExecContext(ctx,
+		`INSERT INTO job_store (proposal_id, version, spec, status, created_at, updated_at)
+		 VALUES ('pending-job', 2, '{"v":2}', 'pending', NOW(), NOW())`)
+	require.NoError(t, err)
+
+	require.NoError(t, s.DeletePendingJob(ctx))
+
+	job, err := s.LoadJob(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "approved-job", job.ProposalID)
+	assert.Equal(t, JobStatusApproved, job.Status)
+}
+
+func TestPostgresStore_DeletePendingJob_WhenEmpty(t *testing.T) {
+	s, _, cleanup := setupPostgresStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, s.DeletePendingJob(ctx))
 }

--- a/common/jd/store/store.go
+++ b/common/jd/store/store.go
@@ -30,15 +30,18 @@ type Job struct {
 //
 //revive:disable-next-line:exported
 type StoreInterface interface {
-	// SaveJob persists a new proposal as pending, replacing any existing record.
-	SaveJob(ctx context.Context, proposalID string, version int64, spec string) error
-	// MarkJobApproved transitions the stored record from pending to approved.
-	MarkJobApproved(ctx context.Context) error
+	// SavePendingJob persists a new proposal as pending.
+	// Any existing pending row is replaced; any existing approved row is preserved.
+	SavePendingJob(ctx context.Context, proposalID string, version int64, spec string) error
+	// AcceptPendingJob promotes the pending record to approved, replacing any old approved record.
+	// Returns true if a pending record was found and promoted, false if there was nothing to promote.
+	AcceptPendingJob(ctx context.Context) (bool, error)
 	// LoadJob returns the current job record, or ErrNoJob if none exists.
+	// When both an approved and a pending row exist, the approved row is returned.
 	LoadJob(ctx context.Context) (*Job, error)
-	// DeleteJob removes all persisted records.
-	DeleteJob(ctx context.Context) error
+	// DeleteAllJobs removes all persisted records.
+	DeleteAllJobs(ctx context.Context) error
 	// DeletePendingJob removes only the pending record, leaving any approved record intact.
-	// Used to rollback a failed replacement proposal so the old approved job can be restarted.
+	// Used to rollback a failed replacement proposal.
 	DeletePendingJob(ctx context.Context) error
 }

--- a/common/jd/store/store.go
+++ b/common/jd/store/store.go
@@ -36,6 +36,9 @@ type StoreInterface interface {
 	MarkJobApproved(ctx context.Context) error
 	// LoadJob returns the current job record, or ErrNoJob if none exists.
 	LoadJob(ctx context.Context) (*Job, error)
-	// DeleteJob removes the persisted record.
+	// DeleteJob removes all persisted records.
 	DeleteJob(ctx context.Context) error
+	// DeletePendingJob removes only the pending record, leaving any approved record intact.
+	// Used to rollback a failed replacement proposal so the old approved job can be restarted.
+	DeletePendingJob(ctx context.Context) error
 }

--- a/internal/mocks/mock_StoreInterface.go
+++ b/internal/mocks/mock_StoreInterface.go
@@ -68,6 +68,52 @@ func (_c *MockStoreInterface_DeleteJob_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// DeletePendingJob provides a mock function with given fields: ctx
+func (_m *MockStoreInterface) DeletePendingJob(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeletePendingJob")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStoreInterface_DeletePendingJob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeletePendingJob'
+type MockStoreInterface_DeletePendingJob_Call struct {
+	*mock.Call
+}
+
+// DeletePendingJob is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockStoreInterface_Expecter) DeletePendingJob(ctx interface{}) *MockStoreInterface_DeletePendingJob_Call {
+	return &MockStoreInterface_DeletePendingJob_Call{Call: _e.mock.On("DeletePendingJob", ctx)}
+}
+
+func (_c *MockStoreInterface_DeletePendingJob_Call) Run(run func(ctx context.Context)) *MockStoreInterface_DeletePendingJob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockStoreInterface_DeletePendingJob_Call) Return(_a0 error) *MockStoreInterface_DeletePendingJob_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStoreInterface_DeletePendingJob_Call) RunAndReturn(run func(context.Context) error) *MockStoreInterface_DeletePendingJob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LoadJob provides a mock function with given fields: ctx
 func (_m *MockStoreInterface) LoadJob(ctx context.Context) (*store.Job, error) {
 	ret := _m.Called(ctx)

--- a/internal/mocks/mock_StoreInterface.go
+++ b/internal/mocks/mock_StoreInterface.go
@@ -22,12 +22,68 @@ func (_m *MockStoreInterface) EXPECT() *MockStoreInterface_Expecter {
 	return &MockStoreInterface_Expecter{mock: &_m.Mock}
 }
 
-// DeleteJob provides a mock function with given fields: ctx
-func (_m *MockStoreInterface) DeleteJob(ctx context.Context) error {
+// AcceptPendingJob provides a mock function with given fields: ctx
+func (_m *MockStoreInterface) AcceptPendingJob(ctx context.Context) (bool, error) {
 	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
-		panic("no return value specified for DeleteJob")
+		panic("no return value specified for AcceptPendingJob")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockStoreInterface_AcceptPendingJob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcceptPendingJob'
+type MockStoreInterface_AcceptPendingJob_Call struct {
+	*mock.Call
+}
+
+// AcceptPendingJob is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockStoreInterface_Expecter) AcceptPendingJob(ctx interface{}) *MockStoreInterface_AcceptPendingJob_Call {
+	return &MockStoreInterface_AcceptPendingJob_Call{Call: _e.mock.On("AcceptPendingJob", ctx)}
+}
+
+func (_c *MockStoreInterface_AcceptPendingJob_Call) Run(run func(ctx context.Context)) *MockStoreInterface_AcceptPendingJob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockStoreInterface_AcceptPendingJob_Call) Return(_a0 bool, _a1 error) *MockStoreInterface_AcceptPendingJob_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockStoreInterface_AcceptPendingJob_Call) RunAndReturn(run func(context.Context) (bool, error)) *MockStoreInterface_AcceptPendingJob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteAllJobs provides a mock function with given fields: ctx
+func (_m *MockStoreInterface) DeleteAllJobs(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAllJobs")
 	}
 
 	var r0 error
@@ -40,30 +96,30 @@ func (_m *MockStoreInterface) DeleteJob(ctx context.Context) error {
 	return r0
 }
 
-// MockStoreInterface_DeleteJob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteJob'
-type MockStoreInterface_DeleteJob_Call struct {
+// MockStoreInterface_DeleteAllJobs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAllJobs'
+type MockStoreInterface_DeleteAllJobs_Call struct {
 	*mock.Call
 }
 
-// DeleteJob is a helper method to define mock.On call
+// DeleteAllJobs is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockStoreInterface_Expecter) DeleteJob(ctx interface{}) *MockStoreInterface_DeleteJob_Call {
-	return &MockStoreInterface_DeleteJob_Call{Call: _e.mock.On("DeleteJob", ctx)}
+func (_e *MockStoreInterface_Expecter) DeleteAllJobs(ctx interface{}) *MockStoreInterface_DeleteAllJobs_Call {
+	return &MockStoreInterface_DeleteAllJobs_Call{Call: _e.mock.On("DeleteAllJobs", ctx)}
 }
 
-func (_c *MockStoreInterface_DeleteJob_Call) Run(run func(ctx context.Context)) *MockStoreInterface_DeleteJob_Call {
+func (_c *MockStoreInterface_DeleteAllJobs_Call) Run(run func(ctx context.Context)) *MockStoreInterface_DeleteAllJobs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context))
 	})
 	return _c
 }
 
-func (_c *MockStoreInterface_DeleteJob_Call) Return(_a0 error) *MockStoreInterface_DeleteJob_Call {
+func (_c *MockStoreInterface_DeleteAllJobs_Call) Return(_a0 error) *MockStoreInterface_DeleteAllJobs_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockStoreInterface_DeleteJob_Call) RunAndReturn(run func(context.Context) error) *MockStoreInterface_DeleteJob_Call {
+func (_c *MockStoreInterface_DeleteAllJobs_Call) RunAndReturn(run func(context.Context) error) *MockStoreInterface_DeleteAllJobs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -172,58 +228,12 @@ func (_c *MockStoreInterface_LoadJob_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
-// MarkJobApproved provides a mock function with given fields: ctx
-func (_m *MockStoreInterface) MarkJobApproved(ctx context.Context) error {
-	ret := _m.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for MarkJobApproved")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockStoreInterface_MarkJobApproved_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkJobApproved'
-type MockStoreInterface_MarkJobApproved_Call struct {
-	*mock.Call
-}
-
-// MarkJobApproved is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockStoreInterface_Expecter) MarkJobApproved(ctx interface{}) *MockStoreInterface_MarkJobApproved_Call {
-	return &MockStoreInterface_MarkJobApproved_Call{Call: _e.mock.On("MarkJobApproved", ctx)}
-}
-
-func (_c *MockStoreInterface_MarkJobApproved_Call) Run(run func(ctx context.Context)) *MockStoreInterface_MarkJobApproved_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *MockStoreInterface_MarkJobApproved_Call) Return(_a0 error) *MockStoreInterface_MarkJobApproved_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockStoreInterface_MarkJobApproved_Call) RunAndReturn(run func(context.Context) error) *MockStoreInterface_MarkJobApproved_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SaveJob provides a mock function with given fields: ctx, proposalID, version, spec
-func (_m *MockStoreInterface) SaveJob(ctx context.Context, proposalID string, version int64, spec string) error {
+// SavePendingJob provides a mock function with given fields: ctx, proposalID, version, spec
+func (_m *MockStoreInterface) SavePendingJob(ctx context.Context, proposalID string, version int64, spec string) error {
 	ret := _m.Called(ctx, proposalID, version, spec)
 
 	if len(ret) == 0 {
-		panic("no return value specified for SaveJob")
+		panic("no return value specified for SavePendingJob")
 	}
 
 	var r0 error
@@ -236,33 +246,33 @@ func (_m *MockStoreInterface) SaveJob(ctx context.Context, proposalID string, ve
 	return r0
 }
 
-// MockStoreInterface_SaveJob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveJob'
-type MockStoreInterface_SaveJob_Call struct {
+// MockStoreInterface_SavePendingJob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SavePendingJob'
+type MockStoreInterface_SavePendingJob_Call struct {
 	*mock.Call
 }
 
-// SaveJob is a helper method to define mock.On call
+// SavePendingJob is a helper method to define mock.On call
 //   - ctx context.Context
 //   - proposalID string
 //   - version int64
 //   - spec string
-func (_e *MockStoreInterface_Expecter) SaveJob(ctx interface{}, proposalID interface{}, version interface{}, spec interface{}) *MockStoreInterface_SaveJob_Call {
-	return &MockStoreInterface_SaveJob_Call{Call: _e.mock.On("SaveJob", ctx, proposalID, version, spec)}
+func (_e *MockStoreInterface_Expecter) SavePendingJob(ctx interface{}, proposalID interface{}, version interface{}, spec interface{}) *MockStoreInterface_SavePendingJob_Call {
+	return &MockStoreInterface_SavePendingJob_Call{Call: _e.mock.On("SavePendingJob", ctx, proposalID, version, spec)}
 }
 
-func (_c *MockStoreInterface_SaveJob_Call) Run(run func(ctx context.Context, proposalID string, version int64, spec string)) *MockStoreInterface_SaveJob_Call {
+func (_c *MockStoreInterface_SavePendingJob_Call) Run(run func(ctx context.Context, proposalID string, version int64, spec string)) *MockStoreInterface_SavePendingJob_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string), args[2].(int64), args[3].(string))
 	})
 	return _c
 }
 
-func (_c *MockStoreInterface_SaveJob_Call) Return(_a0 error) *MockStoreInterface_SaveJob_Call {
+func (_c *MockStoreInterface_SavePendingJob_Call) Return(_a0 error) *MockStoreInterface_SavePendingJob_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockStoreInterface_SaveJob_Call) RunAndReturn(run func(context.Context, string, int64, string) error) *MockStoreInterface_SaveJob_Call {
+func (_c *MockStoreInterface_SavePendingJob_Call) RunAndReturn(run func(context.Context, string, int64, string) error) *MockStoreInterface_SavePendingJob_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Description

This PR fixes a stall bug in the JD lifecycle manager where a failed replacement proposal left the verifier with no running job and no recovery path.

When a replacement proposal arrived, the manager stopped the old job before calling `StartJob` for the new one. If `StartJob` failed, the old job was gone. The manager entered `WaitingForJob` with nothing persisted to restart from. JD wouldn't re-push since the proposal was already in-flight, so the verifier would stall until an operator manually re-proposed.

This builds on the two-phase persistence introduced in #1201  (the `approved` row is now preserved by `SaveJob` during a replacement). The fix adds an explicit rollback path:

1. `SaveJob` only deletes the `pending` row — the old `approved` row survives until the new job is confirmed running.
2. On `StartJob` failure during a replacement, `DeletePendingJob` removes the new pending row, then the old job is restarted from the in-memory snapshot.
3. If the old job restart also fails, state transitions to `WaitingForJob` (the old `approved` row is still in the DB, so restart recovery still works on the next process restart).
4. A `UNIQUE(status)` constraint (migration 0003) prevents accumulation of pending rows from repeated failed replacements.

The README.md has been updated to reflect the new control flow introduced in #1201 and this PR.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

- Ran `go test ./common/jd/... -v -count=1`
- New unit tests covering the replacement failure paths:
  - `TestManager_EventLoop_Proposal_Replacement_StartFails_FallsBackToOldJob`: replacement `StartJob` fails; old job restarted; state stays `Running`.
  - `TestManager_EventLoop_Proposal_Replacement_StartFails_OldJobRestartAlsoFails`: both new and old job fail; state transitions to `WaitingForJob`.
- New store tests covering the two-row invariants:
  - `TestPostgresStore_SavePreservesApprovedRow`
  - `TestPostgresStore_LoadJob_PrefersApproved`
  - `TestPostgresStore_MarkJobApproved_WithTwoRows`
  - `TestPostgresStore_DeletePendingJob_*` (3 cases)

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date