### PR TITLE
extract bootstrap secrets to env vars

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -352,12 +352,22 @@ func buildUpdateNodeRequest(
 
 // startWithJDLifecycle initializes all components required for the JD lifecycle manager and starts it.
 func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
-	db, err := connectToDB(ctx, b.config.DB.URL)
+	dbURL, err := b.config.DB.GetURL()
+	if err != nil {
+		return err
+	}
+
+	db, err := connectToDB(ctx, dbURL)
 	if err != nil {
 		return fmt.Errorf("failed to connect to bootstrapper database: %w", err)
 	}
 
-	keyStore, csaSigner, err := initializeKeystore(ctx, b.lggr, db, b.config.Keystore.Password, b.keys)
+	keyStorePass, err := b.config.Keystore.GetPassword()
+	if err != nil {
+		return err
+	}
+
+	keyStore, csaSigner, err := initializeKeystore(ctx, b.lggr, db, keyStorePass, b.keys)
 	if err != nil {
 		return fmt.Errorf("failed to initialize keystore: %w", err)
 	}

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -354,7 +354,7 @@ func buildUpdateNodeRequest(
 func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 	dbURL, err := b.config.DB.GetURL()
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid db config: %w", err)
 	}
 
 	db, err := connectToDB(ctx, dbURL)
@@ -364,7 +364,7 @@ func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 
 	keyStorePass, err := b.config.Keystore.GetPassword()
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid keystore config: %w", err)
 	}
 
 	keyStore, csaSigner, err := initializeKeystore(ctx, b.lggr, db, keyStorePass, b.keys)

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -35,28 +35,74 @@ func (c *JDConfig) validate() error {
 
 // KeystoreConfig is the configuration for the keystore.
 type KeystoreConfig struct {
-	// Password is the password to the keystore.
+	// Password is the password to the keystore. Has precedence over PasswordEnvVar.
 	Password string `toml:"password"`
+	// PasswordEnvVar is the name of an environment variable containing the keystore password.
+	// Only used if Password is not defined.
+	PasswordEnvVar string `toml:"password_env_var"`
+}
+
+// GetPassword returns the keystore password, following the precedence rule:
+// Password (direct config) takes precedence over PasswordEnvVar (environment variable).
+// Returns an error if neither source is defined or if PasswordEnvVar references a non-existent variable.
+func (c *KeystoreConfig) GetPassword() (string, error) {
+	// If Password is defined, use it (it has precedence)
+	if c.Password != "" {
+		return c.Password, nil
+	}
+
+	// If Password is not defined, try to load from PasswordEnvVar
+	if c.PasswordEnvVar != "" {
+		envPassword := os.Getenv(c.PasswordEnvVar)
+		if envPassword == "" {
+			return "", fmt.Errorf("field 'password' is empty and environment variable %q (from 'password_env_var') is not set", c.PasswordEnvVar)
+		}
+		return envPassword, nil
+	}
+
+	// Neither Password nor PasswordEnvVar is defined
+	return "", fmt.Errorf("field 'password' is required (either 'password' or 'password_env_var' must be defined)")
 }
 
 func (c *KeystoreConfig) validate() error {
-	if c.Password == "" {
-		return fmt.Errorf("field 'password' is required")
-	}
-	return nil
+	_, err := c.GetPassword()
+	return err
 }
 
 // DBConfig is the configuration for the bootstrap database.
 type DBConfig struct {
-	// URL is the URL to use for saving jobs and the keystore.
+	// URL is the database URL. Has precedence over URLEnvVar.
 	URL string `toml:"url"`
+	// URLEnvVar is the name of an environment variable containing the database URL.
+	// Only used if URL is not defined.
+	URLEnvVar string `toml:"url_env_var"`
+}
+
+// GetURL returns the database URL, following the precedence rule:
+// URL (direct config) takes precedence over URLEnvVar (environment variable).
+// Returns an error if neither source is defined or if URLEnvVar references a non-existent variable.
+func (c *DBConfig) GetURL() (string, error) {
+	// If URL is defined, use it (it has precedence)
+	if c.URL != "" {
+		return c.URL, nil
+	}
+
+	// If URL is not defined, try to load from URLEnvVar
+	if c.URLEnvVar != "" {
+		envURL := os.Getenv(c.URLEnvVar)
+		if envURL == "" {
+			return "", fmt.Errorf("field 'url' is empty and environment variable %q (from 'url_env_var') is not set", c.URLEnvVar)
+		}
+		return envURL, nil
+	}
+
+	// Neither URL nor URLEnvVar is defined
+	return "", fmt.Errorf("field 'url' is required (either 'url' or 'url_env_var' must be defined)")
 }
 
 func (c *DBConfig) validate() error {
-	if c.URL == "" {
-		return fmt.Errorf("field 'url' is required")
-	}
-	return nil
+	_, err := c.GetURL()
+	return err
 }
 
 // ServerConfig is the configuration for the HTTP info server.

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -18,7 +18,7 @@ const (
 	DefaultDBURLEnvVar = "BOOTSTRAPPER_DATABASE_URL"
 	// DefaultKeystorePasswordEnvVar is the environment variable read for the keystore password when
 	// neither KeystoreConfig.Password nor KeystoreConfig.PasswordEnvVar is set.
-	DefaultKeystorePasswordEnvVar = "BOOTSTRAPPER_KEYSTORE_PASSWORD" //nolint:gosec // G101: env var name, not a credential
+	DefaultKeystorePasswordEnvVar = "BOOTSTRAPPER_KEYSTORE_PASSWORD"
 )
 
 // JDConfig is the configuration for the Job Distributor.

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -55,7 +55,7 @@ func (c *KeystoreConfig) GetPassword() (string, error) {
 	if c.PasswordEnvVar != "" {
 		envPassword := os.Getenv(c.PasswordEnvVar)
 		if envPassword == "" {
-			return "", fmt.Errorf("field 'password' is empty and environment variable %q (from 'password_env_var') is not set", c.PasswordEnvVar)
+			return "", fmt.Errorf("field 'password' is empty and environment variable %q (from 'password_env_var') is not set or is empty", c.PasswordEnvVar)
 		}
 		return envPassword, nil
 	}
@@ -91,7 +91,7 @@ func (c *DBConfig) GetURL() (string, error) {
 	if c.URLEnvVar != "" {
 		envURL := os.Getenv(c.URLEnvVar)
 		if envURL == "" {
-			return "", fmt.Errorf("field 'url' is empty and environment variable %q (from 'url_env_var') is not set", c.URLEnvVar)
+			return "", fmt.Errorf("field 'url' is empty and environment variable %q (from 'url_env_var') is not set or is empty", c.URLEnvVar)
 		}
 		return envURL, nil
 	}

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -12,6 +12,15 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/common/monitoring"
 )
 
+const (
+	// DefaultDBURLEnvVar is the environment variable read for the database URL when neither
+	// DBConfig.URL nor DBConfig.URLEnvVar is set. These are env var names, not secret values.
+	DefaultDBURLEnvVar = "BOOTSTRAPPER_DATABASE_URL"
+	// DefaultKeystorePasswordEnvVar is the environment variable read for the keystore password when
+	// neither KeystoreConfig.Password nor KeystoreConfig.PasswordEnvVar is set.
+	DefaultKeystorePasswordEnvVar = "BOOTSTRAPPER_KEYSTORE_PASSWORD" //nolint:gosec // G101: env var name, not a credential
+)
+
 // JDConfig is the configuration for the Job Distributor.
 type JDConfig struct {
 	// ServerWSRPCURL is the URL of the Job Distributor server's WebSocket RPC endpoint.
@@ -38,30 +47,30 @@ type KeystoreConfig struct {
 	// Password is the password to the keystore. Has precedence over PasswordEnvVar.
 	Password string `toml:"password"`
 	// PasswordEnvVar is the name of an environment variable containing the keystore password.
-	// Only used if Password is not defined.
+	// Only used if Password is not defined; defaults to DefaultKeystorePasswordEnvVar.
 	PasswordEnvVar string `toml:"password_env_var"`
 }
 
 // GetPassword returns the keystore password, following the precedence rule:
-// Password (direct config) takes precedence over PasswordEnvVar (environment variable).
-// Returns an error if neither source is defined or if PasswordEnvVar references a non-existent variable.
+// Password (direct config) takes precedence over the environment variable, whose name is
+// PasswordEnvVar when set and DefaultKeystorePasswordEnvVar otherwise.
+// Returns an error if the resolved environment variable is not set or is empty.
 func (c *KeystoreConfig) GetPassword() (string, error) {
 	// If Password is defined, use it (it has precedence)
 	if c.Password != "" {
 		return c.Password, nil
 	}
 
-	// If Password is not defined, try to load from PasswordEnvVar
-	if c.PasswordEnvVar != "" {
-		envPassword := os.Getenv(c.PasswordEnvVar)
-		if envPassword == "" {
-			return "", fmt.Errorf("field 'password' is empty and environment variable %q (from 'password_env_var') is not set or is empty", c.PasswordEnvVar)
-		}
-		return envPassword, nil
+	// Otherwise read from the environment: the configured name if set, else the default.
+	envVar := c.PasswordEnvVar
+	if envVar == "" {
+		envVar = DefaultKeystorePasswordEnvVar
 	}
-
-	// Neither Password nor PasswordEnvVar is defined
-	return "", fmt.Errorf("field 'password' is required (either 'password' or 'password_env_var' must be defined)")
+	envPassword := os.Getenv(envVar)
+	if envPassword == "" {
+		return "", fmt.Errorf("field 'password' is empty and environment variable %q is not set or is empty", envVar)
+	}
+	return envPassword, nil
 }
 
 func (c *KeystoreConfig) validate() error {
@@ -74,30 +83,30 @@ type DBConfig struct {
 	// URL is the database URL. Has precedence over URLEnvVar.
 	URL string `toml:"url"`
 	// URLEnvVar is the name of an environment variable containing the database URL.
-	// Only used if URL is not defined.
+	// Only used if URL is not defined; defaults to DefaultDBURLEnvVar.
 	URLEnvVar string `toml:"url_env_var"`
 }
 
 // GetURL returns the database URL, following the precedence rule:
-// URL (direct config) takes precedence over URLEnvVar (environment variable).
-// Returns an error if neither source is defined or if URLEnvVar references a non-existent variable.
+// URL (direct config) takes precedence over the environment variable, whose name is
+// URLEnvVar when set and DefaultDBURLEnvVar otherwise.
+// Returns an error if the resolved environment variable is not set or is empty.
 func (c *DBConfig) GetURL() (string, error) {
 	// If URL is defined, use it (it has precedence)
 	if c.URL != "" {
 		return c.URL, nil
 	}
 
-	// If URL is not defined, try to load from URLEnvVar
-	if c.URLEnvVar != "" {
-		envURL := os.Getenv(c.URLEnvVar)
-		if envURL == "" {
-			return "", fmt.Errorf("field 'url' is empty and environment variable %q (from 'url_env_var') is not set or is empty", c.URLEnvVar)
-		}
-		return envURL, nil
+	// Otherwise read from the environment: the configured name if set, else the default.
+	envVar := c.URLEnvVar
+	if envVar == "" {
+		envVar = DefaultDBURLEnvVar
 	}
-
-	// Neither URL nor URLEnvVar is defined
-	return "", fmt.Errorf("field 'url' is required (either 'url' or 'url_env_var' must be defined)")
+	envURL := os.Getenv(envVar)
+	if envURL == "" {
+		return "", fmt.Errorf("field 'url' is empty and environment variable %q is not set or is empty", envVar)
+	}
+	return envURL, nil
 }
 
 func (c *DBConfig) validate() error {

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -128,10 +128,17 @@ func TestKeystoreConfig_GetPassword(t *testing.T) {
 			errContains: []string{"field 'password' is empty", "MISSING_ENV_VAR", "not set"},
 		},
 		{
-			name:        "error when neither source defined",
+			name:         "falls back to default env var when neither password nor env var name set",
+			config:       &KeystoreConfig{Password: "", PasswordEnvVar: ""},
+			envVars:      map[string]string{DefaultKeystorePasswordEnvVar: "default_env_secret"},
+			wantPassword: "default_env_secret",
+			wantErr:      false,
+		},
+		{
+			name:        "error when neither source defined and default env var unset",
 			config:      &KeystoreConfig{Password: "", PasswordEnvVar: ""},
 			wantErr:     true,
-			errContains: []string{"field 'password' is required"},
+			errContains: []string{"field 'password' is empty", DefaultKeystorePasswordEnvVar, "not set"},
 		},
 	}
 	for _, tt := range tests {
@@ -169,10 +176,10 @@ func TestKeystoreConfig_validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "neither password nor env var defined",
+			name:        "neither password nor env var defined and default env var unset",
 			config:      &KeystoreConfig{Password: "", PasswordEnvVar: ""},
 			wantErr:     true,
-			errContains: []string{"field 'password' is required"},
+			errContains: []string{"field 'password' is empty", DefaultKeystorePasswordEnvVar},
 		},
 	}
 	for _, tt := range tests {
@@ -232,10 +239,17 @@ func TestDBConfig_GetURL(t *testing.T) {
 			errContains: []string{"field 'url' is empty", "MISSING_DB_URL", "not set"},
 		},
 		{
-			name:        "error when neither source defined",
+			name:    "falls back to default env var when neither url nor env var name set",
+			config:  &DBConfig{URL: "", URLEnvVar: ""},
+			envVars: map[string]string{DefaultDBURLEnvVar: "postgres://default_env"},
+			wantURL: "postgres://default_env",
+			wantErr: false,
+		},
+		{
+			name:        "error when neither source defined and default env var unset",
 			config:      &DBConfig{URL: "", URLEnvVar: ""},
 			wantErr:     true,
-			errContains: []string{"field 'url' is required"},
+			errContains: []string{"field 'url' is empty", DefaultDBURLEnvVar, "not set"},
 		},
 	}
 	for _, tt := range tests {
@@ -273,10 +287,10 @@ func TestDBConfig_validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "neither url nor env var defined",
+			name:        "neither url nor env var defined and default env var unset",
 			config:      &DBConfig{URL: "", URLEnvVar: ""},
 			wantErr:     true,
-			errContains: []string{"field 'url' is required"},
+			errContains: []string{"field 'url' is empty", DefaultDBURLEnvVar},
 		},
 	}
 	for _, tt := range tests {

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -91,27 +91,97 @@ func TestJDConfig_validate(t *testing.T) {
 	}
 }
 
-func TestKeystoreConfig_validate(t *testing.T) {
+func TestKeystoreConfig_GetPassword(t *testing.T) {
 	tests := []struct {
-		name        string
-		config      *KeystoreConfig
-		wantErr     bool
-		errContains []string
+		name         string
+		config       *KeystoreConfig
+		envVars      map[string]string
+		wantPassword string
+		wantErr      bool
+		errContains  []string
 	}{
 		{
-			name:    "valid",
-			config:  &KeystoreConfig{Password: "secret"},
-			wantErr: false,
+			name:         "returns direct password",
+			config:       &KeystoreConfig{Password: "direct_secret"},
+			wantPassword: "direct_secret",
+			wantErr:      false,
 		},
 		{
-			name:        "missing password",
-			config:      &KeystoreConfig{Password: ""},
+			name:         "password precedence over env var",
+			config:       &KeystoreConfig{Password: "direct", PasswordEnvVar: "TEST_PASSWORD_ENV_VAR"},
+			envVars:      map[string]string{"TEST_PASSWORD_ENV_VAR": "from_env"},
+			wantPassword: "direct",
+			wantErr:      false,
+		},
+		{
+			name:         "returns env var when password empty",
+			config:       &KeystoreConfig{Password: "", PasswordEnvVar: "TEST_PASSWORD_ENV_VAR"},
+			envVars:      map[string]string{"TEST_PASSWORD_ENV_VAR": "env_secret"},
+			wantPassword: "env_secret",
+			wantErr:      false,
+		},
+		{
+			name:        "error when env var not set",
+			config:      &KeystoreConfig{Password: "", PasswordEnvVar: "MISSING_ENV_VAR"},
+			envVars:     map[string]string{},
+			wantErr:     true,
+			errContains: []string{"field 'password' is empty", "MISSING_ENV_VAR", "not set"},
+		},
+		{
+			name:        "error when neither source defined",
+			config:      &KeystoreConfig{Password: "", PasswordEnvVar: ""},
 			wantErr:     true,
 			errContains: []string{"field 'password' is required"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			password, err := tt.config.GetPassword()
+			if tt.wantErr {
+				require.Error(t, err)
+				for _, sub := range tt.errContains {
+					require.Contains(t, err.Error(), sub)
+				}
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantPassword, password)
+			}
+		})
+	}
+}
+
+func TestKeystoreConfig_validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *KeystoreConfig
+		envVars     map[string]string
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name:    "valid with password",
+			config:  &KeystoreConfig{Password: "secret"},
+			wantErr: false,
+		},
+		{
+			name:        "neither password nor env var defined",
+			config:      &KeystoreConfig{Password: "", PasswordEnvVar: ""},
+			wantErr:     true,
+			errContains: []string{"field 'password' is required"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
 			err := tt.config.validate()
 			if tt.wantErr {
 				require.Error(t, err)
@@ -125,10 +195,75 @@ func TestKeystoreConfig_validate(t *testing.T) {
 	}
 }
 
+func TestDBConfig_GetURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *DBConfig
+		envVars    map[string]string
+		wantURL    string
+		wantErr    bool
+		errContains []string
+	}{
+		{
+			name:    "returns direct url",
+			config:  &DBConfig{URL: "postgres://localhost:5432/mydb"},
+			wantURL: "postgres://localhost:5432/mydb",
+			wantErr: false,
+		},
+		{
+			name:    "url precedence over env var",
+			config:  &DBConfig{URL: "postgres://direct", URLEnvVar: "TEST_DATABASE_URL"},
+			envVars: map[string]string{"TEST_DATABASE_URL": "postgres://from_env"},
+			wantURL: "postgres://direct",
+			wantErr: false,
+		},
+		{
+			name:    "returns env var when url empty",
+			config:  &DBConfig{URL: "", URLEnvVar: "TEST_DATABASE_URL"},
+			envVars: map[string]string{"TEST_DATABASE_URL": "postgres://env_db"},
+			wantURL: "postgres://env_db",
+			wantErr: false,
+		},
+		{
+			name:        "error when env var not set",
+			config:      &DBConfig{URL: "", URLEnvVar: "MISSING_DB_URL"},
+			envVars:     map[string]string{},
+			wantErr:     true,
+			errContains: []string{"field 'url' is empty", "MISSING_DB_URL", "not set"},
+		},
+		{
+			name:        "error when neither source defined",
+			config:      &DBConfig{URL: "", URLEnvVar: ""},
+			wantErr:     true,
+			errContains: []string{"field 'url' is required"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			url, err := tt.config.GetURL()
+			if tt.wantErr {
+				require.Error(t, err)
+				for _, sub := range tt.errContains {
+					require.Contains(t, err.Error(), sub)
+				}
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantURL, url)
+			}
+		})
+	}
+}
+
 func TestDBConfig_validate(t *testing.T) {
 	tests := []struct {
 		name        string
 		config      *DBConfig
+		envVars     map[string]string
 		wantErr     bool
 		errContains []string
 	}{
@@ -138,14 +273,19 @@ func TestDBConfig_validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "missing url",
-			config:      &DBConfig{URL: ""},
+			name:        "neither url nor env var defined",
+			config:      &DBConfig{URL: "", URLEnvVar: ""},
 			wantErr:     true,
 			errContains: []string{"field 'url' is required"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
 			err := tt.config.validate()
 			if tt.wantErr {
 				require.Error(t, err)

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -197,11 +197,11 @@ func TestKeystoreConfig_validate(t *testing.T) {
 
 func TestDBConfig_GetURL(t *testing.T) {
 	tests := []struct {
-		name       string
-		config     *DBConfig
-		envVars    map[string]string
-		wantURL    string
-		wantErr    bool
+		name        string
+		config      *DBConfig
+		envVars     map[string]string
+		wantURL     string
+		wantErr     bool
 		errContains []string
 	}{
 		{


### PR DESCRIPTION
## Summary

This PR adds support for resolving sensitive configuration values from environment variables instead of requiring them to be stored in the TOML configuration file `bootstrap.toml`.

Specifically, the database URL and keystore password can now be provided via environment variables, making it easier to manage secrets securely. If both a value and its corresponding environment variable are configured, the value defined in the configuration file takes precedence.

## Changes

* Added `GetURL()` to `DBConfig` to resolve the database URL from either:

  * `URL` (highest precedence)
  * `URLEnvVar`
* Added `GetPassword()` to `KeystoreConfig` to resolve the keystore password from either:

  * `Password` (highest precedence)
  * `PasswordEnvVar`
* Refactored validation to use the new getter methods, centralizing configuration resolution and removing duplicated logic.
* Updated the bootstrap flow to use the new resolution methods.
* Added comprehensive tests covering:

  * Direct configuration values
  * Configuration precedence over environment variables
  * Environment variable fallback
  * Missing environment variables
  * Missing configuration from both sources

## Motivation

Secrets such as database credentials and keystore passwords should not be committed to or stored in plaintext configuration files. This change allows deployments to inject these values securely through environment variables while maintaining backward compatibility with existing configurations.

This allow as to move from

```toml
[jd]
server_wsrpc_url = "wsrpc-job-distributor.sh"
server_csa_public_key = "41dcc9f2d7....."

[keystore]
password = "sensitive info"

[db]
url = "sensitive info"
[server]
listen_port = 8080
```

to

```toml
[jd]
server_wsrpc_url = "wsrpc-job-distributor.sh"
server_csa_public_key = "41dcc9f2d7....."

[keystore]
password_env_var = "KEYSTORE_PASSOWORD_ENV_VAR"

[db]
url_env_var = "CL_DATABASE_URL"
        
[server]
listen_port = 8080
```

This change is fully backward compatible. Existing configurations that specify password and url directly continue to work unchanged.

In the future, once everything have migrated, we can remove the plaintext secret fields from the configuration, making environment variables the only supported mechanism for supplying sensitive values.