### PR TITLE
feat: parallelise attestation fetching and verification

### DIFF
--- a/verifier/pkg/coordinator_cctp_test.go
+++ b/verifier/pkg/coordinator_cctp_test.go
@@ -488,7 +488,7 @@ func createCCTPCoordinator(
 
 	return verifier.NewCoordinator(
 		ts.logger,
-		cctp.NewVerifierWithConfig(ts.logger, attestationService, 100*time.Millisecond, 100*time.Millisecond),
+		cctp.NewVerifierWithConfig(ts.logger, attestationService, 100*time.Millisecond, 100*time.Millisecond, 10),
 		sourceReaders,
 		ccvWriter,
 		config,

--- a/verifier/pkg/token/cctp/verifier.go
+++ b/verifier/pkg/token/cctp/verifier.go
@@ -16,6 +16,8 @@ import (
 const (
 	attestationNotReadyRetry = 30 * time.Second
 	anyErrorRetry            = 5 * time.Second
+	// Max number of concurrent workers to fetch attestations to verify.
+	maxAttestationFetchers = 10
 )
 
 // Verifier is responsible for verifying CCTP messages by fetching their attestations
@@ -27,6 +29,7 @@ type Verifier struct {
 
 	attestationNotReadyRetry time.Duration
 	anyErrorRetry            time.Duration
+	maxAttestationFetchers   int
 }
 
 func NewVerifier(
@@ -38,6 +41,7 @@ func NewVerifier(
 		attestationService,
 		attestationNotReadyRetry,
 		anyErrorRetry,
+		maxAttestationFetchers,
 	)
 }
 
@@ -46,12 +50,14 @@ func NewVerifierWithConfig(
 	attestationService AttestationService,
 	attestationNotReadyRetry time.Duration,
 	anyErrorRetry time.Duration,
+	maxAttestationFetchers int,
 ) verifier.Verifier {
 	return &Verifier{
 		lggr:                     lggr,
 		attestationService:       attestationService,
 		attestationNotReadyRetry: attestationNotReadyRetry,
 		anyErrorRetry:            anyErrorRetry,
+		maxAttestationFetchers:   maxAttestationFetchers,
 	}
 }
 
@@ -59,69 +65,83 @@ func (v *Verifier) VerifyMessages(
 	ctx context.Context,
 	tasks []verifier.VerificationTask,
 ) []verifier.VerificationResult {
-	results := make([]verifier.VerificationResult, 0, len(tasks))
+	jobResults := make(chan verifier.VerificationResult, len(tasks))
+	jobs := make(chan verifier.VerificationTask, len(tasks))
 
-	// TODO: `attestationService.Fetch` is an IO-bound operation and can be parallelized. Large number of tasks
-	//  may lead to performance bottlenecks. Consider using a worker pool or goroutines with a semaphore to limit
-	//  concurrency.
 	for _, task := range tasks {
-		lggr := logger.With(v.lggr, protocol.LogKeyMessageID, task.MessageID, "txHash", task.TxHash)
-		lggr.Debugw("Verifying CCTP task")
+		jobs <- task
+	}
+	defer close(jobs)
 
-		// 1. Fetch attestation
-		attestation, err := v.attestationService.Fetch(ctx, task.TxHash, task.Message)
-		if err != nil {
-			lggr.Warnw("Failed to fetch attestation", "err", err)
-			verificationError := v.errorRetry(err, task)
-			results = append(results, verifier.VerificationResult{Error: &verificationError})
-			continue
-		}
+	workers := min(len(tasks), v.maxAttestationFetchers)
+	for range workers {
+		go func() {
+			for job := range jobs {
+				jobResults <- v.processVerificationTask(ctx, job)
+			}
+		}()
+	}
 
-		if !attestation.IsReady() {
-			lggr.Debugw("Attestation not ready for message")
-			verificationError := v.attestationErrorRetry(
-				fmt.Errorf("attestation not ready for message ID: %s", task.MessageID),
-				task,
-			)
-			results = append(results, verifier.VerificationResult{Error: &verificationError})
-			continue
-		}
-
-		verifierFormat, err := attestation.ToVerifierFormat()
-		if err != nil {
-			lggr.Errorw("Failed to decode attestation data", "err", err)
-			verificationError := v.errorRetry(err, task)
-			results = append(results, verifier.VerificationResult{Error: &verificationError})
-			continue
-		}
-
-		lggr.Debugw("Attestation fetched and decoded successfully",
-			"status", attestation.status,
-			"attestation", attestation.attestation,
-			"encodedCCTPMessage", attestation.encodedCCTPMessage,
-			"verifierFormat", verifierFormat,
-		)
-
-		// 2. Create VerifierNodeResult
-		result, err := commit.CreateVerifierNodeResult(
-			&task,
-			verifierFormat,
-			attestation.verifierVersion,
-		)
-		if err != nil {
-			lggr.Errorw("CreateVerifierNodeResult: Failed to create VerifierNodeResult", "err", err)
-			verificationError := v.errorRetry(err, task)
-			results = append(results, verifier.VerificationResult{Error: &verificationError})
-			continue
-		}
-
-		// 3. Return successful result
-		// PER-MESSAGE LOG (status): signing complete; storage write is the terminal success.
-		lggr.Infow("VerifierResults: Successfully verified message", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "signature", result.Signature)
-		results = append(results, verifier.VerificationResult{Result: result})
+	results := make([]verifier.VerificationResult, 0, len(tasks))
+	for range tasks {
+		results = append(results, <-jobResults)
 	}
 
 	return results
+}
+
+func (v *Verifier) processVerificationTask(ctx context.Context, task verifier.VerificationTask) verifier.VerificationResult {
+	lggr := logger.With(v.lggr, protocol.LogKeyMessageID, task.MessageID, "txHash", task.TxHash)
+	lggr.Debugw("Verifying CCTP task")
+
+	// 1. Fetch attestation
+	attestation, err := v.attestationService.Fetch(ctx, task.TxHash, task.Message)
+	if err != nil {
+		lggr.Warnw("Failed to fetch attestation", "err", err)
+		verificationError := v.errorRetry(err, task)
+		return verifier.VerificationResult{Error: &verificationError}
+	}
+
+	if !attestation.IsReady() {
+		lggr.Debugw("Attestation not ready for message")
+		verificationError := v.attestationErrorRetry(
+			fmt.Errorf("attestation not ready for message ID: %s", task.MessageID),
+			task,
+		)
+		return verifier.VerificationResult{Error: &verificationError}
+	}
+
+	verifierFormat, err := attestation.ToVerifierFormat()
+	if err != nil {
+		lggr.Errorw("Failed to decode attestation data", "err", err)
+		verificationError := v.errorRetry(err, task)
+		return verifier.VerificationResult{Error: &verificationError}
+	}
+
+	lggr.Debugw(
+		"Attestation fetched and decoded successfully",
+		"status", attestation.status,
+		"attestation", attestation.attestation,
+		"encodedCCTPMessage", attestation.encodedCCTPMessage,
+		"verifierFormat", verifierFormat,
+	)
+
+	// 2. Create VerifierNodeResult
+	result, err := commit.CreateVerifierNodeResult(
+		&task,
+		verifierFormat,
+		attestation.verifierVersion,
+	)
+	if err != nil {
+		lggr.Errorw("CreateVerifierNodeResult: Failed to create VerifierNodeResult", "err", err)
+		verificationError := v.errorRetry(err, task)
+		return verifier.VerificationResult{Error: &verificationError}
+	}
+
+	// 3. Return successful result
+	// PER-MESSAGE LOG (status): signing complete; storage write is the terminal success.
+	lggr.Infow("VerifierResults: Successfully verified message", protocol.LogTypeKey, protocol.LogTypeMessageStatus, "signature", result.Signature)
+	return verifier.VerificationResult{Result: result}
 }
 
 func (v *Verifier) attestationErrorRetry(err error, task verifier.VerificationTask) verifier.VerificationError {

--- a/verifier/pkg/token/cctp/verifier_test.go
+++ b/verifier/pkg/token/cctp/verifier_test.go
@@ -3,7 +3,9 @@ package cctp_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -161,22 +163,76 @@ func TestVerifier_VerifyMessages_MultipleTasksWithMixedResults(t *testing.T) {
 
 	require.Len(t, results, 3, "Expected three results")
 
+	// Results are produced concurrently, so they may arrive in any order.
+	// Index them by message ID rather than relying on input position.
+	successByID := make(map[string]verifier.VerificationResult)
+	errorByID := make(map[string]verifier.VerificationResult)
+	for _, result := range results {
+		switch {
+		case result.Result != nil:
+			successByID[result.Result.MessageID.String()] = result
+		case result.Error != nil:
+			errorByID[result.Error.Task.MessageID] = result
+		default:
+			t.Fatalf("result has neither Result nor Error: %+v", result)
+		}
+	}
+
 	// task1 should succeed
-	assert.Nil(t, results[0].Error, "Expected no error for task1")
-	assert.NotNil(t, results[0].Result, "Expected successful result for task1")
-	assert.Equal(t, task1.MessageID, results[0].Result.MessageID.String())
+	require.Contains(t, successByID, task1.MessageID, "Expected successful result for task1")
+	assert.Nil(t, successByID[task1.MessageID].Error, "Expected no error for task1")
 
 	// task2 should fail
-	assert.Nil(t, results[1].Result, "Expected no result for task2")
-	assert.NotNil(t, results[1].Error, "Expected error for task2")
-	assert.Equal(t, expectedErr, results[1].Error.Error)
-	assert.Equal(t, task2.MessageID, results[1].Error.Task.MessageID)
+	require.Contains(t, errorByID, task2.MessageID, "Expected error for task2")
+	assert.Nil(t, errorByID[task2.MessageID].Result, "Expected no result for task2")
+	assert.Equal(t, expectedErr, errorByID[task2.MessageID].Error.Error)
 
 	// task3 should succeed
-	assert.Nil(t, results[2].Error, "Expected no error for task3")
-	assert.NotNil(t, results[2].Result, "Expected successful result for task3")
-	assert.Equal(t, task3.MessageID, results[2].Result.MessageID.String())
+	require.Contains(t, successByID, task3.MessageID, "Expected successful result for task3")
+	assert.Nil(t, successByID[task3.MessageID].Error, "Expected no error for task3")
 
+	mockAttestationService.AssertExpectations(t)
+}
+
+func TestVerifier_VerifyMessages_RespectsMaxConcurrentFetchers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	lggr := logger.Test(t)
+	mockAttestationService := mocks.NewCCTPAttestationService(t)
+
+	const maxFetchers = 2
+	const numTasks = 12
+
+	var inFlight, maxObserved int64
+	mockAttestationService.EXPECT().
+		Fetch(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ protocol.ByteSlice, _ protocol.Message) {
+			cur := atomic.AddInt64(&inFlight, 1)
+			for {
+				prev := atomic.LoadInt64(&maxObserved)
+				if cur <= prev || atomic.CompareAndSwapInt64(&maxObserved, prev, cur) {
+					break
+				}
+			}
+			// Hold the fetch open so concurrent workers actually overlap.
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt64(&inFlight, -1)
+		}).
+		Return(createTestAttestation(), nil).
+		Times(numTasks)
+
+	tasks := make([]verifier.VerificationTask, 0, numTasks)
+	for i := range numTasks {
+		tasks = append(tasks, internal.CreateTestVerificationTask(i+1))
+	}
+
+	v := cctp.NewVerifierWithConfig(lggr, mockAttestationService, 30*time.Second, 5*time.Second, maxFetchers)
+	results := v.VerifyMessages(ctx, tasks)
+
+	require.Len(t, results, numTasks, "Expected one result per task")
+	assert.LessOrEqual(t, atomic.LoadInt64(&maxObserved), int64(maxFetchers),
+		"Concurrent Fetch calls must not exceed the configured maxFetchers")
 	mockAttestationService.AssertExpectations(t)
 }
 


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

We currently fetch and verify attestations in a synchronous manner, these changes parallelises this by using fixed set of workers in a pool.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
