### PR TITLE
CCIP-11855 client_id + name for aggregator client

### DIFF
--- a/aggregator/pkg/auth/client.go
+++ b/aggregator/pkg/auth/client.go
@@ -12,6 +12,8 @@ type APIKeyPair interface {
 type ClientConfig interface {
 	// GetClientID returns the unique client identifier.
 	GetClientID() string
+	// GetClientName returns the client text representation.
+	GetClientName() string
 	// GetGroups returns the list of groups the client belongs to.
 	GetGroups() []string
 	// IsEnabled returns whether the client is enabled.

--- a/aggregator/pkg/middlewares/hmac_auth_middleware.go
+++ b/aggregator/pkg/middlewares/hmac_auth_middleware.go
@@ -63,7 +63,7 @@ func (m *HMACAuthMiddleware) Intercept(ctx context.Context, req any, info *grpc.
 	}
 
 	if err := hmac.ValidateTimestamp(timestamp); err != nil {
-		m.logger.Warnf("Authentication failed for client %s: %v", client.GetClientID(), err)
+		m.logger.Warnf("Authentication failed for client %s: %v", client.GetClientName(), err)
 		return nil, status.Error(codes.Unauthenticated, "invalid or expired timestamp")
 	}
 
@@ -78,14 +78,14 @@ func (m *HMACAuthMiddleware) Intercept(ctx context.Context, req any, info *grpc.
 	stringToSign := hmac.GenerateStringToSign(hmac.HTTPMethodPost, info.FullMethod, bodyHash, apiKey, timestamp)
 
 	if !hmac.ValidateSignature(stringToSign, providedSignature, pair.GetSecret()) {
-		m.logger.Warnf("Authentication failed for client %s: invalid signature", client.GetClientID())
+		m.logger.Warnf("Authentication failed for client %s: invalid signature", client.GetClientName())
 		return nil, status.Error(codes.Unauthenticated, "invalid signature")
 	}
 
 	identity := auth.CreateCallerIdentity(client.GetClientID(), false)
 	ctx = auth.ToContext(ctx, identity)
 
-	m.logger.Debugf("Successfully authenticated client: %s", client.GetClientID())
+	m.logger.Debugf("Successfully authenticated client: %s", client.GetClientName())
 
 	return handler(ctx, req)
 }

--- a/aggregator/pkg/middlewares/hmac_auth_middleware_test.go
+++ b/aggregator/pkg/middlewares/hmac_auth_middleware_test.go
@@ -39,9 +39,10 @@ type mockClientConfig struct {
 	enabled  bool
 }
 
-func (m *mockClientConfig) GetClientID() string { return m.clientID }
-func (m *mockClientConfig) GetGroups() []string { return m.groups }
-func (m *mockClientConfig) IsEnabled() bool     { return m.enabled }
+func (m *mockClientConfig) GetClientID() string   { return m.clientID }
+func (m *mockClientConfig) GetClientName() string { return m.clientID }
+func (m *mockClientConfig) GetGroups() []string   { return m.groups }
+func (m *mockClientConfig) IsEnabled() bool       { return m.enabled }
 
 type mockClientProvider struct {
 	clientsByAPIKey map[string]*mockClientEntry

--- a/aggregator/pkg/model/config.go
+++ b/aggregator/pkg/model/config.go
@@ -438,12 +438,18 @@ func (c *APIKeyPairEnv) Validate() error {
 type ClientConfig struct {
 	APIKeyPairs []*APIKeyPairEnv `toml:"apiKeyPair"`
 	Groups      []string         `toml:"groups"`
-	Description string           `toml:"description"`
+	Name        string           `toml:"name"`
 	Enabled     bool             `toml:"enabled"`
 	ClientID    string           `toml:"clientId"`
 }
 
 func (c *ClientConfig) GetClientID() string { return c.ClientID }
+func (c *ClientConfig) GetClientName() string {
+	if len(c.Name) > 0 {
+		return c.Name
+	}
+	return c.ClientID
+}
 func (c *ClientConfig) GetGroups() []string { return c.Groups }
 func (c *ClientConfig) IsEnabled() bool     { return c.Enabled }
 

--- a/aggregator/pkg/model/config.go
+++ b/aggregator/pkg/model/config.go
@@ -438,7 +438,7 @@ func (c *APIKeyPairEnv) Validate() error {
 type ClientConfig struct {
 	APIKeyPairs []*APIKeyPairEnv `toml:"apiKeyPair"`
 	Groups      []string         `toml:"groups"`
-	Name        string           `toml:"name"`
+	Name        string           `toml:"name,omitempty"`
 	Enabled     bool             `toml:"enabled"`
 	ClientID    string           `toml:"clientId"`
 }

--- a/aggregator/pkg/model/config_test.go
+++ b/aggregator/pkg/model/config_test.go
@@ -921,9 +921,10 @@ type mockClientConfig struct {
 	enabled  bool
 }
 
-func (m *mockClientConfig) GetClientID() string { return m.clientID }
-func (m *mockClientConfig) GetGroups() []string { return m.groups }
-func (m *mockClientConfig) IsEnabled() bool     { return m.enabled }
+func (m *mockClientConfig) GetClientID() string   { return m.clientID }
+func (m *mockClientConfig) GetClientName() string { return m.clientID }
+func (m *mockClientConfig) GetGroups() []string   { return m.groups }
+func (m *mockClientConfig) IsEnabled() bool       { return m.enabled }
 
 func TestGetClientByAPIKey(t *testing.T) {
 	creds, _ := hmacutil.GenerateCredentials()

--- a/aggregator/pkg/model/config_test.go
+++ b/aggregator/pkg/model/config_test.go
@@ -1179,6 +1179,18 @@ func TestClientConfig_Getters(t *testing.T) {
 	assert.True(t, cfg.IsEnabled())
 }
 
+func TestClientConfig_GetClientName(t *testing.T) {
+	t.Run("returns Name when set", func(t *testing.T) {
+		cfg := &ClientConfig{ClientID: "client-id", Name: "Human Readable Name"}
+		assert.Equal(t, "Human Readable Name", cfg.GetClientName())
+	})
+
+	t.Run("falls back to ClientID when Name is empty", func(t *testing.T) {
+		cfg := &ClientConfig{ClientID: "client-id"}
+		assert.Equal(t, "client-id", cfg.GetClientName())
+	})
+}
+
 func TestLoadFromEnvironment(t *testing.T) {
 	t.Run("loads postgres connection URL", func(t *testing.T) {
 		t.Setenv("AGGREGATOR_STORAGE_CONNECTION_URL", "postgres://localhost:5432/test")

--- a/aggregator/tests/utils.go
+++ b/aggregator/tests/utils.go
@@ -176,9 +176,8 @@ func CreateServerOnlyWithMessageRulesControl(t *testing.T, options ...ConfigOpti
 		Monitoring: model.MonitoringConfig{},
 		APIClients: []*model.ClientConfig{
 			{
-				ClientID:    "test-client",
-				Description: "Test client for integration tests",
-				Enabled:     true,
+				ClientID: "test-client",
+				Enabled:  true,
 				APIKeyPairs: []*model.APIKeyPairEnv{
 					{
 						APIKeyEnvVar: "TEST_API_KEY",

--- a/build/devenv/env-cl-16.toml
+++ b/build/devenv/env-cl-16.toml
@@ -1078,110 +1078,110 @@ LockTimeout = 30
     host_port  = 6379
 
   [[aggregator.api_clients]]
+  # Development default verifier 1
   client_id = "default-verifier-1"
-  description = "Development default verifier 1"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 2
   client_id = "default-verifier-2"
-  description = "Development default verifier 2"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 3
   client_id = "default-verifier-3"
-  description = "Development default verifier 3"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 4
   client_id = "default-verifier-4"
-  description = "Development default verifier 4"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 5
   client_id = "default-verifier-5"
-  description = "Development default verifier 5"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 6
   client_id = "default-verifier-6"
-  description = "Development default verifier 6"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 7
   client_id = "default-verifier-7"
-  description = "Development default verifier 7"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 8
   client_id = "default-verifier-8"
-  description = "Development default verifier 8"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 9
   client_id = "default-verifier-9"
-  description = "Development default verifier 9"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 10
   client_id = "default-verifier-10"
-  description = "Development default verifier 10"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 11
   client_id = "default-verifier-11"
-  description = "Development default verifier 11"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 12
   client_id = "default-verifier-12"
-  description = "Development default verifier 12"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 13
   client_id = "default-verifier-13"
-  description = "Development default verifier 13"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 14
   client_id = "default-verifier-14"
-  description = "Development default verifier 14"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 15
   client_id = "default-verifier-15"
-  description = "Development default verifier 15"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 16
   client_id = "default-verifier-16"
-  description = "Development default verifier 16"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
   [[aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
 
@@ -1208,26 +1208,26 @@ LockTimeout = 30
     host_port  = 6380
 
   [[aggregator.api_clients]]
+  # Development secondary verifier 1
   client_id = "secondary-verifier-1"
-  description = "Development secondary verifier 1"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development secondary verifier 2
   client_id = "secondary-verifier-2"
-  description = "Development secondary verifier 2"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
   [[aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
 
@@ -1254,26 +1254,26 @@ LockTimeout = 30
     host_port  = 6381
 
   [[aggregator.api_clients]]
+  # Development tertiary verifier 1
   client_id = "tertiary-verifier-1"
-  description = "Development tertiary verifier 1"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development tertiary verifier 2
   client_id = "tertiary-verifier-2"
-  description = "Development tertiary verifier 2"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
   [[aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
 

--- a/build/devenv/env-phased.toml
+++ b/build/devenv/env-phased.toml
@@ -519,25 +519,25 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
     image = "redis:7-alpine"
     host_port  = 6379
 
-  [[aggregator.api_clients]]
+  [[committeeccv.aggregator.api_clients]]
   # Development default verifier 1
   client_id = "default-verifier-1"
   enabled = true
   groups = ["verifiers"]
 
-  [[aggregator.api_clients]]
+  [[committeeccv.aggregator.api_clients]]
   # Development default verifier 2
   client_id = "default-verifier-2"
   enabled = true
   groups = ["verifiers"]
 
-  [[aggregator.api_clients]]
+  [[committeeccv.aggregator.api_clients]]
   # Monitoring and infrastructure client
   client_id = "monitoring"
   enabled = true
   groups = ["monitoring"]
 
-  [[aggregator.api_clients]]
+  [[committeeccv.aggregator.api_clients]]
   # Development Indexer
   client_id = "indexer"
   enabled = true

--- a/build/devenv/env-phased.toml
+++ b/build/devenv/env-phased.toml
@@ -519,27 +519,27 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
     image = "redis:7-alpine"
     host_port  = 6379
 
-  [[committeeccv.aggregator.api_clients]]
+  [[aggregator.api_clients]]
+  # Development default verifier 1
   client_id = "default-verifier-1"
-  description = "Development default verifier 1"
   enabled = true
   groups = ["verifiers"]
 
-  [[committeeccv.aggregator.api_clients]]
+  [[aggregator.api_clients]]
+  # Development default verifier 2
   client_id = "default-verifier-2"
-  description = "Development default verifier 2"
   enabled = true
   groups = ["verifiers"]
 
-  [[committeeccv.aggregator.api_clients]]
+  [[aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
-  [[committeeccv.aggregator.api_clients]]
+  [[aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
 
@@ -567,26 +567,26 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
     host_port  = 6380
 
   [[committeeccv.aggregator.api_clients]]
+  # Development secondary verifier 1
   client_id = "secondary-verifier-1"
-  description = "Development secondary verifier 1"
   enabled = true
   groups = ["verifiers"]
 
   [[committeeccv.aggregator.api_clients]]
+  # Development secondary verifier 2
   client_id = "secondary-verifier-2"
-  description = "Development secondary verifier 2"
   enabled = true
   groups = ["verifiers"]
 
   [[committeeccv.aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
   [[committeeccv.aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
 
@@ -613,26 +613,26 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
     host_port  = 6381
 
   [[committeeccv.aggregator.api_clients]]
+  # Development tertiary verifier 1
   client_id = "tertiary-verifier-1"
-  description = "Development tertiary verifier 1"
   enabled = true
   groups = ["verifiers"]
 
   [[committeeccv.aggregator.api_clients]]
+  # Development tertiary verifier 2
   client_id = "tertiary-verifier-2"
-  description = "Development tertiary verifier 2"
   enabled = true
   groups = ["verifiers"]
 
   [[committeeccv.aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
   [[committeeccv.aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
   # Environment variables for sensitive configuration

--- a/build/devenv/env.toml
+++ b/build/devenv/env.toml
@@ -479,26 +479,26 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
     host_port  = 6379
 
   [[aggregator.api_clients]]
+  # Development default verifier 1
   client_id = "default-verifier-1"
-  description = "Development default verifier 1"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development default verifier 2
   client_id = "default-verifier-2"
-  description = "Development default verifier 2"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
   [[aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
 
@@ -526,26 +526,26 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
     host_port  = 6380
 
   [[aggregator.api_clients]]
+  # Development secondary verifier 1
   client_id = "secondary-verifier-1"
-  description = "Development secondary verifier 1"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development secondary verifier 2
   client_id = "secondary-verifier-2"
-  description = "Development secondary verifier 2"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
   [[aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
 
@@ -572,26 +572,26 @@ URI = "postgresql://indexer:indexer@indexer-db:5432/indexer?sslmode=disable"
     host_port  = 6381
 
   [[aggregator.api_clients]]
+  # Development tertiary verifier 1
   client_id = "tertiary-verifier-1"
-  description = "Development tertiary verifier 1"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Development tertiary verifier 2
   client_id = "tertiary-verifier-2"
-  description = "Development tertiary verifier 2"
   enabled = true
   groups = ["verifiers"]
 
   [[aggregator.api_clients]]
+  # Monitoring and infrastructure client
   client_id = "monitoring"
-  description = "Monitoring and infrastructure client"
   enabled = true
   groups = ["monitoring"]
 
   [[aggregator.api_clients]]
+  # Development Indexer
   client_id = "indexer"
-  description = "Development Indexer"
   enabled = true
   groups = ["indexer"]
   # Environment variables for sensitive configuration

--- a/build/devenv/services/aggregator.go
+++ b/build/devenv/services/aggregator.go
@@ -274,7 +274,6 @@ func (a *AggregatorInput) GenerateConfigs(generatedConfigFileName string) (*Gene
 	for _, client := range a.APIClients {
 		config.APIClients = append(config.APIClients, &model.ClientConfig{
 			ClientID:    client.ClientID,
-			Description: client.Description,
 			Enabled:     client.Enabled,
 			Groups:      client.Groups,
 			APIKeyPairs: make([]*model.APIKeyPairEnv, 0, len(client.APIKeyPairs)),

--- a/build/devenv/services/aggregator.go
+++ b/build/devenv/services/aggregator.go
@@ -74,7 +74,6 @@ type AggregatorAPIKeyPair struct {
 }
 type AggregatorClientConfig struct {
 	ClientID    string                  `toml:"client_id"`
-	Description string                  `toml:"description"`
 	Enabled     bool                    `toml:"enabled"`
 	Groups      []string                `toml:"groups"`
 	APIKeyPairs []*AggregatorAPIKeyPair `toml:"api_key_pairs"`

--- a/build/devenv/tests/services/aggregator_test.go
+++ b/build/devenv/tests/services/aggregator_test.go
@@ -81,10 +81,9 @@ func TestServiceAggregator(t *testing.T) {
 			RedisDB:       "0",
 		},
 		APIClients: []*services.AggregatorClientConfig{{
-			ClientID:    "test",
-			Description: "Test client",
-			Enabled:     true,
-			Groups:      []string{},
+			ClientID: "test",
+			Enabled:  true,
+			Groups:   []string{},
 			APIKeyPairs: []*services.AggregatorAPIKeyPair{{
 				APIKey: testCredentials.APIKey,
 				Secret: testCredentials.Secret,
@@ -150,10 +149,9 @@ func TestServiceAggregatorAuthentication(t *testing.T) {
 		},
 		APIClients: []*services.AggregatorClientConfig{
 			{
-				ClientID:    "test",
-				Description: "Test client",
-				Enabled:     true,
-				Groups:      []string{},
+				ClientID: "test",
+				Enabled:  true,
+				Groups:   []string{},
 				APIKeyPairs: []*services.AggregatorAPIKeyPair{{
 					APIKey: testCredentials.APIKey,
 					Secret: testCredentials.Secret,
@@ -471,30 +469,27 @@ func setupAggregatorTestFixture(t *testing.T) *aggregatorTestFixture {
 		},
 		APIClients: []*services.AggregatorClientConfig{
 			{
-				ClientID:    "honest-verifier-1",
-				Description: "Honest verifier 1 client",
-				Enabled:     true,
-				Groups:      []string{"service-tests-1"},
+				ClientID: "honest-verifier-1",
+				Enabled:  true,
+				Groups:   []string{"service-tests-1"},
 				APIKeyPairs: []*services.AggregatorAPIKeyPair{{
 					APIKey: honest1Credentials.APIKey,
 					Secret: honest1Credentials.Secret,
 				}},
 			},
 			{
-				ClientID:    "honest-verifier-2",
-				Description: "Honest verifier 2 client",
-				Enabled:     true,
-				Groups:      []string{"service-tests-1"},
+				ClientID: "honest-verifier-2",
+				Enabled:  true,
+				Groups:   []string{"service-tests-1"},
 				APIKeyPairs: []*services.AggregatorAPIKeyPair{{
 					APIKey: honest2Credentials.APIKey,
 					Secret: honest2Credentials.Secret,
 				}},
 			},
 			{
-				ClientID:    "malicious-verifier",
-				Description: "Malicious verifier client",
-				Enabled:     true,
-				Groups:      []string{"service-tests-2"}, // Low rate limit group for testing
+				ClientID: "malicious-verifier",
+				Enabled:  true,
+				Groups:   []string{"service-tests-2"}, // Low rate limit group for testing
 				APIKeyPairs: []*services.AggregatorAPIKeyPair{{
 					APIKey: maliciousCredentials.APIKey,
 					Secret: maliciousCredentials.Secret,


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description
  - Add `name` field to `ClientConfig`, replacing `description` for human-readable client identification.
  - Expose `GetClientName()` on `APIKeyPair` interface; falls back to `client_id` when `name` is unset.
  - Use `GetClientName()` in HMAC auth middleware log output instead of `GetClientID()`.
  - Migrate all devenv TOML configs (`env.toml`, `env-phased.toml`, `env-cl-16.toml`) from `description` to inline comments; add `name` field matching the client alias where appropriate.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing
tested metrics in grafana

<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
