### PR TITLE
switch devenv registration to nop alias

### DIFF
--- a/build/devenv/environment.go
+++ b/build/devenv/environment.go
@@ -1358,7 +1358,10 @@ func registerStandaloneVerifiersWithJD(ctx context.Context, verifiers []*committ
 			}
 
 			reg := &jobs.BootstrapJDRegistration{
-				Name:         ver.ContainerName,
+				// Register under the NOP alias: it is globally unique (ContainerName is
+				// only unique within a committee/chain family) and is the key the
+				// job-proposal node lookup searches by (propose_jobs FindByName(nopAlias)).
+				Name:         ver.NOPAlias,
 				CSAPublicKey: ver.Out.BootstrapKeys.CSAPublicKey,
 			}
 			if err := jobs.RegisterBootstrapWithJD(gCtx, jdClient, reg); err != nil {

--- a/build/devenv/services/committeeverifier/launch.go
+++ b/build/devenv/services/committeeverifier/launch.go
@@ -135,7 +135,10 @@ func RegisterStandaloneVerifiersWithJD(ctx context.Context, verifiers []*Input, 
 				return fmt.Errorf("bootstrap %s started but CSAPublicKey not available", ver.ContainerName)
 			}
 			reg := &jobs.BootstrapJDRegistration{
-				Name:         ver.ContainerName,
+				// Register under the NOP alias: it is globally unique (ContainerName is
+				// only unique within a committee/chain family) and is the key the
+				// job-proposal node lookup searches by (propose_jobs FindByName(nopAlias)).
+				Name:         ver.NOPAlias,
 				CSAPublicKey: ver.Out.BootstrapKeys.CSAPublicKey,
 			}
 			if err := jobs.RegisterBootstrapWithJD(gCtx, jdClient, reg); err != nil {


### PR DESCRIPTION
## Description

Standalone verifiers were registered with the Job Distributor under `ContainerName`,
which is only unique within a committee/chain family. In multi-committee setups
(e.g. chainlink-canton's EVM + Canton committees, which both have a
`default-verifier-1`), two nodes register under the same JD name. The executor-config
bring-up added in #1202 then fails in `propose_jobs` → `FetchNodeLookup` with
`duplicate node name`.

Register standalone verifiers under `NOPAlias` instead: it's globally unique, it's the
key the job-proposal lookup already searches by (`FindByName(nopAlias)`), and it matches
how CL-node-mode registration (`jobs/jd.go`) already behaves. Fixes both the monolith
(`environment.go`) and phased (`committeeverifier/launch.go`) paths.

## Testing

Reproduced via the chainlink-canton CCIP E2E devenv (`env-canton-evm.toml`, two committees
sharing `default-verifier-1`): `ccv up` failed at executor-config generation with
`duplicate node name "default-verifier-1"`. With this change the duplicate is gone and the
job-proposal lookup resolves each verifier by its NOP alias. https://github.com/smartcontractkit/chainlink-canton/pull/732

## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to d