### PR TITLE
[CCIP-12096] bootstrap: split secrets out of monolithic config

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -36,6 +36,12 @@ const (
 	ConfigPathEnv     = "BOOTSTRAPPER_CONFIG_PATH"
 	DefaultConfigPath = "/etc/config.toml"
 
+	// SecretsPathEnv names the env var pointing at the bootstrap secrets file, which carries the
+	// credential-bearing [db] and [keystore] sections. The default is namespaced
+	// under /etc/bootstrap/ to avoid the /etc/config.toml collision that DefaultConfigPath suffers.
+	SecretsPathEnv     = "BOOTSTRAPPER_SECRETS_PATH"
+	DefaultSecretsPath = "/etc/bootstrap/secrets.toml" //nolint:gosec // G101: this is a file path, not a credential
+
 	defaultStartupTimeout  = 10 * time.Second
 	defaultShutdownTimeout = 10 * time.Second
 )
@@ -125,6 +131,7 @@ type Bootstrapper struct {
 
 	// bootstrapper component configs
 	configPath       string
+	secretsPath      string
 	config           *Config
 	lifecycleManager *lifecycle.Manager
 	infoServer       *infoServer
@@ -193,18 +200,24 @@ func NewBootstrapper(
 			b.keys = append([]keyToInit{{DefaultCSAKeyName, "csa", keystore.Ed25519}}, b.keys...)
 		}
 
-		b.configPath = resolveBootstrapConfigPath(b.configPath)
 		b.config = &Config{}
-		if err := LoadAndValidateConfig(b.configPath, b.config, true); err != nil {
-			return nil, fmt.Errorf("failed to load bootstrap config (%s): %w", b.configPath, err)
+		// Non-secret config first, then overlay the secrets file (if present) so it wins for any
+		// section it defines. The secrets file is optional at the file level: a legacy monolithic
+		// config.toml carrying [db]/[keystore] resolves no secrets file, skips the overlay, and
+		// decodes exactly as before.
+		paths := bootstrapConfigPaths(b.configPath, b.secretsPath)
+		if err := LoadAndValidateConfig(paths, b.config, true); err != nil {
+			return nil, fmt.Errorf("failed to load bootstrap config (%v): %w", paths, err)
 		}
 	} else if path := os.Getenv(ConfigPathEnv); path != "" {
 		// Static-TOML mode: optionally load operator config when BOOTSTRAPPER_CONFIG_PATH is
 		// explicitly set. The default fallback to DefaultConfigPath is intentionally suppressed
 		// here: TOKEN_VERIFIER_CONFIG_PATH and BOOTSTRAPPER_CONFIG_PATH both default to
 		// /etc/config.toml, so applying the default would decode the wrong file. See issue #013.
+		// No secrets file is loaded in static-TOML mode: the token verifier has no [db]/[keystore]
+		// and those are exactly the sections static mode ignores.
 		b.config = &Config{}
-		if err := LoadAndValidateConfig(path, b.config, false); err != nil {
+		if err := LoadAndValidateConfig([]string{path}, b.config, false); err != nil {
 			return nil, fmt.Errorf("failed to load operator config (%s): %w", path, err)
 		}
 	}
@@ -512,6 +525,35 @@ func resolveBootstrapConfigPath(explicit string) string {
 	return DefaultConfigPath
 }
 
+// resolveBootstrapSecretsPath returns the effective bootstrap secrets path — the explicitly-provided
+// path, then BOOTSTRAPPER_SECRETS_PATH, then DefaultSecretsPath — but only if that path points at an
+// existing file. The secrets file is optional: absence returns "" so the caller skips the overlay,
+// which is what keeps a legacy monolithic config (with [db]/[keystore] inline) working.
+func resolveBootstrapSecretsPath(explicit string) string {
+	path := explicit
+	if path == "" {
+		path = os.Getenv(SecretsPathEnv)
+	}
+	if path == "" {
+		path = DefaultSecretsPath
+	}
+	if _, err := os.Stat(path); err != nil { //nolint:gosec // G703: path is a trusted operator-provided config path
+		return ""
+	}
+	return path
+}
+
+// bootstrapConfigPaths returns the ordered list of files to decode in JD mode: the non-secret config
+// file, followed by the secrets file only when one is present. Later files overlay earlier ones, so
+// the secrets file wins for any section it defines.
+func bootstrapConfigPaths(explicitConfig, explicitSecrets string) []string {
+	paths := []string{resolveBootstrapConfigPath(explicitConfig)}
+	if secretsPath := resolveBootstrapSecretsPath(explicitSecrets); secretsPath != "" {
+		paths = append(paths, secretsPath)
+	}
+	return paths
+}
+
 func initializeKeystore(ctx context.Context, lggr logger.Logger, db *sqlx.DB, ksPassword string, requiredKeys []keyToInit) (keystore.Keystore, crypto.Signer, error) {
 	ks, err := keystore.LoadKeystore(ctx, keys.NewPGStorage(db, "default"), ksPassword)
 	if err != nil {
@@ -606,6 +648,18 @@ func WithJD() Option {
 func WithBootstrapperConfigPath(path string) Option {
 	return func(b *Bootstrapper) error {
 		b.configPath = path
+		return nil
+	}
+}
+
+// WithBootstrapperSecretsPath sets the bootstrapper secrets file path. If not set, the bootstrapper
+// looks for the path in the BOOTSTRAPPER_SECRETS_PATH environment variable, and if that is not set,
+// it defaults to DefaultSecretsPath. The secrets file is optional: if the resolved path does not
+// exist, it is skipped (which is how a legacy monolithic config remains valid). Applies in JD mode
+// only.
+func WithBootstrapperSecretsPath(path string) Option {
+	return func(b *Bootstrapper) error {
+		b.secretsPath = path
 		return nil
 	}
 }

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -100,13 +100,10 @@ func (c ChainRegistration) validate() error {
 	return nil
 }
 
-// Config is the configuration for the bootstrapper.
-//
-// The bootstrap config is partitioned by sensitivity across two files: a
-// non-secret config file carries [jd], [server], [[chains]], and [monitoring]; a secrets file
-// carries the credential-bearing [db] and [keystore] sections. Both files decode into this single
-// struct over disjoint sections — the partition is whole-section, so no field is ever split across
-// files. A legacy monolithic file that carries all sections in one file remains supported.
+// NonSecretConfig is the non-secret half of the bootstrap config: the sections that carry no
+// credentials. It is embedded into Config, so its sections ([jd], [server], [[chains]],
+// [Monitoring]) decode and encode at the top level exactly as if declared on Config directly.
+// devenv marshals this type on its own to produce the non-secret config file.
 //
 // Example non-secret config file (config.toml):
 /*
@@ -121,18 +118,6 @@ func (c ChainRegistration) validate() error {
 	type = "EVM"
 	id = "1"
 */
-// Example secrets file (secrets.toml):
-/*
-	[keystore]
-	password = "password"
-
-	[db]
-	url = "postgres://localhost:5432/bootstrapper"
-*/
-// NonSecretConfig is the non-secret half of the bootstrap config: the sections that carry no
-// credentials. It is embedded into Config, so its sections ([jd], [server], [[chains]],
-// [Monitoring]) decode and encode at the top level exactly as if declared on Config directly.
-// devenv marshals this type on its own to produce the non-secret config file (see ADR-0008).
 type NonSecretConfig struct {
 	JD     JDConfig     `toml:"jd,omitempty"`
 	Server ServerConfig `toml:"server,omitempty"`
@@ -157,7 +142,16 @@ type NonSecretConfig struct {
 // Secrets is the secret half of the bootstrap config: the credential-bearing sections. It is
 // embedded into Config, so its sections ([keystore], [db]) decode and encode at the top level
 // exactly as if declared on Config directly. devenv marshals this type on its own to produce the
-// bootstrap secrets file loaded via BOOTSTRAPPER_SECRETS_PATH (see ADR-0008).
+// bootstrap secrets file loaded via BOOTSTRAPPER_SECRETS_PATH.
+//
+// Example secrets file (secrets.toml):
+/*
+	[keystore]
+	password = "password"
+
+	[db]
+	url = "postgres://localhost:5432/bootstrapper"
+*/
 type Secrets struct {
 	Keystore KeystoreConfig `toml:"keystore,omitempty"`
 	DB       DBConfig       `toml:"db,omitempty"`

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -101,17 +101,18 @@ func (c ChainRegistration) validate() error {
 }
 
 // Config is the configuration for the bootstrapper.
-// Example config:
+//
+// The bootstrap config is partitioned by sensitivity across two files: a
+// non-secret config file carries [jd], [server], [[chains]], and [monitoring]; a secrets file
+// carries the credential-bearing [db] and [keystore] sections. Both files decode into this single
+// struct over disjoint sections — the partition is whole-section, so no field is ever split across
+// files. A legacy monolithic file that carries all sections in one file remains supported.
+//
+// Example non-secret config file (config.toml):
 /*
 	[jd]
 	server_wsrpc_url = "ws://localhost:8080/ws"
 	server_csa_public_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-
-	[keystore]
-	password = "password"
-
-	[db]
-	url = "postgres://localhost:5432/bootstrapper"
 
 	[server]
 	listen_port = 9988
@@ -120,11 +121,21 @@ func (c ChainRegistration) validate() error {
 	type = "EVM"
 	id = "1"
 */
-type Config struct {
-	JD       JDConfig       `toml:"jd,omitempty"`
-	Keystore KeystoreConfig `toml:"keystore,omitempty"`
-	DB       DBConfig       `toml:"db,omitempty"`
-	Server   ServerConfig   `toml:"server,omitempty"`
+// Example secrets file (secrets.toml):
+/*
+	[keystore]
+	password = "password"
+
+	[db]
+	url = "postgres://localhost:5432/bootstrapper"
+*/
+// NonSecretConfig is the non-secret half of the bootstrap config: the sections that carry no
+// credentials. It is embedded into Config, so its sections ([jd], [server], [[chains]],
+// [Monitoring]) decode and encode at the top level exactly as if declared on Config directly.
+// devenv marshals this type on its own to produce the non-secret config file (see ADR-0008).
+type NonSecretConfig struct {
+	JD     JDConfig     `toml:"jd,omitempty"`
+	Server ServerConfig `toml:"server,omitempty"`
 	// Chains declares the chains on which this node has a signing identity.
 	// Each entry causes the bootstrapper to register the node's signing key for that chain in JD.
 	// Optional: if empty, no signing key sync is performed.
@@ -141,6 +152,25 @@ type Config struct {
 	// only when it is nil. The token verifier is the exception: it loads no bootstrap config and keeps
 	// monitoring in its (already operator-provided) mounted app config.
 	Monitoring *monitoring.Config
+}
+
+// Secrets is the secret half of the bootstrap config: the credential-bearing sections. It is
+// embedded into Config, so its sections ([keystore], [db]) decode and encode at the top level
+// exactly as if declared on Config directly. devenv marshals this type on its own to produce the
+// bootstrap secrets file loaded via BOOTSTRAPPER_SECRETS_PATH (see ADR-0008).
+type Secrets struct {
+	Keystore KeystoreConfig `toml:"keystore,omitempty"`
+	DB       DBConfig       `toml:"db,omitempty"`
+}
+
+// Config is the full bootstrap config, composed of its non-secret and secret halves. The two halves
+// are embedded (not nested) so that a legacy monolithic file — carrying all sections at the top
+// level in one file — decodes unchanged, while the split layout decodes the same sections from two
+// files. The partition is the single source of truth for which section belongs in which file:
+// devenv marshals NonSecretConfig and Secrets independently, and the loader overlays them.
+type Config struct {
+	NonSecretConfig
+	Secrets
 }
 
 // validateInfra validates the coupled infra bundle (jd/db/keystore/server/chains).
@@ -218,18 +248,24 @@ func (c *Config) validate(needsInfra bool) error {
 	return errors.Join(errs...)
 }
 
-// LoadAndValidateConfig loads the configuration from a path to a TOML file, in strict mode.
+// LoadAndValidateConfig loads the configuration from one or more TOML files and validates the
+// merged result. Files are decoded into cfg in order, and a later file overlays only the sections
+// it defines — so when both a non-secret config file and a secrets file are provided, the secrets
+// file wins for any section it declares. Validation runs once on the merged struct.
+//
 // needsInfra selects mode-driven validation (see validate): pass true in JD mode, false in
-// static-TOML mode.
-func LoadAndValidateConfig(path string, cfg *Config, needsInfra bool) error {
-	tomlBytes, err := os.ReadFile(path) //nolint:gosec // G304: path is provided by trusted caller
-	if err != nil {
-		return fmt.Errorf("failed to read config file: %w", err)
-	}
-	// TODO switch to strict mode once config migration is over
-	err = parseTOML(string(tomlBytes), cfg, false)
-	if err != nil {
-		return fmt.Errorf("failed to parse config: %w", err)
+// static-TOML mode. Because validation runs on the merged struct, "is [db] present and valid" is
+// independent of which file supplied it.
+func LoadAndValidateConfig(paths []string, cfg *Config, needsInfra bool) error {
+	for _, path := range paths {
+		tomlBytes, err := os.ReadFile(path) //nolint:gosec // G304: path is provided by trusted caller
+		if err != nil {
+			return fmt.Errorf("failed to read config file %q: %w", path, err)
+		}
+		// TODO switch to strict mode once config migration is over
+		if err := parseTOML(string(tomlBytes), cfg, false); err != nil {
+			return fmt.Errorf("failed to parse config %q: %w", path, err)
+		}
 	}
 
 	if err := cfg.validate(needsInfra); err != nil {

--- a/bootstrap/config_test.go
+++ b/bootstrap/config_test.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -210,16 +212,17 @@ func TestConfig_validate(t *testing.T) {
 	}{
 		{
 			name:    "valid",
-			config:  &Config{JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer},
+			config:  &Config{NonSecretConfig: NonSecretConfig{JD: validJD, Server: validServer}, Secrets: Secrets{Keystore: validKeystore, DB: validDB}},
 			wantErr: false,
 		},
 		{
 			name: "invalid JD section",
 			config: &Config{
-				JD:       JDConfig{ServerWSRPCURL: "", ServerCSAPublicKey: validEd25519PublicKeyHex},
-				Keystore: validKeystore,
-				DB:       validDB,
-				Server:   validServer,
+				NonSecretConfig: NonSecretConfig{
+					JD:     JDConfig{ServerWSRPCURL: "", ServerCSAPublicKey: validEd25519PublicKeyHex},
+					Server: validServer,
+				},
+				Secrets: Secrets{Keystore: validKeystore, DB: validDB},
 			},
 			wantErr:     true,
 			errContains: []string{"failed to validate 'jd' section", "ServerWSRPCURL"},
@@ -227,10 +230,8 @@ func TestConfig_validate(t *testing.T) {
 		{
 			name: "invalid keystore section",
 			config: &Config{
-				JD:       validJD,
-				Keystore: KeystoreConfig{Password: ""},
-				DB:       validDB,
-				Server:   validServer,
+				NonSecretConfig: NonSecretConfig{JD: validJD, Server: validServer},
+				Secrets:         Secrets{Keystore: KeystoreConfig{Password: ""}, DB: validDB},
 			},
 			wantErr:     true,
 			errContains: []string{"failed to validate 'keystore' section", "password"},
@@ -238,10 +239,8 @@ func TestConfig_validate(t *testing.T) {
 		{
 			name: "invalid db section",
 			config: &Config{
-				JD:       validJD,
-				Keystore: validKeystore,
-				DB:       DBConfig{URL: ""},
-				Server:   validServer,
+				NonSecretConfig: NonSecretConfig{JD: validJD, Server: validServer},
+				Secrets:         Secrets{Keystore: validKeystore, DB: DBConfig{URL: ""}},
 			},
 			wantErr:     true,
 			errContains: []string{"failed to validate 'db' section", "url"},
@@ -249,10 +248,8 @@ func TestConfig_validate(t *testing.T) {
 		{
 			name: "invalid server section",
 			config: &Config{
-				JD:       validJD,
-				Keystore: validKeystore,
-				DB:       validDB,
-				Server:   ServerConfig{ListenPort: 0},
+				NonSecretConfig: NonSecretConfig{JD: validJD, Server: ServerConfig{ListenPort: 0}},
+				Secrets:         Secrets{Keystore: validKeystore, DB: validDB},
 			},
 			wantErr:     true,
 			errContains: []string{"failed to validate 'server' section", "listen_port"},
@@ -262,8 +259,8 @@ func TestConfig_validate(t *testing.T) {
 			// monitoring in the bootstrap config, and validate() must skip it.
 			name: "valid with monitoring unset (nil allowed)",
 			config: &Config{
-				JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-				Monitoring: nil,
+				NonSecretConfig: NonSecretConfig{JD: validJD, Server: validServer, Monitoring: nil},
+				Secrets:         Secrets{Keystore: validKeystore, DB: validDB},
 			},
 			wantErr: false,
 		},
@@ -272,31 +269,35 @@ func TestConfig_validate(t *testing.T) {
 			// Enabled is false, so an explicit "off" passes (and any Beholder values are ignored).
 			name: "valid with monitoring present but disabled",
 			config: &Config{
-				JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-				Monitoring: &monitoring.Config{},
+				NonSecretConfig: NonSecretConfig{JD: validJD, Server: validServer, Monitoring: &monitoring.Config{}},
+				Secrets:         Secrets{Keystore: validKeystore, DB: validDB},
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid with monitoring enabled (beholder)",
 			config: &Config{
-				JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-				Monitoring: validBeholderMonitoring(),
+				NonSecretConfig: NonSecretConfig{JD: validJD, Server: validServer, Monitoring: validBeholderMonitoring()},
+				Secrets:         Secrets{Keystore: validKeystore, DB: validDB},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid monitoring: enabled beholder with non-positive metric interval",
 			config: &Config{
-				JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-				Monitoring: &monitoring.Config{
-					Beholder: monitoring.BeholderConfig{
-						Enabled:              true,
-						MetricReaderInterval: 0,
-						TraceSampleRatio:     0.5,
-						TraceBatchTimeout:    5,
+				NonSecretConfig: NonSecretConfig{
+					JD:     validJD,
+					Server: validServer,
+					Monitoring: &monitoring.Config{
+						Beholder: monitoring.BeholderConfig{
+							Enabled:              true,
+							MetricReaderInterval: 0,
+							TraceSampleRatio:     0.5,
+							TraceBatchTimeout:    5,
+						},
 					},
 				},
+				Secrets: Secrets{Keystore: validKeystore, DB: validDB},
 			},
 			wantErr:     true,
 			errContains: []string{"failed to validate 'monitoring' section", "metric_reader_interval"},
@@ -305,8 +306,8 @@ func TestConfig_validate(t *testing.T) {
 			// validate() uses errors.Join, so a bad section and bad monitoring both surface.
 			name: "aggregates errors across db and monitoring sections",
 			config: &Config{
-				JD: validJD, Keystore: validKeystore, DB: DBConfig{URL: ""}, Server: validServer,
-				Monitoring: &monitoring.Config{LogLevel: "invalid"},
+				NonSecretConfig: NonSecretConfig{JD: validJD, Server: validServer, Monitoring: &monitoring.Config{LogLevel: "invalid"}},
+				Secrets:         Secrets{Keystore: validKeystore, DB: DBConfig{URL: ""}},
 			},
 			wantErr:     true,
 			errContains: []string{"failed to validate 'db' section", "failed to validate 'monitoring' section"},
@@ -329,7 +330,7 @@ func TestConfig_validate(t *testing.T) {
 
 	// A monitoring-only config in static-TOML mode (needsInfra=false) must pass validation.
 	t.Run("monitoring-only config (static mode) is valid", func(t *testing.T) {
-		cfg := &Config{Monitoring: validBeholderMonitoring()}
+		cfg := &Config{NonSecretConfig: NonSecretConfig{Monitoring: validBeholderMonitoring()}}
 		require.NoError(t, cfg.validate(false))
 	})
 
@@ -337,18 +338,112 @@ func TestConfig_validate(t *testing.T) {
 	// passes because needsInfra=false, even when md reports infra sections present (they are only
 	// warned about, not validated). This is the mode-driven behavior that replaces presence-driven.
 	t.Run("static mode ignores present infra (no error)", func(t *testing.T) {
-		cfg := &Config{Monitoring: validBeholderMonitoring()}
+		cfg := &Config{NonSecretConfig: NonSecretConfig{Monitoring: validBeholderMonitoring()}}
 		require.NoError(t, cfg.validate(false))
 	})
 
 	// Symmetric guard: the same empty infra config in JD mode (needsInfra=true) DOES fail, naming
 	// the missing sections — the precise, load-time error that motivated mode-driven validation.
 	t.Run("JD mode requires infra (names missing sections)", func(t *testing.T) {
-		cfg := &Config{Monitoring: validBeholderMonitoring()}
+		cfg := &Config{NonSecretConfig: NonSecretConfig{Monitoring: validBeholderMonitoring()}}
 		err := cfg.validate(true)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to validate 'jd' section")
 		require.Contains(t, err.Error(), "failed to validate 'db' section")
+	})
+}
+
+// writeFile writes content to a fresh file under dir and returns its path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// TestLoadAndValidateConfig exercises the config/secrets split load path: the legacy
+// monolithic layout, the split layout, secrets-file precedence on overlap, and that validation runs
+// on the merged struct regardless of which file supplied a section.
+func TestLoadAndValidateConfig(t *testing.T) {
+	const nonSecretTOML = `
+[jd]
+server_wsrpc_url = "ws://localhost:8080/ws"
+server_csa_public_key = "` + validEd25519PublicKeyHex + `"
+
+[server]
+listen_port = 9988
+
+[[chains]]
+type = "EVM"
+id = "1"
+`
+	const secretsTOML = `
+[keystore]
+password = "s3cret"
+
+[db]
+url = "postgres://localhost:5432/bootstrapper"
+`
+	const monolithTOML = nonSecretTOML + secretsTOML
+
+	assertFullyPopulated := func(t *testing.T, cfg *Config) {
+		t.Helper()
+		require.Equal(t, "ws://localhost:8080/ws", cfg.JD.ServerWSRPCURL)
+		require.Equal(t, 9988, cfg.Server.ListenPort)
+		require.Len(t, cfg.Chains, 1)
+		require.Equal(t, "s3cret", cfg.Keystore.Password)
+		require.Equal(t, "postgres://localhost:5432/bootstrapper", cfg.DB.URL)
+	}
+
+	t.Run("legacy monolith: single file with all sections is valid", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeFile(t, dir, "config.toml", monolithTOML)
+
+		cfg := &Config{}
+		require.NoError(t, LoadAndValidateConfig([]string{path}, cfg, true))
+		assertFullyPopulated(t, cfg)
+	})
+
+	t.Run("split: config file + secrets file merge into one valid config", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := writeFile(t, dir, "config.toml", nonSecretTOML)
+		secretsPath := writeFile(t, dir, "secrets.toml", secretsTOML)
+
+		cfg := &Config{}
+		require.NoError(t, LoadAndValidateConfig([]string{configPath, secretsPath}, cfg, true))
+		assertFullyPopulated(t, cfg)
+	})
+
+	t.Run("secrets file wins on overlapping section", func(t *testing.T) {
+		dir := t.TempDir()
+		// config.toml carries a stale [db]; secrets.toml carries the authoritative one.
+		staleDB := nonSecretTOML + "\n[db]\nurl = \"postgres://stale/db\"\n"
+		configPath := writeFile(t, dir, "config.toml", staleDB)
+		secretsPath := writeFile(t, dir, "secrets.toml", secretsTOML)
+
+		cfg := &Config{}
+		require.NoError(t, LoadAndValidateConfig([]string{configPath, secretsPath}, cfg, true))
+		require.Equal(t, "postgres://localhost:5432/bootstrapper", cfg.DB.URL,
+			"the later (secrets) file must overlay and win for a section it defines")
+	})
+
+	t.Run("JD mode: missing secret section (no secrets file) fails validation naming it", func(t *testing.T) {
+		dir := t.TempDir()
+		// Only the non-secret file is provided, simulating a resolved-but-absent secrets file.
+		configPath := writeFile(t, dir, "config.toml", nonSecretTOML)
+
+		cfg := &Config{}
+		err := LoadAndValidateConfig([]string{configPath}, cfg, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to validate 'keystore' section")
+		require.Contains(t, err.Error(), "failed to validate 'db' section")
+	})
+
+	t.Run("read error names the offending path", func(t *testing.T) {
+		cfg := &Config{}
+		err := LoadAndValidateConfig([]string{filepath.Join(t.TempDir(), "does-not-exist.toml")}, cfg, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does-not-exist.toml")
 	})
 }
 
@@ -390,27 +485,29 @@ func TestConfig_validate_Chains(t *testing.T) {
 	validDB := DBConfig{URL: "postgres://localhost/test"}
 	validServer := ServerConfig{ListenPort: 9988}
 
+	// withChains builds a valid Config carrying the given chains, so each case varies only the chains.
+	withChains := func(chains ...ChainRegistration) *Config {
+		return &Config{
+			NonSecretConfig: NonSecretConfig{JD: validJD, Server: validServer, Chains: chains},
+			Secrets:         Secrets{Keystore: validKeystore, DB: validDB},
+		}
+	}
+
 	t.Run("no chains is valid", func(t *testing.T) {
 		t.Parallel()
-		cfg := &Config{JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer}
+		cfg := withChains()
 		require.NoError(t, cfg.validate(true))
 	})
 
 	t.Run("valid chains", func(t *testing.T) {
 		t.Parallel()
-		cfg := &Config{
-			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-			Chains: []ChainRegistration{{Type: "EVM", ID: "1"}, {Type: "EVM", ID: "137"}},
-		}
+		cfg := withChains(ChainRegistration{Type: "EVM", ID: "1"}, ChainRegistration{Type: "EVM", ID: "137"})
 		require.NoError(t, cfg.validate(true))
 	})
 
 	t.Run("invalid chain entry fails validation", func(t *testing.T) {
 		t.Parallel()
-		cfg := &Config{
-			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-			Chains: []ChainRegistration{{Type: "NOTACHAIN", ID: "1"}},
-		}
+		cfg := withChains(ChainRegistration{Type: "NOTACHAIN", ID: "1"})
 		err := cfg.validate(true)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid chain at index 0")
@@ -418,10 +515,7 @@ func TestConfig_validate_Chains(t *testing.T) {
 
 	t.Run("mixed chain families fails validation", func(t *testing.T) {
 		t.Parallel()
-		cfg := &Config{
-			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-			Chains: []ChainRegistration{{Type: "EVM", ID: "1"}, {Type: "SOLANA", ID: "mainnet"}},
-		}
+		cfg := withChains(ChainRegistration{Type: "EVM", ID: "1"}, ChainRegistration{Type: "SOLANA", ID: "mainnet"})
 		err := cfg.validate(true)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `chain at index 1 has type "SOLANA"`)
@@ -430,19 +524,13 @@ func TestConfig_validate_Chains(t *testing.T) {
 
 	t.Run("mixed chain families is case-insensitive", func(t *testing.T) {
 		t.Parallel()
-		cfg := &Config{
-			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-			Chains: []ChainRegistration{{Type: "evm", ID: "1"}, {Type: "EVM", ID: "137"}},
-		}
+		cfg := withChains(ChainRegistration{Type: "evm", ID: "1"}, ChainRegistration{Type: "EVM", ID: "137"})
 		require.NoError(t, cfg.validate(true), "same family in different casing must not be flagged as mixed")
 	})
 
 	t.Run("an invalid entry does not mask the family the remaining valid entries share", func(t *testing.T) {
 		t.Parallel()
-		cfg := &Config{
-			JD: validJD, Keystore: validKeystore, DB: validDB, Server: validServer,
-			Chains: []ChainRegistration{{Type: "NOTACHAIN", ID: "1"}, {Type: "EVM", ID: "1"}, {Type: "SOLANA", ID: "mainnet"}},
-		}
+		cfg := withChains(ChainRegistration{Type: "NOTACHAIN", ID: "1"}, ChainRegistration{Type: "EVM", ID: "1"}, ChainRegistration{Type: "SOLANA", ID: "mainnet"})
 		err := cfg.validate(true)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid chain at index 0")

--- a/build/devenv/services/bootstrap.go
+++ b/build/devenv/services/bootstrap.go
@@ -84,17 +84,26 @@ func CreateBootstrapDBInitScriptFile() (path string, err error) {
 	return tempFile.Name(), nil
 }
 
-// GenerateBootstrapConfig marshals the bootstrap configuration to TOML.
+// GenerateBootstrapConfig marshals the non-secret bootstrap config ([jd], [server], [[chains]],
+// [Monitoring]) to TOML. Credentials go to a separate secrets file; see GenerateBootstrapSecrets.
+// It marshals bootstrap.NonSecretConfig directly so the partition stays defined in one place.
 func GenerateBootstrapConfig(in BootstrapInput) ([]byte, error) {
-	config := bootstrap.Config{
-		Keystore:   *in.Keystore,
-		DB:         *in.DB,
+	return toml.Marshal(bootstrap.NonSecretConfig{
 		JD:         *in.JD,
 		Server:     *in.Server,
 		Chains:     in.Chains,
 		Monitoring: in.Monitoring,
-	}
-	return toml.Marshal(config)
+	})
+}
+
+// GenerateBootstrapSecrets marshals the credential-bearing bootstrap sections ([keystore], [db]) to
+// TOML, for the bootstrap secrets file loaded via BOOTSTRAPPER_SECRETS_PATH. It marshals
+// bootstrap.Secrets directly so the partition stays defined in one place.
+func GenerateBootstrapSecrets(in BootstrapInput) ([]byte, error) {
+	return toml.Marshal(bootstrap.Secrets{
+		Keystore: *in.Keystore,
+		DB:       *in.DB,
+	})
 }
 
 // BootstrapKeys holds the public keys exposed by the bootstrap info-server.

--- a/build/devenv/services/bootstrap_test.go
+++ b/build/devenv/services/bootstrap_test.go
@@ -3,10 +3,56 @@ package services
 import (
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
 	"github.com/smartcontractkit/chainlink-ccv/common/monitoring"
 )
+
+// validEd25519PublicKeyHex is 32 bytes (64 hex chars), accepted by JDConfig validation.
+const validEd25519PublicKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// TestGenerateBootstrap_SplitFiles locks in the config/secrets split: the non-secret file
+// carries only [jd]/[server]/[[chains]]/[Monitoring] and the secrets file carries only
+// [keystore]/[db]; decoding both into one bootstrap.Config reconstructs the full, valid config.
+func TestGenerateBootstrap_SplitFiles(t *testing.T) {
+	in := BootstrapInput{
+		Keystore: &bootstrap.KeystoreConfig{Password: "s3cret"},
+		Server:   &bootstrap.ServerConfig{ListenPort: 9988},
+		DB:       &bootstrap.DBConfig{URL: "postgres://user:pass@host:5432/db"},
+		JD: &bootstrap.JDConfig{
+			ServerWSRPCURL:     "ws://jd:8080/ws",
+			ServerCSAPublicKey: validEd25519PublicKeyHex,
+		},
+		Chains: []bootstrap.ChainRegistration{{Type: "EVM", ID: "1"}},
+	}
+
+	configTOML, err := GenerateBootstrapConfig(in)
+	require.NoError(t, err)
+	secretsTOML, err := GenerateBootstrapSecrets(in)
+	require.NoError(t, err)
+
+	// The non-secret file must not carry credentials.
+	require.NotContains(t, string(configTOML), "s3cret")
+	require.NotContains(t, string(configTOML), "postgres://")
+	// The secrets file must not carry the non-secret sections.
+	require.NotContains(t, string(secretsTOML), "server_wsrpc_url")
+	require.NotContains(t, string(secretsTOML), "listen_port")
+
+	// Decoding both into one struct (config first, secrets overlay) reconstructs the full config.
+	var cfg bootstrap.Config
+	_, err = toml.Decode(string(configTOML), &cfg)
+	require.NoError(t, err)
+	_, err = toml.Decode(string(secretsTOML), &cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, "ws://jd:8080/ws", cfg.JD.ServerWSRPCURL)
+	require.Equal(t, 9988, cfg.Server.ListenPort)
+	require.Len(t, cfg.Chains, 1)
+	require.Equal(t, "s3cret", cfg.Keystore.Password)
+	require.Equal(t, "postgres://user:pass@host:5432/db", cfg.DB.URL)
+}
 
 // TestApplyBootstrapDefaults_PreservesMonitoring locks in the contract the devenv routing relies on:
 // ApplyBootstrapDefaults must not touch a caller-set Monitoring. The component/environment loops set

--- a/build/devenv/services/committeeverifier/base.go
+++ b/build/devenv/services/committeeverifier/base.go
@@ -272,14 +272,23 @@ func launchVerifier(ctx context.Context, in *Input, outputs []*blockchain.Output
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate bootstrap config: %w", err)
 	}
+	bootstrapSecrets, err := services.GenerateBootstrapSecrets(*bootstrapInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate bootstrap secrets: %w", err)
+	}
 	confDir := util.CCVConfigDir()
 	bootstrapConfigFilePath := filepath.Join(confDir,
 		fmt.Sprintf("bootstrap-%s-config-%d.toml", in.CommitteeName, in.NodeIndex+1))
 	if err := os.WriteFile(bootstrapConfigFilePath, bootstrapConfig, 0o644); err != nil {
 		return nil, fmt.Errorf("failed to write bootstrap config to file: %w", err)
 	}
+	bootstrapSecretsFilePath := filepath.Join(confDir,
+		fmt.Sprintf("bootstrap-%s-secrets-%d.toml", in.CommitteeName, in.NodeIndex+1))
+	if err := os.WriteFile(bootstrapSecretsFilePath, bootstrapSecrets, 0o644); err != nil {
+		return nil, fmt.Errorf("failed to write bootstrap secrets to file: %w", err)
+	}
 
-	req, err := baseImageRequest(in, envVars, bootstrapConfigFilePath)
+	req, err := baseImageRequest(in, envVars, bootstrapConfigFilePath, bootstrapSecretsFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base image request: %w", err)
 	}
@@ -391,7 +400,7 @@ func startContainer(ctx context.Context, req testcontainers.ContainerRequest) (t
 	return nil, fmt.Errorf("failed to start container after %d attempts: %w", maxAttempts, lastErr)
 }
 
-func baseImageRequest(in *Input, envVars map[string]string, bootstrapConfigFilePath string) (testcontainers.ContainerRequest, error) {
+func baseImageRequest(in *Input, envVars map[string]string, bootstrapConfigFilePath, bootstrapSecretsFilePath string) (testcontainers.ContainerRequest, error) {
 	req := testcontainers.ContainerRequest{
 		Image:    in.Image,
 		Name:     in.ContainerName,
@@ -438,6 +447,12 @@ func baseImageRequest(in *Input, envVars map[string]string, bootstrapConfigFileP
 	req.Mounts = append(req.Mounts, testcontainers.BindMount(
 		bootstrapConfigFilePath,
 		bootstrap.DefaultConfigPath,
+	))
+	// Mount secrets at the default secrets path so the bootstrapper resolves it without an env var,
+	// exercising the split config/secrets load path.
+	req.Mounts = append(req.Mounts, testcontainers.BindMount(
+		bootstrapSecretsFilePath,
+		bootstrap.DefaultSecretsPath,
 	))
 
 	// Note: identical code to aggregator.go/executor.go -- will indexer be identical as well?

--- a/build/devenv/services/executor/base.go
+++ b/build/devenv/services/executor/base.go
@@ -203,14 +203,23 @@ func launchExecutor(ctx context.Context, in *Input, outputs []*blockchain.Output
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate bootstrap config: %w", err)
 	}
+	bootstrapSecrets, err := services.GenerateBootstrapSecrets(*bs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate bootstrap secrets: %w", err)
+	}
 	confDir := util.CCVConfigDir()
 	bootstrapConfigFilePath := filepath.Join(confDir,
 		fmt.Sprintf("bootstrap-executor-%s-config.toml", in.ContainerName))
 	if err := os.WriteFile(bootstrapConfigFilePath, bootstrapConfig, 0o644); err != nil {
 		return nil, fmt.Errorf("failed to write bootstrap config to file: %w", err)
 	}
+	bootstrapSecretsFilePath := filepath.Join(confDir,
+		fmt.Sprintf("bootstrap-executor-%s-secrets.toml", in.ContainerName))
+	if err := os.WriteFile(bootstrapSecretsFilePath, bootstrapSecrets, 0o644); err != nil {
+		return nil, fmt.Errorf("failed to write bootstrap secrets to file: %w", err)
+	}
 
-	req, err := baseImageRequest(in, bootstrapConfigFilePath)
+	req, err := baseImageRequest(in, bootstrapConfigFilePath, bootstrapSecretsFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base image request: %w", err)
 	}
@@ -322,7 +331,7 @@ func startContainer(ctx context.Context, req testcontainers.ContainerRequest) (t
 	return nil, fmt.Errorf("failed to start container after %d attempts: %w", maxAttempts, lastErr)
 }
 
-func baseImageRequest(in *Input, bootstrapConfigFilePath string) (testcontainers.ContainerRequest, error) {
+func baseImageRequest(in *Input, bootstrapConfigFilePath, bootstrapSecretsFilePath string) (testcontainers.ContainerRequest, error) {
 	req := testcontainers.ContainerRequest{
 		Image:    in.Image,
 		Name:     in.ContainerName,
@@ -358,6 +367,12 @@ func baseImageRequest(in *Input, bootstrapConfigFilePath string) (testcontainers
 	req.Mounts = append(req.Mounts, testcontainers.BindMount(
 		bootstrapConfigFilePath,
 		bootstrap.DefaultConfigPath,
+	))
+	// Mount secrets at the default secrets path so the bootstrapper resolves it without an env var,
+	// exercising the split config/secrets load path.
+	req.Mounts = append(req.Mounts, testcontainers.BindMount(
+		bootstrapSecretsFilePath,
+		bootstrap.DefaultSecretsPath,
 	))
 
 	if in.SourceCodePath != "" {

--- a/build/devenv/services/tokenVerifier.go
+++ b/build/devenv/services/tokenVerifier.go
@@ -166,7 +166,7 @@ func NewTokenVerifier(in *TokenVerifierInput, blockchainOutputs []*blockchain.Ou
 
 	// Generate and write the bootstrap (operator) config, carrying monitoring from the generated config.
 	// The token verifier runs in static-TOML mode with no infra, so only the non-secret monitoring
-	// section is written (no secrets file); validation correctly skips infra checks. See ADR-0008.
+	// section is written (no secrets file); validation correctly skips infra checks.
 	bootstrapConfig, err := toml.Marshal(bootstrap.NonSecretConfig{Monitoring: in.Bootstrap.Monitoring})
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate bootstrap config for token verifier: %w", err)

--- a/build/devenv/services/tokenVerifier.go
+++ b/build/devenv/services/tokenVerifier.go
@@ -165,9 +165,9 @@ func NewTokenVerifier(in *TokenVerifierInput, blockchainOutputs []*blockchain.Ou
 	}
 
 	// Generate and write the bootstrap (operator) config, carrying monitoring from the generated config.
-	// Only the monitoring section is set; the infra sections (jd/db/keystore/server) are zero-valued
-	// and omitted from the TOML output via omitempty, so validation correctly skips infra checks.
-	bootstrapConfig, err := toml.Marshal(bootstrap.Config{Monitoring: in.Bootstrap.Monitoring})
+	// The token verifier runs in static-TOML mode with no infra, so only the non-secret monitoring
+	// section is written (no secrets file); validation correctly skips infra checks. See ADR-0008.
+	bootstrapConfig, err := toml.Marshal(bootstrap.NonSecretConfig{Monitoring: in.Bootstrap.Monitoring})
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate bootstrap config for token verifier: %w", err)
 	}

--- a/changelog/2026-07-07_bootstrap_config_secret_split.md
+++ b/changelog/2026-07-07_bootstrap_config_secret_split.md
@@ -5,8 +5,7 @@
 The bootstrapper's operator config can now be split by sensitivity into a
 non-secret `config.toml` and a `secrets.toml` (credentials only), so the two
 halves can be deployed from separate sources (e.g. a k8s ConfigMap vs a Secret).
-The legacy monolithic single-file layout still works unchanged. See
-`docs/adr/0008-bootstrap-secret-config-split.md`.
+The legacy monolithic single-file layout still works unchanged.
 
 ---
 

--- a/changelog/2026-07-07_bootstrap_config_secret_split.md
+++ b/changelog/2026-07-07_bootstrap_config_secret_split.md
@@ -1,0 +1,91 @@
+# Bootstrap config split into non-secret config + secrets files
+
+## Summary
+
+The bootstrapper's operator config can now be split by sensitivity into a
+non-secret `config.toml` and a `secrets.toml` (credentials only), so the two
+halves can be deployed from separate sources (e.g. a k8s ConfigMap vs a Secret).
+The legacy monolithic single-file layout still works unchanged. See
+`docs/adr/0008-bootstrap-secret-config-split.md`.
+
+---
+
+## Breaking change: `bootstrap.Config` is now composed of two embedded structs
+
+The credential-bearing sections moved into a `Secrets` struct and the rest into
+`NonSecretConfig`; `Config` embeds both. Field **reads** are unaffected
+(`cfg.JD`, `cfg.DB` still work via promotion), but **keyed composite literals no
+longer compile**. TOML decoding/encoding is unchanged — sections stay top-level.
+
+| What | Before | After |
+|------|--------|-------|
+| `Config` shape | flat: `JD`, `Keystore`, `DB`, `Server`, `Chains`, `Monitoring` | `struct { NonSecretConfig; Secrets }` |
+| Secret sections | `Keystore`, `DB` on `Config` | on `Secrets` (`[keystore]`, `[db]`) |
+| Non-secret sections | `JD`, `Server`, `Chains`, `Monitoring` on `Config` | on `NonSecretConfig` |
+
+Before:
+```go
+cfg := bootstrap.Config{JD: jd, Keystore: ks, DB: db, Server: srv}
+```
+
+After:
+```go
+cfg := bootstrap.Config{
+    NonSecretConfig: bootstrap.NonSecretConfig{JD: jd, Server: srv},
+    Secrets:         bootstrap.Secrets{Keystore: ks, DB: db},
+}
+```
+
+---
+
+## Breaking change: `LoadAndValidateConfig` takes a path list
+
+Now accepts an ordered list of files, decoded into one struct (later files
+overlay earlier ones), so config + secrets merge before validation.
+
+Before:
+```go
+err := bootstrap.LoadAndValidateConfig(path, cfg, needsInfra)
+```
+
+After:
+```go
+err := bootstrap.LoadAndValidateConfig([]string{configPath, secretsPath}, cfg, needsInfra)
+```
+
+---
+
+## New: separate secrets file via `BOOTSTRAPPER_SECRETS_PATH`
+
+In JD mode the bootstrapper loads `config.toml` (`BOOTSTRAPPER_CONFIG_PATH`,
+default `/etc/config.toml`) and overlays an optional `secrets.toml`
+(`BOOTSTRAPPER_SECRETS_PATH`, default `/etc/bootstrap/secrets.toml`) carrying
+`[keystore]` and `[db]`. The secrets file wins for any section it defines and is
+optional — if absent, a monolithic `config.toml` with all sections still loads.
+Static-TOML mode (token verifier) is unchanged. Set the path explicitly with the
+new `WithBootstrapperSecretsPath` option.
+
+```toml
+# /etc/config.toml (non-secret)
+[jd]
+server_wsrpc_url = "ws://jd:8080/ws"
+server_csa_public_key = "..."
+[server]
+listen_port = 9988
+
+# /etc/bootstrap/secrets.toml (secrets)
+[keystore]
+password = "..."
+[db]
+url = "postgres://user:pass@host:5432/db"
+```
+
+Migration: the monolithic layout is deprecated and will be removed once
+deployments cut over. No deprecation warning is emitted yet.
+
+---
+
+## Recommended additions
+
+- Update deployment manifests (Helm/k8s) to mount `secrets.toml` from a Secret
+  and `config.toml` from a ConfigMap before the monolith is removed.


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

The bootstrapper's operator config is a single TOML file that mixes credential-bearing sections (`[db]`, `[keystore]`) with non-sensitive ones (`[jd]`, `[server]`, `[[chains]]`, `[monitoring]`). Operators asked to deploy the two halves from different sources, the non-secret half from a ConfigMap, the secrets from a Secret with its own lifecycle and RBAC, which the monolithic file can't support without routing credentials through the non-secret delivery path.

This splits the config by sensitivity into a non-secret `config.toml` and a `secrets.toml`, **backwards-compatibly**: apps already deployed with the monolithic file keep working untouched.

Design:

- The partition lives in the type system as two embedded halves: `Config = struct { NonSecretConfig; Secrets }`. Because they're embedded (anonymous, not nested), TOML flattens their sections to the top level, so a monolithic file decodes into `Config` exactly as before, and each half can be marshalled independently to produce one of the two split files. This makes the partition a single source of truth.
- `LoadAndValidateConfig` now takes an ordered list of paths and decodes them into one struct: `config.toml` first, then `secrets.toml` overlaid on top, so the secrets file wins for any section it defines. Validation runs once on the merged struct, so a required section is checked regardless of which file supplied it.
- A new `BOOTSTRAPPER_SECRETS_PATH` env var (default `/etc/bootstrap/secrets.toml`) points at the secrets file. It's optional at the file level. Absence is skipped, which is what keeps a legacy monolith valid. Secrets loading is JD-mode only; static mode (token verifier) is untouched.
- devenv implements the split: the committee verifier and executor now emit and mount both a `config.toml` and a `secrets.toml`, so e2e exercises the merge path in real containers.

Migration: the monolithic layout is deprecated and slated for removal once operators cut over. No deprecation warning ships in this change.

## Testing

- `go test ./bootstrap/...` 
- `go test ./build/devenv/services/...` 

## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date