### PR TITLE
verifier/token: consume bootstrap config toml

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -216,7 +216,7 @@ func NewBootstrapper(
 
 		b.configPath = resolveBootstrapConfigPath(b.configPath)
 		b.config = &Config{}
-		if err := LoadAndValidateConfig(b.configPath, b.config); err != nil {
+		if err := LoadAndValidateConfig(lggr, b.configPath, b.config, true); err != nil {
 			return nil, fmt.Errorf("failed to load bootstrap config (%s): %w", b.configPath, err)
 		}
 		// not logging config because it contains secrets.
@@ -227,7 +227,7 @@ func NewBootstrapper(
 		// here: TOKEN_VERIFIER_CONFIG_PATH and BOOTSTRAPPER_CONFIG_PATH both default to
 		// /etc/config.toml, so applying the default would decode the wrong file. See issue #013.
 		b.config = &Config{}
-		if err := LoadAndValidateConfig(path, b.config); err != nil {
+		if err := LoadAndValidateConfig(lggr, path, b.config, false); err != nil {
 			return nil, fmt.Errorf("failed to load operator config (%s): %w", path, err)
 		}
 		lggr.Infow("loaded operator config for static-TOML mode")

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -210,46 +210,27 @@ func NewBootstrapper(
 	if b.jdMode {
 		// JD mode requires a CSA key for node authentication. Inject the default if the caller
 		// did not explicitly declare one, so callers only need to list their application keys.
-		hasCSA := false
-		for _, k := range b.keys {
-			if k.purpose == "csa" {
-				hasCSA = true
-				break
-			}
-		}
-		if !hasCSA {
+		if !hasCSAKey(b.keys) {
 			b.keys = append([]keyToInit{{DefaultCSAKeyName, "csa", keystore.Ed25519}}, b.keys...)
 		}
 
-		// Use provided config path if set by an option.
-		if b.configPath == "" {
-			// If no config path is provided by an option, check the environment variable.
-			b.configPath = os.Getenv(ConfigPathEnv)
-			if b.configPath == "" {
-				// If the environment variable is not set, use the default config path.
-				b.configPath = DefaultConfigPath
-			}
-		}
-
+		b.configPath = resolveBootstrapConfigPath(b.configPath)
 		b.config = &Config{}
 		if err := LoadAndValidateConfig(b.configPath, b.config); err != nil {
 			return nil, fmt.Errorf("failed to load bootstrap config (%s): %w", b.configPath, err)
 		}
-
 		// not logging config because it contains secrets.
 		lggr.Infow("loaded bootstrap config")
-	} else {
+	} else if path := os.Getenv(ConfigPathEnv); path != "" {
 		// Static-TOML mode: optionally load operator config when BOOTSTRAPPER_CONFIG_PATH is
 		// explicitly set. The default fallback to DefaultConfigPath is intentionally suppressed
 		// here: TOKEN_VERIFIER_CONFIG_PATH and BOOTSTRAPPER_CONFIG_PATH both default to
 		// /etc/config.toml, so applying the default would decode the wrong file. See issue #013.
-		if path := os.Getenv(ConfigPathEnv); path != "" {
-			b.config = &Config{}
-			if err := LoadAndValidateConfig(path, b.config); err != nil {
-				return nil, fmt.Errorf("failed to load operator config (%s): %w", path, err)
-			}
-			lggr.Infow("loaded operator config for static-TOML mode")
+		b.config = &Config{}
+		if err := LoadAndValidateConfig(path, b.config); err != nil {
+			return nil, fmt.Errorf("failed to load operator config (%s): %w", path, err)
 		}
+		lggr.Infow("loaded operator config for static-TOML mode")
 	}
 
 	return b, nil
@@ -514,6 +495,27 @@ func connectToDB(ctx context.Context, connStr string) (*sqlx.DB, error) {
 		return nil, fmt.Errorf("failed to run bootstrapper database migrations: %w", err)
 	}
 	return db, nil
+}
+
+func hasCSAKey(keys []keyToInit) bool {
+	for _, k := range keys {
+		if k.purpose == "csa" {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveBootstrapConfigPath returns the effective bootstrap config path: the explicitly-provided
+// path takes precedence, then BOOTSTRAPPER_CONFIG_PATH, then DefaultConfigPath.
+func resolveBootstrapConfigPath(explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if env := os.Getenv(ConfigPathEnv); env != "" {
+		return env
+	}
+	return DefaultConfigPath
 }
 
 func newLogger(logLevel zapcore.Level, name string) (logger.Logger, error) {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -51,9 +51,8 @@ type ServiceDeps struct {
 	Registry chainaccess.Registry
 
 	// Monitoring is the operator-provided monitoring config from the bootstrap config (Config.Monitoring).
-	// It is nil when the operator did not configure monitoring in the bootstrap config, or when the
-	// bootstrapper runs in static-TOML mode (which loads no bootstrap config). Services prefer this value
-	// and fall back to their own app-config monitoring field when it is nil.
+	// It is nil when the operator did not configure monitoring in the bootstrap config. Services prefer
+	// this value and fall back to their own app-config monitoring field when it is nil.
 	Monitoring *monitoring.Config
 }
 
@@ -152,6 +151,12 @@ type Bootstrapper struct {
 	infoServer       *infoServer
 	keys             []keyToInit
 
+	// jdMode is true when the bootstrapper runs in JD lifecycle mode (WithJD or default).
+	// false means static-TOML mode (WithTOMLAppConfig). Routing in Start() uses this flag
+	// rather than checking b.config != nil, because b.config may now be set in both modes
+	// (operator config is optionally loaded in static-TOML mode too).
+	jdMode bool
+
 	// application
 	appCfg *string
 	fac    ServiceFactory
@@ -192,14 +197,19 @@ func NewBootstrapper(
 		}
 	}
 
-	// If no configuration is provided, default to JD lifecycle manager with config loaded from the default path.
-	if b.appCfg == nil && b.config == nil {
-		b.config = &Config{}
+	// WithJD and WithTOMLAppConfig are mutually exclusive.
+	if b.jdMode && b.appCfg != nil {
+		return nil, fmt.Errorf("WithJD and WithTOMLAppConfig are mutually exclusive")
 	}
 
-	// JD mode requires a CSA key for node authentication. Inject the default if the caller
-	// did not explicitly declare one, so callers only need to list their application keys.
-	if b.config != nil {
+	// If neither mode was explicitly selected, default to JD lifecycle mode.
+	if !b.jdMode && b.appCfg == nil {
+		b.jdMode = true
+	}
+
+	if b.jdMode {
+		// JD mode requires a CSA key for node authentication. Inject the default if the caller
+		// did not explicitly declare one, so callers only need to list their application keys.
 		hasCSA := false
 		for _, k := range b.keys {
 			if k.purpose == "csa" {
@@ -210,9 +220,7 @@ func NewBootstrapper(
 		if !hasCSA {
 			b.keys = append([]keyToInit{{DefaultCSAKeyName, "csa", keystore.Ed25519}}, b.keys...)
 		}
-	}
 
-	if b.config != nil {
 		// Use provided config path if set by an option.
 		if b.configPath == "" {
 			// If no config path is provided by an option, check the environment variable.
@@ -223,13 +231,25 @@ func NewBootstrapper(
 			}
 		}
 
-		err := LoadAndValidateConfig(b.configPath, b.config)
-		if err != nil {
+		b.config = &Config{}
+		if err := LoadAndValidateConfig(b.configPath, b.config); err != nil {
 			return nil, fmt.Errorf("failed to load bootstrap config (%s): %w", b.configPath, err)
 		}
 
 		// not logging config because it contains secrets.
 		lggr.Infow("loaded bootstrap config")
+	} else {
+		// Static-TOML mode: optionally load operator config when BOOTSTRAPPER_CONFIG_PATH is
+		// explicitly set. The default fallback to DefaultConfigPath is intentionally suppressed
+		// here: TOKEN_VERIFIER_CONFIG_PATH and BOOTSTRAPPER_CONFIG_PATH both default to
+		// /etc/config.toml, so applying the default would decode the wrong file. See issue #013.
+		if path := os.Getenv(ConfigPathEnv); path != "" {
+			b.config = &Config{}
+			if err := LoadAndValidateConfig(path, b.config); err != nil {
+				return nil, fmt.Errorf("failed to load operator config (%s): %w", path, err)
+			}
+			lggr.Infow("loaded operator config for static-TOML mode")
+		}
 	}
 
 	return b, nil
@@ -239,6 +259,11 @@ func NewBootstrapper(
 func (b *Bootstrapper) startWithAppConfig(ctx context.Context) (startErr error) {
 	if b.appCfg == nil {
 		return fmt.Errorf("bootstrapper has no app config")
+	}
+
+	lggr, err := newLogger(b.logLevel, b.name)
+	if err != nil {
+		return fmt.Errorf("failed to create logger: %w", err)
 	}
 
 	b.lggr.Infow("Calling NewRegistry with app config")
@@ -265,7 +290,15 @@ func (b *Bootstrapper) startWithAppConfig(ctx context.Context) (startErr error) 
 		AppConfig:     *b.appCfg,
 	}
 
-	return b.fac.Start(ctx, js, ServiceDeps{Registry: b.accCloser})
+	deps := ServiceDeps{
+		Logger:   lggr,
+		Registry: b.accCloser,
+	}
+	if b.config != nil {
+		deps.Monitoring = b.config.Monitoring
+	}
+
+	return b.fac.Start(ctx, js, deps)
 }
 
 // chainTypeFromString maps a config chain type string to the proto ChainType enum.
@@ -373,8 +406,6 @@ func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create service deps: %w", err)
 	}
-	// Surface the operator-provided monitoring config to the service. Only the JD path populates this;
-	// static-TOML mode (startWithAppConfig) loads no bootstrap config and leaves it nil.
 	deps.Monitoring = b.config.Monitoring
 
 	jobRunner := &runner{fac: b.fac, deps: deps}
@@ -434,14 +465,10 @@ func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 
 // Start initializes the keystore, connects to JD, and starts the lifecycle manager.
 func (b *Bootstrapper) Start(ctx context.Context) error {
-	if b.config != nil {
+	if b.jdMode {
 		return b.startWithJDLifecycle(ctx)
 	}
-	if b.appCfg != nil {
-		return b.startWithAppConfig(ctx)
-	}
-
-	return fmt.Errorf("no configuration provided: either JD config or app config must be provided")
+	return b.startWithAppConfig(ctx)
 }
 
 // Stop shuts down all active components.
@@ -489,12 +516,19 @@ func connectToDB(ctx context.Context, connStr string) (*sqlx.DB, error) {
 	return db, nil
 }
 
-func newServiceDeps(keyStore keystore.Keystore, logLevel zapcore.Level, name string) (ServiceDeps, error) {
+func newLogger(logLevel zapcore.Level, name string) (logger.Logger, error) {
 	lggr, err := logger.NewWith(zaplog.GetLogProfile(logLevel))
 	if err != nil {
-		return ServiceDeps{}, fmt.Errorf("failed to create logger: %w", err)
+		return nil, fmt.Errorf("failed to create logger: %w", err)
 	}
-	lggr = logger.Sugared(logger.Named(lggr, name))
+	return logger.Sugared(logger.Named(lggr, name)), nil
+}
+
+func newServiceDeps(keyStore keystore.Keystore, logLevel zapcore.Level, name string) (ServiceDeps, error) {
+	lggr, err := newLogger(logLevel, name)
+	if err != nil {
+		return ServiceDeps{}, err
+	}
 	return ServiceDeps{
 		Logger:   lggr,
 		Keystore: keyStore,
@@ -584,7 +618,7 @@ func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 // already declared via WithKey.
 func WithJD() Option {
 	return func(b *Bootstrapper) error {
-		b.config = &Config{}
+		b.jdMode = true
 		return nil
 	}
 }

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -121,10 +121,10 @@ func (c ChainRegistration) validate() error {
 	id = "1"
 */
 type Config struct {
-	JD       JDConfig
-	Keystore KeystoreConfig
-	DB       DBConfig
-	Server   ServerConfig
+	JD       JDConfig       `toml:"jd,omitempty"`
+	Keystore KeystoreConfig `toml:"keystore,omitempty"`
+	DB       DBConfig       `toml:"db,omitempty"`
+	Server   ServerConfig   `toml:"server,omitempty"`
 	// Chains declares the chains on which this node has a signing identity.
 	// Each entry causes the bootstrapper to register the node's signing key for that chain in JD.
 	// Optional: if empty, no signing key sync is performed.
@@ -143,26 +143,45 @@ type Config struct {
 	Monitoring *monitoring.Config
 }
 
-func (c *Config) validate() error {
+// validate checks the config for correctness. md is the TOML metadata from decoding, used to
+// detect which top-level sections were actually present in the file (as opposed to zero-valued
+// from an absent section). The infra bundle (jd/db/keystore/server) is validated only when any
+// infra key appears in md — so a monitoring-only bootstrap file is valid. Monitoring is always
+// validated independently when non-nil.
+func (c *Config) validate(md toml.MetaData) error {
 	var errs []error
-	if err := c.JD.validate(); err != nil {
-		errs = append(errs, fmt.Errorf("failed to validate 'jd' section: %w", err))
-	}
-	if err := c.Keystore.validate(); err != nil {
-		errs = append(errs, fmt.Errorf("failed to validate 'keystore' section: %w", err))
-	}
-	if err := c.DB.validate(); err != nil {
-		errs = append(errs, fmt.Errorf("failed to validate 'db' section: %w", err))
-	}
-	if err := c.Server.validate(); err != nil {
-		errs = append(errs, fmt.Errorf("failed to validate 'server' section: %w", err))
-	}
-	for i, chain := range c.Chains {
-		if err := chain.validate(); err != nil {
-			errs = append(errs, fmt.Errorf("invalid chain at index %d: %w", i, err))
+
+	infraPresent := false
+	for _, key := range md.Keys() {
+		switch key[0] {
+		case "jd", "db", "keystore", "server":
+			infraPresent = true
+		}
+		if infraPresent {
+			break
 		}
 	}
-	// Monitoring is optional; validate it only when the operator configured it.
+
+	if infraPresent {
+		if err := c.JD.validate(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to validate 'jd' section: %w", err))
+		}
+		if err := c.Keystore.validate(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to validate 'keystore' section: %w", err))
+		}
+		if err := c.DB.validate(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to validate 'db' section: %w", err))
+		}
+		if err := c.Server.validate(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to validate 'server' section: %w", err))
+		}
+		for i, chain := range c.Chains {
+			if err := chain.validate(); err != nil {
+				errs = append(errs, fmt.Errorf("invalid chain at index %d: %w", i, err))
+			}
+		}
+	}
+
 	if c.Monitoring != nil {
 		if err := c.Monitoring.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to validate 'monitoring' section: %w", err))
@@ -178,24 +197,24 @@ func LoadAndValidateConfig(path string, cfg *Config) error {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	err = parseTOMLStrict(string(tomlBytes), cfg)
+	md, err := parseTOMLStrict(string(tomlBytes), cfg)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	if err := cfg.validate(); err != nil {
+	if err := cfg.validate(md); err != nil {
 		return fmt.Errorf("config validation failed: %w", err)
 	}
 	return nil
 }
 
-func parseTOMLStrict[T any](tomlString string, out T) error {
+func parseTOMLStrict[T any](tomlString string, out T) (toml.MetaData, error) {
 	md, err := toml.Decode(tomlString, out)
 	if err != nil {
-		return fmt.Errorf("failed to decode toml: %w", err)
+		return toml.MetaData{}, fmt.Errorf("failed to decode toml: %w", err)
 	}
 	if len(md.Undecoded()) > 0 {
-		return fmt.Errorf("strict decode failed, found undecoded fields: %+v", md.Undecoded())
+		return toml.MetaData{}, fmt.Errorf("strict decode failed, found undecoded fields: %+v", md.Undecoded())
 	}
-	return nil
+	return md, nil
 }

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap/keys"
 	"github.com/smartcontractkit/chainlink-ccv/pkg/monitoring"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // JDConfig is the configuration for the Job Distributor.
@@ -143,15 +144,22 @@ type Config struct {
 	Monitoring *monitoring.Config
 }
 
-// hasInfraKeys reports whether any infra section (jd, db, keystore, server) appears in md.
-func hasInfraKeys(md toml.MetaData) bool {
+// presentInfraSections returns the infra sections (jd, db, keystore, server) that appear in md,
+// in declaration order and de-duplicated. Used only to warn when infra is present in static-TOML
+// mode, where it is ignored; infra presence does not drive validation (see validate).
+func presentInfraSections(md toml.MetaData) []string {
+	seen := make(map[string]bool, 4)
+	var out []string
 	for _, key := range md.Keys() {
-		switch key[0] {
+		switch section := key[0]; section {
 		case "jd", "db", "keystore", "server":
-			return true
+			if !seen[section] {
+				seen[section] = true
+				out = append(out, section)
+			}
 		}
 	}
-	return false
+	return out
 }
 
 // validateInfra validates the coupled infra bundle (jd/db/keystore/server/chains).
@@ -177,15 +185,26 @@ func (c *Config) validateInfra() []error {
 	return errs
 }
 
-// validate checks the config for correctness. md is the TOML metadata from decoding, used to
-// detect which top-level sections were actually present in the file (as opposed to zero-valued
-// from an absent section). The infra bundle (jd/db/keystore/server) is validated only when any
-// infra key appears in md — so a monitoring-only bootstrap file is valid. Monitoring is always
-// validated independently when non-nil.
-func (c *Config) validate(md toml.MetaData) error {
+// validate checks the config for correctness. Validation is mode-driven, keyed on needsInfra —
+// which the caller derives from the bootstrapper's mode (true in JD mode, false in static-TOML
+// mode) — rather than inferred from which sections happen to be present in the file:
+//
+//   - needsInfra: the infra bundle (jd/db/keystore/server/chains) is required; a missing or
+//     invalid section is an error naming that section. This lets a JD-mode app with a malformed
+//     bootstrap file fail at load time with a precise message, instead of a downstream connection
+//     failure that a present-driven check would allow through.
+//   - !needsInfra: the infra bundle is ignored. Any infra section present in md is warned about
+//     (it does nothing in static-TOML mode) but is not an error.
+//
+// Monitoring is always validated when non-nil, in both modes. md is used only to name the
+// ignored sections in the static-mode warning.
+func (c *Config) validate(lggr logger.Logger, md toml.MetaData, needsInfra bool) error {
 	var errs []error
-	if hasInfraKeys(md) {
+	if needsInfra {
 		errs = append(errs, c.validateInfra()...)
+	} else if present := presentInfraSections(md); len(present) > 0 {
+		lggr.Warnw("ignoring infra sections present in static-TOML mode bootstrap config; "+
+			"these belong in a JD-mode bootstrap config", "sections", present)
 	}
 	if c.Monitoring != nil {
 		if err := c.Monitoring.Validate(); err != nil {
@@ -196,7 +215,9 @@ func (c *Config) validate(md toml.MetaData) error {
 }
 
 // LoadAndValidateConfig loads the configuration from a path to a TOML file, in strict mode.
-func LoadAndValidateConfig(path string, cfg *Config) error {
+// needsInfra selects mode-driven validation (see validate): pass true in JD mode, false in
+// static-TOML mode.
+func LoadAndValidateConfig(lggr logger.Logger, path string, cfg *Config, needsInfra bool) error {
 	tomlBytes, err := os.ReadFile(path) //nolint:gosec // G304: path is provided by trusted caller
 	if err != nil {
 		return fmt.Errorf("failed to read config file: %w", err)
@@ -207,7 +228,7 @@ func LoadAndValidateConfig(path string, cfg *Config) error {
 		return fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	if err := cfg.validate(md); err != nil {
+	if err := cfg.validate(lggr, md, needsInfra); err != nil {
 		return fmt.Errorf("config validation failed: %w", err)
 	}
 	return nil

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -143,6 +143,40 @@ type Config struct {
 	Monitoring *monitoring.Config
 }
 
+// hasInfraKeys reports whether any infra section (jd, db, keystore, server) appears in md.
+func hasInfraKeys(md toml.MetaData) bool {
+	for _, key := range md.Keys() {
+		switch key[0] {
+		case "jd", "db", "keystore", "server":
+			return true
+		}
+	}
+	return false
+}
+
+// validateInfra validates the coupled infra bundle (jd/db/keystore/server/chains).
+func (c *Config) validateInfra() []error {
+	var errs []error
+	if err := c.JD.validate(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to validate 'jd' section: %w", err))
+	}
+	if err := c.Keystore.validate(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to validate 'keystore' section: %w", err))
+	}
+	if err := c.DB.validate(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to validate 'db' section: %w", err))
+	}
+	if err := c.Server.validate(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to validate 'server' section: %w", err))
+	}
+	for i, chain := range c.Chains {
+		if err := chain.validate(); err != nil {
+			errs = append(errs, fmt.Errorf("invalid chain at index %d: %w", i, err))
+		}
+	}
+	return errs
+}
+
 // validate checks the config for correctness. md is the TOML metadata from decoding, used to
 // detect which top-level sections were actually present in the file (as opposed to zero-valued
 // from an absent section). The infra bundle (jd/db/keystore/server) is validated only when any
@@ -150,38 +184,9 @@ type Config struct {
 // validated independently when non-nil.
 func (c *Config) validate(md toml.MetaData) error {
 	var errs []error
-
-	infraPresent := false
-	for _, key := range md.Keys() {
-		switch key[0] {
-		case "jd", "db", "keystore", "server":
-			infraPresent = true
-		}
-		if infraPresent {
-			break
-		}
+	if hasInfraKeys(md) {
+		errs = append(errs, c.validateInfra()...)
 	}
-
-	if infraPresent {
-		if err := c.JD.validate(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to validate 'jd' section: %w", err))
-		}
-		if err := c.Keystore.validate(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to validate 'keystore' section: %w", err))
-		}
-		if err := c.DB.validate(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to validate 'db' section: %w", err))
-		}
-		if err := c.Server.validate(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to validate 'server' section: %w", err))
-		}
-		for i, chain := range c.Chains {
-			if err := chain.validate(); err != nil {
-				errs = append(errs, fmt.Errorf("invalid chain at index %d: %w", i, err))
-			}
-		}
-	}
-
 	if c.Monitoring != nil {
 		if err := c.Monitoring.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to validate 'monitoring' section: %w", err))

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -7,13 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-ccv/pkg/monitoring"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // validEd25519PublicKeyHex is 32 bytes (64 hex chars) for use in JD config tests.
 const validEd25519PublicKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 // infraMeta returns a toml.MetaData indicating all four infra sections (jd, db, keystore, server)
-// are present, for use in validate() calls that must exercise infra bundle validation.
+// are present. Under mode-driven validation, md only affects the static-mode "ignored infra"
+// warning; the infra bundle is validated based on needsInfra, not on md.
 func infraMeta(t *testing.T) toml.MetaData {
 	t.Helper()
 	var dummy Config
@@ -344,11 +346,11 @@ func TestConfig_validate(t *testing.T) {
 			errContains: []string{"failed to validate 'db' section", "failed to validate 'monitoring' section"},
 		},
 	}
-	// All table cases above have infra sections configured; pass infraMeta so the infra bundle is validated.
+	// All table cases above exercise JD mode (needsInfra=true) so the infra bundle is validated.
 	infraMD := infraMeta(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.validate(infraMD)
+			err := tt.config.validate(logger.Test(t), infraMD, true)
 			if tt.wantErr {
 				require.Error(t, err)
 				for _, sub := range tt.errContains {
@@ -360,10 +362,28 @@ func TestConfig_validate(t *testing.T) {
 		})
 	}
 
-	// A monitoring-only config (no infra sections in TOML) must pass validation.
-	t.Run("monitoring-only config (no infra) is valid", func(t *testing.T) {
+	// A monitoring-only config in static-TOML mode (needsInfra=false) must pass validation.
+	t.Run("monitoring-only config (static mode) is valid", func(t *testing.T) {
 		cfg := &Config{Monitoring: validBeholderMonitoring()}
-		require.NoError(t, cfg.validate(toml.MetaData{}))
+		require.NoError(t, cfg.validate(logger.Test(t), toml.MetaData{}, false))
+	})
+
+	// Static-TOML mode ignores the infra bundle entirely: an empty/invalid infra config still
+	// passes because needsInfra=false, even when md reports infra sections present (they are only
+	// warned about, not validated). This is the mode-driven behavior that replaces presence-driven.
+	t.Run("static mode ignores present infra (no error)", func(t *testing.T) {
+		cfg := &Config{Monitoring: validBeholderMonitoring()}
+		require.NoError(t, cfg.validate(logger.Test(t), infraMeta(t), false))
+	})
+
+	// Symmetric guard: the same empty infra config in JD mode (needsInfra=true) DOES fail, naming
+	// the missing sections — the precise, load-time error that motivated mode-driven validation.
+	t.Run("JD mode requires infra (names missing sections)", func(t *testing.T) {
+		cfg := &Config{Monitoring: validBeholderMonitoring()}
+		err := cfg.validate(logger.Test(t), toml.MetaData{}, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to validate 'jd' section")
+		require.Contains(t, err.Error(), "failed to validate 'db' section")
 	})
 }
 
@@ -410,7 +430,7 @@ func TestConfig_validate_Chains(t *testing.T) {
 	t.Run("no chains is valid", func(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer}
-		require.NoError(t, cfg.validate(infraMD))
+		require.NoError(t, cfg.validate(logger.Test(t), infraMD, true))
 	})
 
 	t.Run("valid chains", func(t *testing.T) {
@@ -419,7 +439,7 @@ func TestConfig_validate_Chains(t *testing.T) {
 			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
 			Chains: []ChainRegistration{{Type: "EVM", ID: "1"}, {Type: "EVM", ID: "137"}},
 		}
-		require.NoError(t, cfg.validate(infraMD))
+		require.NoError(t, cfg.validate(logger.Test(t), infraMD, true))
 	})
 
 	t.Run("invalid chain entry fails validation", func(t *testing.T) {
@@ -428,7 +448,7 @@ func TestConfig_validate_Chains(t *testing.T) {
 			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
 			Chains: []ChainRegistration{{Type: "NOTACHAIN", ID: "1"}},
 		}
-		err := cfg.validate(infraMD)
+		err := cfg.validate(logger.Test(t), infraMD, true)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid chain at index 0")
 	})

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-ccv/pkg/monitoring"
@@ -10,6 +11,26 @@ import (
 
 // validEd25519PublicKeyHex is 32 bytes (64 hex chars) for use in JD config tests.
 const validEd25519PublicKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// infraMeta returns a toml.MetaData indicating all four infra sections (jd, db, keystore, server)
+// are present, for use in validate() calls that must exercise infra bundle validation.
+func infraMeta(t *testing.T) toml.MetaData {
+	t.Helper()
+	var dummy Config
+	md, err := toml.Decode(`
+[jd]
+server_wsrpc_url = ""
+server_csa_public_key = ""
+[db]
+url = ""
+[keystore]
+password = ""
+[server]
+listen_port = 0
+`, &dummy)
+	require.NoError(t, err)
+	return md
+}
 
 // validBeholderMonitoring returns a fully-populated, enabled beholder monitoring config
 // whose Validate() passes, for use in Config validation tests.
@@ -323,9 +344,11 @@ func TestConfig_validate(t *testing.T) {
 			errContains: []string{"failed to validate 'db' section", "failed to validate 'monitoring' section"},
 		},
 	}
+	// All table cases above have infra sections configured; pass infraMeta so the infra bundle is validated.
+	infraMD := infraMeta(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.validate()
+			err := tt.config.validate(infraMD)
 			if tt.wantErr {
 				require.Error(t, err)
 				for _, sub := range tt.errContains {
@@ -336,6 +359,12 @@ func TestConfig_validate(t *testing.T) {
 			}
 		})
 	}
+
+	// A monitoring-only config (no infra sections in TOML) must pass validation.
+	t.Run("monitoring-only config (no infra) is valid", func(t *testing.T) {
+		cfg := &Config{Monitoring: validBeholderMonitoring()}
+		require.NoError(t, cfg.validate(toml.MetaData{}))
+	})
 }
 
 func TestChainRegistration_validate(t *testing.T) {
@@ -376,10 +405,12 @@ func TestConfig_validate_Chains(t *testing.T) {
 	validDB := DBConfig{URL: "postgres://localhost/test"}
 	validServer := ServerConfig{ListenPort: 9988}
 
+	infraMD := infraMeta(t)
+
 	t.Run("no chains is valid", func(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer}
-		require.NoError(t, cfg.validate())
+		require.NoError(t, cfg.validate(infraMD))
 	})
 
 	t.Run("valid chains", func(t *testing.T) {
@@ -388,7 +419,7 @@ func TestConfig_validate_Chains(t *testing.T) {
 			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
 			Chains: []ChainRegistration{{Type: "EVM", ID: "1"}, {Type: "EVM", ID: "137"}},
 		}
-		require.NoError(t, cfg.validate())
+		require.NoError(t, cfg.validate(infraMD))
 	})
 
 	t.Run("invalid chain entry fails validation", func(t *testing.T) {
@@ -397,7 +428,7 @@ func TestConfig_validate_Chains(t *testing.T) {
 			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
 			Chains: []ChainRegistration{{Type: "NOTACHAIN", ID: "1"}},
 		}
-		err := cfg.validate()
+		err := cfg.validate(infraMD)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid chain at index 0")
 	})

--- a/build/devenv/services/tokenVerifier.go
+++ b/build/devenv/services/tokenVerifier.go
@@ -16,7 +16,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	aggregator "github.com/smartcontractkit/chainlink-ccv/aggregator/pkg"
+	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/util"
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/accessors/evm"
 	ccvblockchain "github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
@@ -113,16 +113,29 @@ func NewTokenVerifier(in *TokenVerifierInput, blockchainOutputs []*blockchain.Ou
 		return nil, fmt.Errorf("failed to create database: %w", err)
 	}
 
-	// Generate and store config file.
-	config, err := in.GenerateConfigWithBlockchainInfos(blockchainInfos)
+	// Generate and write the app config.
+	appConfig, err := in.GenerateConfigWithBlockchainInfos(blockchainInfos)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate verifier config for token verifier %w", err)
 	}
 
 	confDir := util.CCVConfigDir()
-	configFilePath := filepath.Join(confDir, "verifier-config.toml")
-	if err := os.WriteFile(configFilePath, config, 0o644); err != nil {
-		return nil, fmt.Errorf("failed to write aggregator config to file: %w", err)
+	appConfigFilePath := filepath.Join(confDir, "token-verifier-app-config.toml")
+	if err := os.WriteFile(appConfigFilePath, appConfig, 0o644); err != nil {
+		return nil, fmt.Errorf("failed to write token verifier app config to file: %w", err)
+	}
+
+	// Generate and write the bootstrap (operator) config, carrying monitoring from the generated config.
+	// Only the monitoring section is set; the infra sections (jd/db/keystore/server) are zero-valued
+	// and omitted from the TOML output via omitempty, so validation correctly skips infra checks.
+	monitoringCfg := in.GeneratedConfig.Monitoring
+	bootstrapConfig, err := toml.Marshal(bootstrap.Config{Monitoring: &monitoringCfg})
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate bootstrap config for token verifier: %w", err)
+	}
+	bootstrapConfigFilePath := filepath.Join(confDir, "token-verifier-bootstrap-config.toml")
+	if err := os.WriteFile(bootstrapConfigFilePath, bootstrapConfig, 0o644); err != nil {
+		return nil, fmt.Errorf("failed to write token verifier bootstrap config to file: %w", err)
 	}
 
 	envVars := make(map[string]string)
@@ -130,6 +143,8 @@ func NewTokenVerifier(in *TokenVerifierInput, blockchainOutputs []*blockchain.Ou
 	internalDBConnectionString := fmt.Sprintf("postgresql://%s:%s@%s:5432/%s?sslmode=disable",
 		in.ContainerName, in.ContainerName, in.DB.Name, in.ContainerName)
 	envVars["CL_DATABASE_URL"] = internalDBConnectionString
+	envVars["TOKEN_VERIFIER_CONFIG_PATH"] = "/etc/token-verifier-app-config.toml"
+	envVars["BOOTSTRAPPER_CONFIG_PATH"] = bootstrap.DefaultConfigPath
 	if lvl := os.Getenv("LOG_LEVEL"); lvl != "" {
 		envVars["LOG_LEVEL"] = lvl
 	}
@@ -161,10 +176,10 @@ func NewTokenVerifier(in *TokenVerifierInput, blockchainOutputs []*blockchain.Ou
 	}
 
 	req.Mounts = testcontainers.Mounts()
-	req.Mounts = append(req.Mounts, testcontainers.BindMount(
-		configFilePath,
-		aggregator.DefaultConfigFile, // TODO: switch to token verifier path, not aggregator path.
-	))
+	req.Mounts = append(req.Mounts,
+		testcontainers.BindMount(appConfigFilePath, "/etc/token-verifier-app-config.toml"),
+		testcontainers.BindMount(bootstrapConfigFilePath, bootstrap.DefaultConfigPath),
+	)
 
 	// Note: identical code to aggregator.go/executor.go -- will indexer be identical as well?
 	if in.SourceCodePath != "" {

--- a/build/devenv/services/tokenVerifier.template.toml
+++ b/build/devenv/services/tokenVerifier.template.toml
@@ -1,14 +1,1 @@
 pyroscope_url = "http://pyroscope:4040"
-
-[Monitoring]
-Enabled = true
-Type = "beholder"
-[Monitoring.Beholder]
-InsecureConnection = true
-CACertFile = ""
-OtelExporterGRPCEndpoint = ""
-OtelExporterHTTPEndpoint = "host.docker.internal:4318"
-LogStreamingEnabled = true
-MetricReaderInterval = 5
-TraceSampleRatio = 1.0
-TraceBatchTimeout = 10

--- a/changelog/2026-07-01_token_verifier_operator_config.md
+++ b/changelog/2026-07-01_token_verifier_operator_config.md
@@ -99,10 +99,12 @@ constructing their own logger.
 
 ## New: mode-aware bootstrap config validation {#config-validate-mode-aware}
 
-`bootstrap.Config.validate()` now detects whether the infra bundle (`[jd]`, `[db]`,
-`[keystore]`, `[server]`) was present in the decoded TOML using `toml.MetaData.Keys()`.
-Infra validation runs only when at least one infra key is present; monitoring is always
-validated independently. This makes a monitoring-only bootstrap TOML valid:
+`bootstrap.Config.validate()` is now **mode-driven**: it validates the infra bundle
+(`[jd]`, `[db]`, `[keystore]`, `[server]`) only when the bootstrapper runs in JD mode
+(the caller passes `needsInfra=true`, derived from the `jdMode` flag). In static-TOML
+mode (`needsInfra=false`) the infra bundle is ignored — any infra section present is
+logged as a warning, not an error. Monitoring is always validated independently, in both
+modes. This makes a monitoring-only bootstrap TOML valid:
 
 ```toml
 # Valid for token verifier — no infra sections required
@@ -118,9 +120,10 @@ TraceSampleRatio = 1.0
 TraceBatchTimeout = 5
 ```
 
-The infra struct fields (`JD`, `Keystore`, `DB`, `Server`) also gained `omitempty`
-TOML marshal tags so that marshaling a monitoring-only `bootstrap.Config` does not emit
-empty infra sections that would trigger infra validation on reload.
+The infra struct fields (`JD`, `Keystore`, `DB`, `Server`) also carry `omitempty` TOML
+marshal tags so that marshaling a monitoring-only `bootstrap.Config` does not emit empty
+infra sections — which, on reload in static-TOML mode, would otherwise be logged as
+"ignored infra section" warnings.
 
 ---
 

--- a/changelog/2026-07-01_token_verifier_operator_config.md
+++ b/changelog/2026-07-01_token_verifier_operator_config.md
@@ -1,0 +1,234 @@
+# Token verifier adopts bootstrap operator config for monitoring
+
+## Summary
+
+The token verifier now sources monitoring config from the bootstrap TOML
+(`BOOTSTRAPPER_CONFIG_PATH`) in addition to its existing app config path, resolving the
+exception documented in the previous changelog. This is the prerequisite for a
+structured OTel log-streaming logger constructed in bootstrap code and delivered via
+`ServiceDeps.Logger`. The change is backwards compatible — existing deployments without
+a bootstrap config file continue to read monitoring from the app config as before.
+
+- Affects: `bootstrap`, `cmd/verifier/token`, `build/devenv/services`
+- Does **not** affect the commit verifier or executor (their paths are unchanged)
+
+## AI Adapter Index
+
+| Symbol | Kind | Search | Location | Section |
+|---|---|---|---|---|
+| `bootstrap.Config` infra fields | changed | `bootstrap\.Config\b` | `bootstrap/config.go:123` | [#config-validate-mode-aware](#config-validate-mode-aware) |
+| `bootstrap.ServiceDeps.Monitoring` | changed | `ServiceDeps\b` | `bootstrap/bootstrap.go:57` | [#servicedeps-now-populated-in-static-toml-mode](#servicedeps-now-populated-in-static-toml-mode) |
+| `bootstrap.WithJD` + `bootstrap.WithTOMLAppConfig` | changed | `WithJD\(\)\|WithTOMLAppConfig\(` | `bootstrap/bootstrap.go` | [#withJD-and-withtomLappconfig-are-now-mutually-exclusive](#withJD-and-withtomLappconfig-are-now-mutually-exclusive) |
+| `token.Config.Monitoring` | deprecated | `token\.Config\b` | `verifier/pkg/token/config.go` | [#token-verifier-app-config-monitoring-deprecated](#token-verifier-app-config-monitoring-deprecated) |
+| `services.NewTokenVerifier` (devenv) | changed | `NewTokenVerifier\(` | `build/devenv/services/tokenVerifier.go:62` | [#devenv-two-config-files](#devenv-two-config-files) |
+
+---
+
+## Breaking change: `WithJD` and `WithTOMLAppConfig` are now mutually exclusive
+
+Previously, calling both options on the same bootstrapper silently picked JD mode and
+ignored the app config path. `NewBootstrapper` now returns an error immediately.
+
+```go
+// Before — silently started in JD mode, WithTOMLAppConfig was ignored
+b, _ := bootstrap.NewBootstrapper("svc", lggr, fac,
+    bootstrap.WithJD(),
+    bootstrap.WithTOMLAppConfig("/etc/app.toml"),
+)
+
+// After — returns: "WithJD and WithTOMLAppConfig are mutually exclusive"
+b, err := bootstrap.NewBootstrapper("svc", lggr, fac,
+    bootstrap.WithJD(),
+    bootstrap.WithTOMLAppConfig("/etc/app.toml"),
+)
+```
+
+This is unlikely to affect real callers (the combination was always wrong), but worth
+checking if any test or integration harness constructed bootstrappers this way.
+
+---
+
+## New: operator config loading in static-TOML mode
+
+`NewBootstrapper` in static-TOML mode (`WithTOMLAppConfig`) now optionally loads a
+bootstrap TOML from `BOOTSTRAPPER_CONFIG_PATH` **when that env var is explicitly set**.
+If present, `[monitoring]` (and any future operator sections) are decoded and surfaced
+via `ServiceDeps.Monitoring`.
+
+The default fallback to `/etc/config.toml` is **intentionally suppressed** in
+static-TOML mode: the token verifier's `TOKEN_VERIFIER_CONFIG_PATH` and the bootstrap
+`BOOTSTRAPPER_CONFIG_PATH` both default to that path, so applying the default would
+silently decode the wrong file. Set the env var explicitly to opt in.
+
+```toml
+# /etc/bootstrap-config.toml  (operator mounts this alongside the app config)
+[monitoring]
+Enabled = true
+Type = "beholder"
+
+[monitoring.Beholder]
+OtelExporterGRPCEndpoint = "localhost:4317"
+MetricReaderInterval = 10
+TraceSampleRatio = 1.0
+TraceBatchTimeout = 5
+```
+
+```sh
+BOOTSTRAPPER_CONFIG_PATH=/etc/bootstrap-config.toml
+TOKEN_VERIFIER_CONFIG_PATH=/etc/token-verifier-app-config.toml
+```
+
+---
+
+## New: `ServiceDeps.Logger` and `ServiceDeps.Monitoring` populated in static-TOML mode
+
+`startWithAppConfig` previously handed service factories an almost-empty `ServiceDeps`
+(only `Registry` was set). It now constructs a full `ServiceDeps`:
+
+| Field | Before | After |
+|---|---|---|
+| `Logger` | `nil` | built from `WithLogLevelFromEnv` / `WithLogLevel` option |
+| `Registry` | set | set (unchanged) |
+| `Keystore` | `nil` | `nil` (no keystore in static-TOML mode) |
+| `Monitoring` | `nil` | set from bootstrap config when loaded; `nil` otherwise |
+
+Service factories in static-TOML mode should use `deps.Logger` directly instead of
+constructing their own logger.
+
+---
+
+## New: mode-aware bootstrap config validation {#config-validate-mode-aware}
+
+`bootstrap.Config.validate()` now detects whether the infra bundle (`[jd]`, `[db]`,
+`[keystore]`, `[server]`) was present in the decoded TOML using `toml.MetaData.Keys()`.
+Infra validation runs only when at least one infra key is present; monitoring is always
+validated independently. This makes a monitoring-only bootstrap TOML valid:
+
+```toml
+# Valid for token verifier — no infra sections required
+[monitoring]
+Enabled = true
+Type = "beholder"
+
+[monitoring.Beholder]
+OtelExporterHTTPEndpoint = "host.docker.internal:4318"
+LogStreamingEnabled = true
+MetricReaderInterval = 10
+TraceSampleRatio = 1.0
+TraceBatchTimeout = 5
+```
+
+The infra struct fields (`JD`, `Keystore`, `DB`, `Server`) also gained `omitempty`
+TOML marshal tags so that marshaling a monitoring-only `bootstrap.Config` does not emit
+empty infra sections that would trigger infra validation on reload.
+
+---
+
+## Deprecation: token verifier app-config monitoring {#token-verifier-app-config-monitoring-deprecated}
+
+`token.Config.Monitoring` is now deprecated. The token verifier reads monitoring via
+`bootstrap.ResolveMonitoring(deps.Monitoring, cfg.Monitoring)`, preferring the bootstrap
+config and falling back to the app-config field only when `deps.Monitoring` is `nil`
+(i.e. no bootstrap config is loaded). This is the same F2 fallback pattern introduced
+for the commit verifier and executor in the previous migration.
+
+**Planned removal:** once all token verifier deployments mount a bootstrap config,
+remove `token.Config.Monitoring` and the fallback call in the factory.
+
+---
+
+## Devenv: two config files for the token verifier {#devenv-two-config-files}
+
+`services.NewTokenVerifier` now generates and mounts two files:
+
+| File | Container path | Env var |
+|---|---|---|
+| App config (blockchain infos, verifier config) | `/etc/token-verifier-app-config.toml` | `TOKEN_VERIFIER_CONFIG_PATH` |
+| Bootstrap config (monitoring only) | `/etc/config.toml` | `BOOTSTRAPPER_CONFIG_PATH` |
+
+The `[Monitoring]` section has been removed from `tokenVerifier.template.toml`; it is
+now carried solely by the bootstrap config. This also fixes a pre-existing bug where the
+app config was mounted at `aggregator.DefaultConfigFile` (`/etc/config.toml`) instead
+of a token-verifier-specific path.
+
+---
+
+## Migration guide: token verifier in production
+
+The change is **backwards compatible**. No immediate action is required — monitoring
+continues to be read from the app config via the F2 fallback until you opt in.
+
+### Step 1 — add a bootstrap config for the token verifier
+
+Create a new TOML file that the token verifier can mount as its operator config. It only
+needs the monitoring section — no DB, JD, keystore, or server entries:
+
+```toml
+# token-verifier-operator-config.toml
+[monitoring]
+Enabled = true
+Type = "beholder"
+
+[monitoring.Beholder]
+OtelExporterGRPCEndpoint = "<your-otel-collector>:4317"  # or HTTP endpoint below
+# OtelExporterHTTPEndpoint = "<your-otel-collector>:4318"
+InsecureConnection = false
+CACertFile = ""
+LogStreamingEnabled = true
+MetricReaderInterval = 10
+TraceSampleRatio = 1.0
+TraceBatchTimeout = 5
+```
+
+### Step 2 — mount the file and set the env var
+
+In your k8s deployment, mount the new ConfigMap alongside the existing app config and
+set `BOOTSTRAPPER_CONFIG_PATH`:
+
+```yaml
+env:
+  - name: TOKEN_VERIFIER_CONFIG_PATH
+    value: /etc/token-verifier/app-config.toml   # wherever your app config is mounted
+  - name: BOOTSTRAPPER_CONFIG_PATH
+    value: /etc/token-verifier/operator-config.toml
+volumeMounts:
+  - name: app-config
+    mountPath: /etc/token-verifier/app-config.toml
+    subPath: config.toml
+  - name: operator-config
+    mountPath: /etc/token-verifier/operator-config.toml
+    subPath: operator-config.toml
+```
+
+### Step 3 — roll the binary
+
+Deploy the new binary. On startup it will log:
+
+```
+loaded operator config for static-TOML mode
+Using monitoring config from bootstrap config
+```
+
+Monitoring continues uninterrupted. The app-config `[monitoring]` field is now ignored
+(bootstrap wins); you can leave it in place or remove it from the app config at your
+convenience — it is no longer read.
+
+### Rollout matrix
+
+| Binary | `BOOTSTRAPPER_CONFIG_PATH` set | Monitoring source |
+|---|---|---|
+| old | n/a | app config (unchanged) |
+| new | not set | app config fallback (unchanged) |
+| new | set, file present | bootstrap config (new behaviour) |
+| new | set, file absent | startup error — `LoadAndValidateConfig` fails |
+
+### Step 4 — cleanup (later, non-urgent)
+
+Once all instances are migrated, open a follow-up to remove `token.Config.Monitoring`
+and the `ResolveMonitoring` call in the factory.
+
+---
+
+## References
+
+- Prior changelog: `2026-06-24_monitoring_config_in_bootstrap.md`

--- a/cmd/verifier/token/main.go
+++ b/cmd/verifier/token/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/integration/pkg/heartbeatclient"
 	"github.com/smartcontractkit/chainlink-ccv/pkg/chainaccess"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
-	"github.com/smartcontractkit/chainlink-ccv/protocol/common/logging"
 	verifier "github.com/smartcontractkit/chainlink-ccv/verifier/pkg"
 	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/chainstatus"
 	"github.com/smartcontractkit/chainlink-ccv/verifier/pkg/monitoring"
@@ -45,6 +44,7 @@ func main() {
 		"TokenVerifier",
 		&tokenVerifierFactory{},
 		bootstrap.WithTOMLAppConfig(configPath),
+		bootstrap.WithLogLevelFromEnv(zapcore.InfoLevel),
 	)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to run token verifier: %v\n", err)
@@ -96,27 +96,7 @@ func (tvf *tokenVerifierFactory) Start(ctx context.Context, spec bootstrap.JobSp
 		return errors.Join(errs...)
 	}
 
-	// TODO: Add "WithLogLevelFromEnv" option and use deps.lggr.
-	{
-		logLevelStr := os.Getenv("LOG_LEVEL")
-		if logLevelStr == "" {
-			logLevelStr = "info"
-		}
-		var zapLevel zapcore.Level
-		if err := zapLevel.UnmarshalText([]byte(logLevelStr)); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Invalid LOG_LEVEL '%s', defaulting to 'info'\n", logLevelStr)
-			zapLevel = zapcore.InfoLevel
-		}
-		var err error
-		tvf.lggr, err = logger.NewWith(logging.GetLogProfile(zapLevel))
-		if err != nil {
-			return fmt.Errorf("failed to create logger: %v", err)
-		}
-		tvf.lggr = logger.Named(tvf.lggr, "verifier")
-	}
-
-	// Use SugaredLogger for better API
-	tvf.lggr = logger.Sugared(tvf.lggr)
+	tvf.lggr = deps.Logger
 
 	protocol.InitChainSelectorCache()
 
@@ -148,7 +128,8 @@ func (tvf *tokenVerifierFactory) Start(ctx context.Context, spec bootstrap.JobSp
 		tvf.lggr.Infow("Created source reader for chain", "chainSelector", selector)
 	}
 
-	verifierMonitoring := cmd.SetupMonitoring(tvf.lggr, cfg.Monitoring, "token_verifier")
+	monitoringCfg := bootstrap.ResolveMonitoring(tvf.lggr, deps.Monitoring, cfg.Monitoring)
+	verifierMonitoring := cmd.SetupMonitoring(tvf.lggr, monitoringCfg, "token_verifier")
 
 	rmnRemoteAddresses := make(map[string]protocol.UnknownAddress)
 	for selector, address := range cfg.RMNRemoteAddresses {


### PR DESCRIPTION
## Description

The token verifier previously sourced monitoring config from its own app config TOML, which was fine when monitoring was the only operator-provided section. The blocker was that `bootstrap.Config` unconditionally required the full infra bundle (JD/DB/Keystore/Server), so the token verifier, which runs in static-TOML mode with no DB or JD,  couldn't load a bootstrap config at all.

The trigger to fix this arrived: a structured OTel log-streaming logger will be constructed in bootstrap code from `monitoring.Config` and delivered to service factories via `ServiceDeps.Logger`. The token verifier must receive that logger, which means it must participate in the same operator-config load path as the commit verifier and executor.

**What changed:**

- bootstrap.Config.validate() is now mode-driven. It validates the infra bundle ([jd], [db], [keystore], [server]) only in JD mode, keyed on the jdMode flag (passed as needsInfra), not on which sections happen to be present in the TOML. 
  - In static-TOML mode the infra bundle is ignored: any infra section present is logged as a warning, not an error. Monitoring is always validated independently, in both modes. This makes a monitoring-only bootstrap TOML valid, while a JD-mode app with a missing/malformed infra section still fails at load time with a precise, per-section error.

- `Bootstrapper` gains an unexported `jdMode bool`. `Start()` routes on this flag instead of `b.config != nil`, because `b.config` can now be set in both modes. In static-TOML mode, if `BOOTSTRAPPER_CONFIG_PATH` is explicitly set, the bootstrap TOML is loaded (no default fallback to `/etc/config.toml`; that would collide with `TOKEN_VERIFIER_CONFIG_PATH`, which shares the same default; will create a follow-up ticket for this).

- `startWithAppConfig` now builds a full `ServiceDeps` (Logger + Monitoring). Previously it only set `Registry`. The token verifier's inline logger-creation block (and its `// TODO: use deps.lggr` comment) is gone; it uses `deps.Logger` via `WithLogLevelFromEnv`.

- The token verifier uses `bootstrap.ResolveMonitoring(deps.Monitoring, cfg.Monitoring)` — the same F2 fallback pattern as the commit verifier and executor — so existing deployments without a bootstrap config continue to read monitoring from the app config unchanged.

- Devenv generates a separate bootstrap config (monitoring only) for the token verifier alongside its app config, and sets both `TOKEN_VERIFIER_CONFIG_PATH` and `BOOTSTRAPPER_CONFIG_PATH` explicitly. This also fixes the pre-existing TODO where the app config was mounted at `aggregator.DefaultConfigFile`.

The change is backwards compatible. No operator action is required until they want to opt in; see the migration guide in `changelog/2026-07-01_token_verifier_operator_config.md`.

## Testing

- `go test ./bootstrap/...`.

## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date