### PR TITLE
CCIP-12199 ignore unknown monitoring in app config

### DIFF
--- a/bootstrap/job.go
+++ b/bootstrap/job.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 
@@ -46,7 +47,7 @@ func (js JobSpec) GetAppConfig(cfg any) error {
 	// Filter out undecoded fields under blockchain_infos.
 	var undecoded []string
 	for _, key := range md.Undecoded() {
-		if key[0] != "blockchain_infos" {
+		if key[0] != "blockchain_infos" && strings.ToLower(key[0]) != "monitoring" {
 			undecoded = append(undecoded, key.String())
 		}
 	}

--- a/bootstrap/job_test.go
+++ b/bootstrap/job_test.go
@@ -124,6 +124,10 @@ value = 42
 name    = "svc"
 value   = 7
 truck = "El Toro Loco"
+
+[Monitoring]
+Enabled = true
+Type = "beholder"
 ` + blockchainInfoFragment,
 		}
 		var cfg testAppConfig


### PR DESCRIPTION
<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

  - Skip `[Monitoring]` TOML keys when validating app config to avoid errors on unknown config sections.
  - Cover the new skip behavior in existing app config test.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

  - Unit test added in `bootstrap/job_test.go` with `[Monitoring]` block in job spec


<!-- Run through this list before requesting review. -->
## Checklist

- [x] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [x] `just generate` - mocks and protobufs are up to date
