### PR TITLE
CODEOWNERS: ccip-platform owners of changelog/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 build/devenv @smartcontractkit/ccip-platform
 deployment @smartcontractkit/ccip-platform
 bootstrap @smartcontractkit/ccip-platform
+changelog @smartcontractkit/ccip-platform


### PR DESCRIPTION
Make ccip-platform codeowners of the changelog/ directory, which currently houses detailed changelogs of each breaking change merge, and will be linked to by release-please notes.