### PR TITLE
Standalone mode improvement step 2: deprecate blockchain info from appConfig for verifier serviceFactory

### DIFF
--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -23,8 +23,8 @@ type JobSpec struct {
 // JD app config should not ship chain connection info (RPC URLs, etc.); that belongs
 // in local config for standalone mode or node config for CL mode. Devenv still
 // injects blockchain_infos through this decode path today. Prefer GetAppConfig for
-// typed app-only config. GenericConfig should be fully deprecated
-func (js JobSpec) GetGenericConfig() (chainaccess.GenericConfig, error) {
+// typed app-only config. GenericConfig should be fully deprecated once EVM swtich to use local config
+func (js JobSpec) GetGenericConfig() (chainaccess.GenericConfig, error) { //nolint:staticcheck
 	var gcfg chainaccess.GenericConfig
 	if _, err := toml.Decode(js.AppConfig, &gcfg); err != nil {
 		return chainaccess.GenericConfig{}, fmt.Errorf("error decoding app config: %w", err)

--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -23,8 +23,8 @@ type JobSpec struct {
 // JD app config should not ship chain connection info (RPC URLs, etc.); that belongs
 // in local config for standalone mode or node config for CL mode. Devenv still
 // injects blockchain_infos through this decode path today. Prefer GetAppConfig for
-// typed app-only config. GenericConfig should be fully deprecated once EVM swtich to use local config
-func (js JobSpec) GetGenericConfig() (chainaccess.GenericConfig, error) { //nolint:staticcheck
+// typed app-only config. GenericConfig should be fully deprecated once EVM swtich to use local config.
+func (js JobSpec) GetGenericConfig() (chainaccess.GenericConfig, error) {
 	var gcfg chainaccess.GenericConfig
 	if _, err := toml.Decode(js.AppConfig, &gcfg); err != nil {
 		return chainaccess.GenericConfig{}, fmt.Errorf("error decoding app config: %w", err)

--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -18,6 +18,12 @@ type JobSpec struct {
 }
 
 // GetGenericConfig decodes the AppConfig field into chainaccess.GenericConfig.
+//
+// Deprecated: GenericConfig is where the blockchain_infos TOML table is defined.
+// JD app config should not ship chain connection info (RPC URLs, etc.); that belongs
+// in local config for standalone mode or node config for CL mode. Devenv still
+// injects blockchain_infos through this decode path today. Prefer GetAppConfig for
+// typed app-only config. GenericConfig should be fully deprecated
 func (js JobSpec) GetGenericConfig() (chainaccess.GenericConfig, error) {
 	var gcfg chainaccess.GenericConfig
 	if _, err := toml.Decode(js.AppConfig, &gcfg); err != nil {

--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -35,6 +35,8 @@ func (js JobSpec) GetAppConfig(cfg any) error {
 		return fmt.Errorf("error decoding app config: %w", err)
 	}
 
+	// Deprecated: blockchain_infos should be dropped from appConfig, blockchain info will come from local config for standalone mode
+	// or node config for cl-mode. Remove this filter once chain family repos stopped using blockchain_infos in appConfig.
 	// Filter out undecoded fields under blockchain_infos.
 	var undecoded []string
 	for _, key := range md.Undecoded() {

--- a/bootstrap/job_test.go
+++ b/bootstrap/job_test.go
@@ -51,6 +51,7 @@ type testAppConfig struct {
 	Value int    `toml:"value"`
 }
 
+//nolint:staticcheck // exercises deprecated GetGenericConfig before it's fully removed
 func TestJobSpec_GetGenericConfig(t *testing.T) {
 	t.Run("decodes known GenericConfig fields", func(t *testing.T) {
 		js := JobSpec{

--- a/cmd/executor/service_test.go
+++ b/cmd/executor/service_test.go
@@ -38,7 +38,7 @@ func init() {
 	// Register a test EVM factory so that NewRegistry picks it up.
 	// Default nil evmFactory keeps existing tests working (GetAccessor returns error);
 	// tests that need a working accessor assign evmFactory before calling Start.
-	chainaccess.Register("evm", func(_ logger.Logger, _ chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) {
+	chainaccess.Register("evm", func(_ logger.Logger, _ chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) { //nolint:staticcheck
 		return &evmFactoryProxy{}, nil
 	})
 }

--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -53,16 +53,10 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 
 	protocol.InitChainSelectorCache()
 
-	genericConfig, err := spec.GetGenericConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get generic config: %w", err)
-	}
-
 	var config commit.Config
 	if err := spec.GetAppConfig(&config); err != nil {
 		return fmt.Errorf("failed to get app config: %w", err)
 	}
-	lggr.Infow("Using blockchain information from config", "info", genericConfig.ChainConfig)
 
 	if config.PyroscopeURL != "" {
 		profiler, err := StartPyroscope(lggr, config.PyroscopeURL, "verifier")
@@ -72,8 +66,6 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		}
 		f.profiler = profiler
 	}
-
-	chainSelectors := genericConfig.ChainConfig.GetAllChainSelectors()
 
 	// Create verifier addresses before source readers setup
 	verifierAddresses := make(map[string]protocol.UnknownAddress)
@@ -135,6 +127,7 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		}
 	}
 
+	chainSelectors := chainaccess.Infos[string](config.OnRampAddresses).GetAllChainSelectors()
 	sourceReaders := make(map[protocol.ChainSelector]chainaccess.SourceReader)
 	for _, selector := range chainSelectors {
 		accessor, err := deps.Registry.GetAccessor(ctx, selector)

--- a/cmd/verifier/servicefactory.go
+++ b/cmd/verifier/servicefactory.go
@@ -58,6 +58,10 @@ func (f *factory) Start(ctx context.Context, spec bootstrap.JobSpec, deps bootst
 		return fmt.Errorf("failed to get app config: %w", err)
 	}
 
+	if err := config.Validate(); err != nil {
+		return err
+	}
+
 	if config.PyroscopeURL != "" {
 		profiler, err := StartPyroscope(lggr, config.PyroscopeURL, "verifier")
 		if err != nil {

--- a/executor/config.go
+++ b/executor/config.go
@@ -23,6 +23,7 @@ const (
 
 type ConfigWithBlockchainInfo[T any] struct {
 	Configuration
+	// Deprecated: BlockchainInfos is deprecated and will be removed
 	BlockchainInfos chainaccess.Infos[T] `toml:"blockchain_infos"`
 }
 

--- a/integration/pkg/accessors/evm/factory_constructor.go
+++ b/integration/pkg/accessors/evm/factory_constructor.go
@@ -37,6 +37,7 @@ var _ chainaccess.AccessorFactoryConstructor = CreateEVMAccessorFactory
 func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) {
 	// Convert generic chain config -> Infos[evm.Info]
 	evmInfos := make(chainaccess.Infos[Info])
+	// TODO: To support standalone mode, need to support local config, GenericConfig will be deprecated as JD job will not have rpc info.
 	err := genericConfig.GetAllConcreteConfig(chainsel.FamilyEVM, &evmInfos)
 	if err != nil {
 		return nil, fmt.Errorf("error getting evm info: %w", err)

--- a/integration/pkg/accessors/evm/factory_constructor.go
+++ b/integration/pkg/accessors/evm/factory_constructor.go
@@ -34,7 +34,7 @@ var _ chainaccess.AccessorFactoryConstructor = CreateEVMAccessorFactory
 //
 // It will take all config values it needs from all available config. Note that it would be
 // very unusual for a config to have more than one of Committee/Token/Executor configs.
-func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) {
+func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) { //nolint:staticcheck // registry still decodes GenericConfig util local config supported
 	// Convert generic chain config -> Infos[evm.Info]
 	evmInfos := make(chainaccess.Infos[Info])
 	// TODO: To support standalone mode, need to support local config, GenericConfig will be deprecated as JD job will not have rpc info.
@@ -48,6 +48,8 @@ func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.Gene
 
 // CreateAccessorFactory creates a factory that can build EVM chain accessors.
 // TODO: Defer geth client and head tracker creation until GetAccessor is called.
+//
+//nolint:staticcheck // generic param is chainaccess.GenericConfig until CCIP-11840.
 func CreateAccessorFactory(
 	ctx context.Context,
 	lggr logger.Logger,

--- a/pkg/chainaccess/registry.go
+++ b/pkg/chainaccess/registry.go
@@ -55,6 +55,9 @@ type registry struct {
 // should be included here. Note that the Committee Configs are present, they must map to the same location
 // that they appear when parsing just the committee config file:
 //
+// Deprecated: blockchain_infos in JD config is deprecated. blockchain info should come from chain family
+// local config for standalone mode or node config for CL mode. Use getAppConfig for accessing verifier/executor config.
+//
 //	type ConfigWithBlockchainInfos struct {
 //	    Config
 //	    BlockchainInfos map[string]any `toml:"blockchain_infos"`
@@ -74,6 +77,9 @@ type registry struct {
 // TODO: Use protocol.Selector instead of string for all the map[string].
 type GenericConfig struct {
 	// ChainConfig is parsed by the concrete implementation.
+	//
+	// Deprecated: chain connection and tuning belong in local or node config, not
+	// blockchain_infos in the JD app config.
 	ChainConfig Infos[any] `toml:"blockchain_infos"`
 
 	CommitteeConfig


### PR DESCRIPTION
Stop enumerating verifier source chains from job blockchain_infos. Use on_ramp_addresses instead, via the same chainaccess.Infos.GetAllChainSelectors() helper (non-numeric keys are skipped, matching the old behavior).

blockchain_infos remains in the app config for EVM accessor RPC via chainaccess.NewRegistry; Solana RPC still comes from the NOP file. Executor is unchanged, it already uses chain_configuration.

Related [doc](https://docs.google.com/document/d/1LGA_tvAqDrKlgTk9q2yzlNSvYm7jSZx2iLdqQT5TN3w/edit?tab=t.0): step 2