### PR TITLE
verifier/pkg/commit: harden HMAC creds against log leaks

### DIFF
--- a/protocol/common/hmac/hmac_auth.go
+++ b/protocol/common/hmac/hmac_auth.go
@@ -91,7 +91,9 @@ func ValidateAPIKey(apiKey string) error {
 func ValidateSecret(secret string) error {
 	decoded, err := hex.DecodeString(secret)
 	if err != nil {
-		return fmt.Errorf("secret must be hex-encoded: %w", err)
+		// Do not wrap err: hex.InvalidByteError echoes an offending byte of the secret, and callers
+		// log this error. Report only the failure reason, never any fragment of the credential.
+		return errors.New("secret must be hex-encoded")
 	}
 	if len(decoded) < MinSecretBytes {
 		return fmt.Errorf("secret must be at least %d bytes (%d hex chars), got %d bytes",

--- a/verifier/pkg/commit/config.go
+++ b/verifier/pkg/commit/config.go
@@ -74,13 +74,13 @@ const (
 // aggregator_address) falls back to the un-suffixed DefaultAggregator* variables, preserving the
 // existing single-aggregator deployment contract. Config generators (changeset, devenv) and the
 // deploy layer use the same convention to set the matching environment variables.
-func (a AggregatorConnection) AggregatorCredentialEnvVars() (apiKeyVar, secretKeyVar string) {
+func (a AggregatorConnection) AggregatorCredentialEnvVars() (apiKeyEnvName, secretKeyEnvName string) {
 	return AggregatorCredentialEnvVars(a.SecretName)
 }
 
 // AggregatorCredentialEnvVars returns the credential environment variable names for an aggregator
 // with the given secret name. An empty secret name yields the default (legacy) un-suffixed variables.
-func AggregatorCredentialEnvVars(secretName string) (apiKeyVar, secretKeyVar string) {
+func AggregatorCredentialEnvVars(secretName string) (apiKeyEnvName, secretKeyEnvName string) {
 	if strings.TrimSpace(secretName) == "" {
 		return DefaultAggregatorAPIKeyEnvVar, DefaultAggregatorSecretKeyEnvVar
 	}
@@ -96,6 +96,9 @@ func AggregatorCredentialEnvVars(secretName string) (apiKeyVar, secretKeyVar str
 // used; otherwise resolution falls back to the environment variables named by
 // AggregatorCredentialEnvVars, preserving the backwards-compatible env-only deployment contract. A
 // nil secrets map (no file, or a file with no [[aggregators]]) is the env-only path.
+//
+// Errors intentionally name the source (env var name, or file field name), never the credential
+// value, so they are safe to log.
 func (a AggregatorConnection) ResolveHMACConfig(secrets vsecrets.AggregatorSecrets) (*hmac.ClientConfig, error) {
 	if secrets != nil {
 		if cred, ok := secrets[strings.TrimSpace(a.SecretName)]; ok {
@@ -103,8 +106,8 @@ func (a AggregatorConnection) ResolveHMACConfig(secrets vsecrets.AggregatorSecre
 		}
 	}
 
-	apiKeyVar, secretKeyVar := a.AggregatorCredentialEnvVars()
-	return buildHMACConfig(os.Getenv(apiKeyVar), os.Getenv(secretKeyVar), apiKeyVar, secretKeyVar, a.Label())
+	apiKeyEnvName, secretKeyEnvName := a.AggregatorCredentialEnvVars()
+	return buildHMACConfig(os.Getenv(apiKeyEnvName), os.Getenv(secretKeyEnvName), apiKeyEnvName, secretKeyEnvName, a.Label())
 }
 
 // buildHMACConfig validates an API key / secret pair and returns the client config. apiKeyLabel and


### PR DESCRIPTION
## Description

Addresses a CodeQL `go/clear-text-logging-sensitive-data` alert on the aggregator HMAC credential path. The alert fires where a job-proposal error is logged (`common/jd/lifecycle/manager.go`), tracing back to `AggregatorConnection.ResolveHMACConfig` in `verifier/pkg/commit/config.go`.

Investigation confirmed it is a **false positive for the credential values**: the errors interpolate the environment-variable *names* (`VERIFIER_AGGREGATOR_<NAME>_API_KEY` / `_SECRET_KEY`) and the aggregator label, never the API key or secret values. CodeQL's heuristic fired on the variable identifiers (`apiKeyVar` / `secretKeyVar`) because their names contain "Key"/"secret" and flow into a log sink.

The alert was already dismissed on the originating PR (#1240). This change makes it not recur, and closes one genuine (if tiny) gap:

- **Rename** `apiKeyVar`/`secretKeyVar` → `apiKeyEnvName`/`secretKeyEnvName` in `AggregatorCredentialEnvVars` and `ResolveHMACConfig`. These hold env-var names, not values; the rename says so and clears CodeQL's name-based heuristic. A doc comment records that the errors are safe to log.
- **Harden `hmac.ValidateSecret`**: stop wrapping the `hex.DecodeString` error. `hex.InvalidByteError` echoes an offending byte of a malformed secret, and callers log this error — so a single byte of a bad secret could leak. It now returns a plain `"secret must be hex-encoded"`.

## Testing

CodeQL passes in CI.

<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date