### PR TITLE
CCIP-12199 tmp no strict bootstrap config parsing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 * @smartcontractkit/ccip-protocol
 build/devenv @smartcontractkit/ccip-platform
 deployment @smartcontractkit/ccip-platform
+bootstrap @smartcontractkit/ccip-platform

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -212,7 +212,7 @@ func LoadAndValidateConfig(path string, cfg *Config, needsInfra bool) error {
 	return nil
 }
 
-func parseTOML[T any](tomlString string, out T, strict bool) error {
+func parseTOML[T any](tomlString string, out *T, strict bool) error {
 	md, err := toml.Decode(tomlString, out)
 	if err != nil {
 		return fmt.Errorf("failed to decode toml: %w", err)

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -200,8 +200,8 @@ func LoadAndValidateConfig(path string, cfg *Config, needsInfra bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
-
-	err = parseTOMLStrict(string(tomlBytes), cfg)
+	// TODO switch to strict mode once config migration is over
+	err = parseTOML(string(tomlBytes), cfg, false)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %w", err)
 	}
@@ -212,12 +212,12 @@ func LoadAndValidateConfig(path string, cfg *Config, needsInfra bool) error {
 	return nil
 }
 
-func parseTOMLStrict[T any](tomlString string, out T) error {
+func parseTOML[T any](tomlString string, out T, strict bool) error {
 	md, err := toml.Decode(tomlString, out)
 	if err != nil {
 		return fmt.Errorf("failed to decode toml: %w", err)
 	}
-	if len(md.Undecoded()) > 0 {
+	if strict && len(md.Undecoded()) > 0 {
 		return fmt.Errorf("strict decode failed, found undecoded fields: %+v", md.Undecoded())
 	}
 	return nil


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
Disable bootstrap tmpl config strict mode parsing to allow deploying pods with old monitoring config layout

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing
CI checks

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
