### PR TITLE
.github/workflows: fix triggers wedging release PRs

### DIFF
--- a/.github/workflows/test-deployment-module.yaml
+++ b/.github/workflows/test-deployment-module.yaml
@@ -41,7 +41,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only "${BASE_SHA}...HEAD" | grep -qE '^deployment/'; then
+          if git diff --name-only "${BASE_SHA}...HEAD" | grep -qE '^(deployment/|\.github/workflows/test-deployment-module\.yaml)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-evm-integration-module.yaml
+++ b/.github/workflows/test-evm-integration-module.yaml
@@ -3,13 +3,9 @@ name: EVM Integration Module Tests
 on:
   merge_group:
   pull_request:
-    paths:
-      - "integration/evm/**"
   push:
     branches:
       - main
-    paths:
-      - "integration/evm/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,7 +18,37 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Full history so the change-detection step can diff against the PR base.
+          fetch-depth: 0
+
+      # This job intentionally has no `paths:` filter so it runs (and reports a status) on every
+      # PR — a required check with a paths filter deadlocks PRs that don't touch the filtered
+      # paths. Only the expensive steps below are gated on integration/evm/** actually changing.
+      - name: Detect evm changes
+        id: changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # merge_group (the merge-queue gate) and push to main always run the full suite.
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "${BASE_SHA}...HEAD" | grep -qE '^(integration/evm/|\.github/workflows/test-evm-integration-module\.yaml)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No integration/evm/** changes; skipping evm integration module tests."
+          fi
+
       - name: Setup GitHub Token
+        if: steps.changes.outputs.changed == 'true'
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
         with:
@@ -31,10 +57,8 @@ jobs:
           aws-region: ${{ secrets.GATI_AWS_REGION }}
           set-git-config: true
 
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
       - name: Set up Go
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-go@v6
         env:
           GOPRIVATE: github.com/smartcontractkit/*
@@ -44,5 +68,6 @@ jobs:
           cache-dependency-path: integration/evm/go.sum
 
       - name: Run tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: integration/evm
         run: go test ./...

--- a/.github/workflows/test-services.yaml
+++ b/.github/workflows/test-services.yaml
@@ -2,7 +2,10 @@ name: Services CCV Tests
 
 on:
   merge_group:
+  pull_request:
   push:
+    branches:
+      - main
 
 defaults:
   run:
@@ -19,7 +22,38 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          # Full history so the change-detection step can diff against the PR base.
+          fetch-depth: 0
+
+      # This job intentionally has no `paths:` filter so it runs (and reports a status) on every
+      # PR — a required check with a paths filter deadlocks PRs that don't touch the filtered
+      # paths. Only the expensive steps below are gated on relevant service source changing.
+      - name: Detect service changes
+        id: changes
+        shell: bash
+        working-directory: .
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # merge_group (the merge-queue gate) and push to main always run the full suite.
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "${BASE_SHA}...HEAD" | grep -qE '^(build/devenv/|aggregator/|executor/|verifier/|indexer/|pricer/|protocol/|common/|pkg/|\.github/workflows/test-services\.yaml)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No relevant service source changes; skipping services tests."
+          fi
+
       - name: Setup GitHub Token
+        if: steps.changes.outputs.changed == 'true'
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
         with:
@@ -28,20 +62,18 @@ jobs:
           aws-region: ${{ secrets.GATI_AWS_REGION }}
           set-git-config: true
 
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
       - name: Set up Docker Buildx
+        if: steps.changes.outputs.changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Install Just
+        if: steps.changes.outputs.changed == 'true'
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
         with:
           just-version: '1.40.0'
 
       - name: Authenticate to AWS ECR
+        if: steps.changes.outputs.changed == 'true'
         uses: ./.github/actions/aws-ecr-auth
         with:
           role-to-assume: ${{ secrets.CCV_IAM_ROLE }}
@@ -49,6 +81,7 @@ jobs:
           registry-type: public
 
       - name: Set up Go
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-go@v6 # v6
         env:
           GOPRIVATE: github.com/smartcontractkit/*
@@ -58,15 +91,18 @@ jobs:
           cache-dependency-path: build/devenv/go.sum
 
       - name: Download Go dependencies
+        if: steps.changes.outputs.changed == 'true'
         run: |
           go mod download
 
       - name: Build Docker Images
+        if: steps.changes.outputs.changed == 'true'
         run: just build-docker-ci
         env:
           DOCKER_BUILDKIT: 1
 
       - name: Test Services
+        if: steps.changes.outputs.changed == 'true'
         working-directory: build/devenv/tests/services
         run: |
           go test -v -run TestService


### PR DESCRIPTION
## Description

- Drop paths: filter from evm-integration workflow's PR/push triggers so it always reports a status; add in-job change detection to gate the expensive steps instead
- Add pull_request trigger to test-services and restrict push to main; gate Docker build/ECR/test steps on a path-based change-detection step covering all service source dirs
- Self-trigger each workflow's full suite when its own yaml file changes, so edits to CI logic get exercised in the PR


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

CI workflows should trigger in this PR.


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
