### PR TITLE
feat(executor): attach CCIP messageID to TXM transaction meta (CCIP-11890)

### DIFF
--- a/integration/pkg/contracttransmitter/txm_evm_contract_transmitter.go
+++ b/integration/pkg/contracttransmitter/txm_evm_contract_transmitter.go
@@ -86,6 +86,11 @@ func (ct *TXMEVMContractTransmitter) ConvertAndWriteMessageToChain(ctx context.C
 		EncodedPayload: payload,
 		FeeLimit:       feeLimit,
 		Strategy:       txmgrcommon.NewSendEveryStrategy(),
+		// Correlates this tx with its CCIP message in TXM logs (the TXM
+		// logs meta.MessageIDs as "messageID" on every tx log line).
+		Meta: &txmgr.TxMeta{
+			MessageIDs: []string{messageID.String()},
+		},
 	})
 	if err != nil {
 		ct.monitoring.Metrics().IncrementUnrecoverableMessageFailure(ctx)

--- a/integration/pkg/contracttransmitter/txm_evm_contract_transmitter_test.go
+++ b/integration/pkg/contracttransmitter/txm_evm_contract_transmitter_test.go
@@ -408,6 +408,47 @@ func TestEIP150ForwardingGasBuffer(t *testing.T) {
 	}
 }
 
+func TestTXMEVMContractTransmitter_SetsMessageIDMeta(t *testing.T) {
+	ctx := context.Background()
+	lggr := logger.Test(t)
+	testKey := "test-key"
+
+	msg := mustCreateMessage(t, 1, 2, 100, 1000000, 1000000)
+	expectedMessageID, err := msg.MessageID()
+	require.NoError(t, err)
+
+	report := protocol.AbstractAggregatedReport{
+		CCVS: []protocol.UnknownAddress{
+			protocol.UnknownAddress(common.HexToAddress("0x1111111111111111111111111111111111111111").Bytes()),
+		},
+		CCVData: [][]byte{[]byte("ccv_data_1")},
+		Message: msg,
+	}
+
+	mockTxm := new(mockTxManager)
+	mockRR := new(mockRoundRobin)
+	fromAddr := common.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+	mockRR.On("GetNextAddress", mock.Anything, mock.Anything).Return(fromAddr, nil)
+	mockTxm.On("CreateTransaction", mock.Anything, mock.MatchedBy(func(req txmgr.TxRequest) bool {
+		return req.Meta != nil &&
+			len(req.Meta.MessageIDs) == 1 &&
+			req.Meta.MessageIDs[0] == expectedMessageID.String()
+	})).Return(txmgr.Tx{IdempotencyKey: &testKey}, nil)
+
+	transmitter := NewEVMContractTransmitterFromTxm(
+		lggr,
+		protocol.ChainSelector(1),
+		mockTxm,
+		common.HexToAddress("0x9999999999999999999999999999999999999999"),
+		mockRR,
+		[]common.Address{fromAddr},
+		monitoring.NewNoopExecutorMonitoring(),
+	)
+
+	require.NoError(t, transmitter.ConvertAndWriteMessageToChain(ctx, report))
+	mockTxm.AssertExpectations(t)
+}
+
 // mustCreateMessage creates a test message or fails the test.
 func mustCreateMessage(t *testing.T, sourceChain, destChain, nonce uint64, executionGasLimit, ccipReceiveGasLimit uint32) protocol.Message {
 	msg, err := protocol.NewMessage(


### PR DESCRIPTION
The TXM automatically logs meta.MessageIDs as 'messageID' on every log line for the transaction, so stuck messages (e.g. insufficient-funds retry loops) can be traced from TXM logs back to the CCIP message.

<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
