### PR TITLE
fix inference signer fetch

### DIFF
--- a/deployment/changesets/state_inputs.go
+++ b/deployment/changesets/state_inputs.go
@@ -7,7 +7,6 @@ import (
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -19,27 +18,33 @@ import (
 // committee qualifier from observed state instead of a topology blob — the state
 // analog of CommitteeInputFromTopologyPerFamily.
 //
-// Membership is read on-chain: for every chain the committee verifier is deployed
-// on (discovered via adapters.AllDeployedCommitteeVerifierChains), the verifier's
-// signature configs are scanned and their signer addresses mapped back to NOP
-// aliases via ids. ChainConfigs is keyed by the verifier chain selector, matching
-// how ApplyVerifierConfig consumes it (those keys drive verifier-contract
-// resolution and signer-family detection).
+// Membership is read on-chain. A committee verifier deployed on chain V stores a
+// *per-source* signer set: its config for source chain S carries the signers of the
+// committee members responsible for S (see getSignatureConfigForLane in
+// chainlink-ccip, which derives those signers from the topology's ChainConfigs[S]).
+// The signers physically stored on V therefore belong to V's *counterparties*, not
+// to V itself. Reconstruction keys membership by *source* chain accordingly: every
+// deployed verifier chain is scanned (discovered via
+// adapters.AllDeployedCommitteeVerifierChains), and each signature config's signers
+// are attributed to its SourceChainSelector, resolved to NOP aliases via ids using
+// the verifier chain's address family. The result is keyed identically to
+// CommitteeInputFromTopologyPerFamily (by the chain a membership belongs to), so the
+// two compare directly.
 //
-// chainFamily filters to a single verifier-chain family per call, mirroring
-// CommitteeInputFromTopologyPerFamily; pass "" to fold every family together.
+// Keying by source rather than by verifier chain is essential for committees whose
+// membership differs per chain — e.g. one committee spanning multiple chain families,
+// where chain V's verifier holds only its counterparties' signers. A by-verifier-chain
+// key would mislabel those as V's own members and report a spurious mismatch.
+//
+// chainFamily filters the *result* to source chains of a single family; pass "" to
+// include every chain. Scanning always covers all verifier-chain families, since a
+// source chain's signers live on its counterparties' verifiers.
 //
 // Aggregators are intentionally left empty: aggregator endpoints are offchain
 // service infrastructure, not on/off-chain state, so the caller supplies them
 // (see ApplyVerifierConfigInputFromState). The returned input is bootstrap-safe:
 // when no verifier is deployed yet the result is an empty committee, not an error.
-//
-// Reconciliation note: on-chain, each verifier carries a *per-source* signer set,
-// whereas CommitteeInput models a single membership per verifier chain. The two
-// are reconciled by unioning the per-source signer sets into one membership. When
-// the sources disagree (a member present on some sources but not others) the
-// divergence is logged as a warning — it surfaces real drift while still producing
-// a usable input; an unmappable signer (no JD-known NOP) remains a hard error.
+// An unmappable signer (no JD-known NOP) remains a hard error.
 func CommitteeInputFromState(
 	ctx context.Context,
 	env deployment.Environment,
@@ -54,26 +59,28 @@ func CommitteeInputFromState(
 	verifierChains := adapters.AllDeployedCommitteeVerifierChains(env.DataStore, qualifier)
 	slices.Sort(verifierChains)
 
-	chainConfigs := make(map[uint64]CommitteeChainMembership)
-	for _, sel := range verifierChains {
-		family, err := chainsel.GetSelectorFamily(sel)
+	// sourceChain -> member aliases, unioned across every verifier that attests it.
+	// A source chain's signers live on its counterparties' verifiers, so we scan all
+	// verifier-chain families regardless of the requested chainFamily; with >2 chains
+	// a source's signer set appears on each counterparty verifier, all describing the
+	// same committee, so unioning is idempotent.
+	bySource := make(map[uint64]map[shared.NOPAlias]struct{})
+	for _, vSel := range verifierChains {
+		vFamily, err := chainsel.GetSelectorFamily(vSel)
 		if err != nil {
-			return CommitteeInput{}, fmt.Errorf("committee %q: unknown family for chain %d: %w", qualifier, sel, err)
-		}
-		if chainFamily != "" && family != chainFamily {
-			continue
+			return CommitteeInput{}, fmt.Errorf("committee %q: unknown family for verifier chain %d: %w", qualifier, vSel, err)
 		}
 
-		onchain, err := adapters.GetCommitteeVerifierOnchainRegistry().Get(sel)
+		onchain, err := adapters.GetCommitteeVerifierOnchainRegistry().Get(vSel)
 		if err != nil {
 			return CommitteeInput{}, fmt.Errorf("committee %q: %w", qualifier, err)
 		}
-		states, err := onchain.ScanCommitteeStates(ctx, env, sel)
+		states, err := onchain.ScanCommitteeStates(ctx, env, vSel)
 		if err != nil {
-			return CommitteeInput{}, fmt.Errorf("committee %q: scan chain %d: %w", qualifier, sel, err)
+			return CommitteeInput{}, fmt.Errorf("committee %q: scan chain %d: %w", qualifier, vSel, err)
 		}
 
-		state, err := findCommitteeState(states, qualifier, sel)
+		state, err := findCommitteeState(states, qualifier, vSel)
 		if err != nil {
 			return CommitteeInput{}, err
 		}
@@ -82,13 +89,42 @@ func CommitteeInputFromState(
 			continue
 		}
 
-		aliases, err := membershipFromState(ids, family, sel, qualifier, state, env.Logger)
-		if err != nil {
-			return CommitteeInput{}, err
+		// Attribute each signature config's signers to the source chain it attests.
+		// Signers are stored in the verifier chain's address family, so resolve with vFamily.
+		for _, sc := range state.SignatureConfigs {
+			set := bySource[sc.SourceChainSelector]
+			if set == nil {
+				set = make(map[shared.NOPAlias]struct{}, len(sc.Signers))
+				bySource[sc.SourceChainSelector] = set
+			}
+			for _, signer := range sc.Signers {
+				alias, ok := ids.AliasForSigner(vFamily, signer)
+				if !ok {
+					return CommitteeInput{}, fmt.Errorf(
+						"committee %q: on-chain signer %q (verifier chain %d, source %d) has no JD-known NOP — "+
+							"signer set is out of sync with the Job Distributor",
+						qualifier, signer, vSel, sc.SourceChainSelector)
+				}
+				set[alias] = struct{}{}
+			}
 		}
-		if len(aliases) > 0 {
-			chainConfigs[sel] = CommitteeChainMembership{NOPAliases: aliases}
+	}
+
+	chainConfigs := make(map[uint64]CommitteeChainMembership, len(bySource))
+	for sSel, set := range bySource {
+		if len(set) == 0 {
+			continue
 		}
+		if chainFamily != "" {
+			sFamily, err := chainsel.GetSelectorFamily(sSel)
+			if err != nil {
+				return CommitteeInput{}, fmt.Errorf("committee %q: unknown family for source chain %d: %w", qualifier, sSel, err)
+			}
+			if sFamily != chainFamily {
+				continue
+			}
+		}
+		chainConfigs[sSel] = CommitteeChainMembership{NOPAliases: sortedAliases(set)}
 	}
 
 	return CommitteeInput{Qualifier: qualifier, ChainConfigs: chainConfigs}, nil
@@ -113,58 +149,6 @@ func findCommitteeState(states []*adapters.CommitteeState, qualifier string, cha
 	return found, nil
 }
 
-// membershipFromState collapses a verifier's per-source signer sets into the
-// single NOP-alias membership CommitteeInput expects, mapping signer addresses to
-// aliases via ids. Unknown signers (no JD-known NOP) are a hard error. When the
-// per-source sets disagree the union is returned and the divergence is logged as a
-// warning (drift the topology file could never surface), since collapsing to a
-// single membership is inherently lossy.
-func membershipFromState(
-	ids *NOPIdentities,
-	signerFamily string,
-	verifierChain uint64,
-	qualifier string,
-	state *adapters.CommitteeState,
-	lggr logger.Logger,
-) ([]shared.NOPAlias, error) {
-	union := make(map[shared.NOPAlias]struct{})
-	perSource := make(map[uint64][]shared.NOPAlias, len(state.SignatureConfigs))
-	var first map[shared.NOPAlias]struct{}
-	diverged := false
-
-	for _, sc := range state.SignatureConfigs {
-		set := make(map[shared.NOPAlias]struct{}, len(sc.Signers))
-		for _, signer := range sc.Signers {
-			alias, ok := ids.AliasForSigner(signerFamily, signer)
-			if !ok {
-				return nil, fmt.Errorf(
-					"committee %q on verifier chain %d (source %d): on-chain signer %q has no JD-known NOP — "+
-						"signer set is out of sync with the Job Distributor",
-					qualifier, verifierChain, sc.SourceChainSelector, signer)
-			}
-			set[alias] = struct{}{}
-			union[alias] = struct{}{}
-		}
-		if first == nil {
-			first = set
-		} else if !aliasSetsEqual(first, set) {
-			diverged = true
-		}
-		perSource[sc.SourceChainSelector] = sortedAliases(set)
-	}
-
-	if diverged && lggr != nil {
-		lggr.Warnw(
-			"committee membership differs across source chains on verifier; unioning into a single membership",
-			"committee", qualifier,
-			"verifierChain", verifierChain,
-			"perSource", perSource,
-		)
-	}
-
-	return sortedAliases(union), nil
-}
-
 // CommitteeChainSelectorsFromState returns the sorted verifier-chain selectors a
 // committee is deployed on, optionally filtered to a single family. Mirror of
 // CommitteeChainSelectorsFromTopology, sourced from the datastore.
@@ -185,18 +169,6 @@ func CommitteeChainSelectorsFromState(ds datastore.DataStore, qualifier, chainFa
 	}
 	slices.Sort(out)
 	return out, nil
-}
-
-func aliasSetsEqual(a, b map[shared.NOPAlias]struct{}) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k := range a {
-		if _, ok := b[k]; !ok {
-			return false
-		}
-	}
-	return true
 }
 
 func sortedAliases(set map[shared.NOPAlias]struct{}) []shared.NOPAlias {

--- a/deployment/changesets/state_inputs_test.go
+++ b/deployment/changesets/state_inputs_test.go
@@ -195,11 +195,14 @@ func TestCommitteeInputFromState_ErrorsOnUnknownSigner(t *testing.T) {
 	assert.Contains(t, err.Error(), "no JD-known NOP")
 }
 
-func TestCommitteeInputFromState_UnionsOnCrossSourceDrift(t *testing.T) {
+func TestCommitteeInputFromState_KeysEachSourceSeparately(t *testing.T) {
 	registerEVMChainTypeForIdentities()
 	sel := chainsel.TEST_90000001.Selector
 	src2 := chainsel.TEST_90000002.Selector
 
+	// One verifier carrying two source-keyed signer sets with different membership.
+	// Membership is attributed to each SourceChainSelector independently — not unioned
+	// onto the verifier chain — so the two sources yield two distinct chain configs.
 	adapter := &stubFullAdapter{
 		states: map[uint64][]*adapters.CommitteeState{
 			sel: {{
@@ -207,7 +210,6 @@ func TestCommitteeInputFromState_UnionsOnCrossSourceDrift(t *testing.T) {
 				ChainSelector: sel,
 				SignatureConfigs: []adapters.SignatureConfig{
 					{SourceChainSelector: sel, Signers: []string{"0xAAA1", "0xBBB2"}, Threshold: 2},
-					// nop2 missing on the second source — divergence is unioned (and warned).
 					{SourceChainSelector: src2, Signers: []string{"0xAAA1"}, Threshold: 1},
 				},
 			}},
@@ -226,8 +228,58 @@ func TestCommitteeInputFromState_UnionsOnCrossSourceDrift(t *testing.T) {
 
 	committee, err := CommitteeInputFromState(context.Background(), env, ids, testQualifier, "")
 	require.NoError(t, err)
-	// Union of both source memberships.
 	assert.Equal(t, []shared.NOPAlias{"nop1", "nop2"}, committee.ChainConfigs[sel].NOPAliases)
+	assert.Equal(t, []shared.NOPAlias{"nop1"}, committee.ChainConfigs[src2].NOPAliases)
+}
+
+// TestCommitteeInputFromState_KeysMembershipBySourceChain is the regression test for
+// the cross-chain committee inference bug: a committee verifier on chain V stores its
+// *counterparties'* signers (keyed by SourceChainSelector), so membership must be
+// attributed to the source chain — not to the verifier chain that physically holds it.
+// Before the fix, V's signers were mislabeled as V's own members, producing a spurious
+// "state inference mismatch" for committees whose membership differs per chain (e.g. a
+// single committee spanning an EVM and a Canton chain).
+func TestCommitteeInputFromState_KeysMembershipBySourceChain(t *testing.T) {
+	registerEVMChainTypeForIdentities()
+	chainA := chainsel.TEST_90000001.Selector
+	chainB := chainsel.TEST_90000002.Selector
+
+	// chainA's verifier attests messages from chainB -> it holds chainB's committee
+	// members. chainB's verifier holds chainA's. Members differ per chain.
+	adapter := &stubFullAdapter{
+		states: map[uint64][]*adapters.CommitteeState{
+			chainA: {{
+				Qualifier:     testQualifier,
+				ChainSelector: chainA,
+				SignatureConfigs: []adapters.SignatureConfig{
+					{SourceChainSelector: chainB, Signers: []string{"0xBBB1", "0xBBB2"}, Threshold: 2},
+				},
+			}},
+			chainB: {{
+				Qualifier:     testQualifier,
+				ChainSelector: chainB,
+				SignatureConfigs: []adapters.SignatureConfig{
+					{SourceChainSelector: chainA, Signers: []string{"0xAAA1", "0xAAA2"}, Threshold: 2},
+				},
+			}},
+		},
+		verifierAddrs: map[uint64]string{chainA: testVerifierAddr, chainB: testVerifierAddr},
+	}
+	registerFullEVMAdapters(adapter)
+
+	env := newIdentitiesEnv(t,
+		map[string]string{"node-a1": "a1", "node-a2": "a2", "node-b1": "b1", "node-b2": "b2"},
+		map[string]string{"node-a1": "0xAAA1", "node-a2": "0xAAA2", "node-b1": "0xBBB1", "node-b2": "0xBBB2"},
+		[]uint64{chainA, chainB},
+	)
+	ids, err := LoadNOPIdentities(context.Background(), env)
+	require.NoError(t, err)
+
+	committee, err := CommitteeInputFromState(context.Background(), env, ids, testQualifier, "")
+	require.NoError(t, err)
+	// Membership is attributed to the source chain, not the verifier chain holding it.
+	assert.Equal(t, []shared.NOPAlias{"a1", "a2"}, committee.ChainConfigs[chainA].NOPAliases)
+	assert.Equal(t, []shared.NOPAlias{"b1", "b2"}, committee.ChainConfigs[chainB].NOPAliases)
 }
 
 // Reproduces the standalone-NOP case that JD cannot resolve (the signer is not in


### PR DESCRIPTION
## Description

`CommitteeInputFromState` reconstructed committee membership keyed by the **verifier chain**. But a committee verifier deployed on chain V stores its *counterparties'* signers, keyed by `SourceChainSelector` — `getSignatureConfigForLane` derives a lane's signers from the topology's `ChainConfigs[remoteSelector]`. Treating the signers physically stored on V as V's own members is only correct when every chain in a committee has identical membership.

For a committee whose membership differs per chain — e.g. a single `default` committee spanning an EVM chain and a Canton chain, where each chain's verifier holds only the *other* chain's signers — the state-inference gate added in #1202 then reported a spurious mismatch and failed devenv bring-up:

```
state inference mismatch vs topology-derived committee input
  committee=default family=evm
  topology=[evm-default-verifier-1, evm-default-verifier-2]
  state   =[canton-default-verifier-1, canton-default-verifier-2]
```

The on-chain write was correct; only the inference's reverse mapping was wrong (it surfaces in any multi-family / per-chain-distinct-membership committee, which uniform single-family setups never hit).

This change keys reconstruction by `SourceChainSelector`, attributing each signature config's signers to the chain they are responsible for — matching the write semantics and `CommitteeInputFromTopologyPerFamily`'s keying, so topology- and state-derived inputs compare directly. Scanning now covers all verifier-chain families (a source's signers live on its counterparties' verifiers) and `chainFamily` filters the result by source chain. The obsolete cross-source union (`membershipFromState`) and its `aliasSetsEqual` helper are removed.

## Testing

- `go test ./deployment/changesets/` — 132 pass.
- Added `TestCommitteeInputFromState_KeysMembershipBySourceChain`: two chains, each verifier holding only the other chain's signers with distinct membership; asserts membership is attributed to the source chain. This fails on the prior by-verifier-chain keying and passes now.
- Reworked the former `UnionsOnCrossSourceDrift` test into `KeysEachSourceSeparately`, since cross-source unioning is exactly the behavior removed.
- End-to-end: chainlink-canton#732 bumps `chainlink-ccv/*` (and the devenv verifier image ref) to this branch and runs the CCIP E2E devenv (`ccip/devenv/env-canton-evm.toml` — one `default` committee with separate EVM and Canton members), exercising the committee state-inference gate through a real cross-family bring-up.

## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (chainlink-canton#732; follows #1202, #1211)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
