### PR TITLE
aggregator: load creds from secrets file

### DIFF
--- a/aggregator/cmd/main.go
+++ b/aggregator/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/common"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/configuration"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/monitoring"
+	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/secrets"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/storage/postgres"
 	"github.com/smartcontractkit/chainlink-ccv/common/monitoring/logging"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
@@ -86,8 +87,12 @@ func main() {
 				if err != nil {
 					return fmt.Errorf("failed to load config: %w", err)
 				}
-				if err := cfg.LoadFromEnvironment(); err != nil {
-					return fmt.Errorf("failed to load config from environment: %w", err)
+				sec, err := secrets.LoadFromEnv(secrets.SecretsPathEnvVar, secrets.DefaultSecretsPath)
+				if err != nil {
+					return fmt.Errorf("failed to load secrets: %w", err)
+				}
+				if err := cfg.ResolveSecrets(sec); err != nil {
+					return fmt.Errorf("failed to resolve secrets: %w", err)
 				}
 				db, err := sql.Open("postgres", cfg.Storage.ConnectionURL)
 				if err != nil {
@@ -142,11 +147,16 @@ func runServer(configPath string, lggr logger.Logger, sugaredLggr logger.Sugared
 	}
 	lggr.Infow("Loaded configuration", "config", config)
 
-	if err := config.LoadFromEnvironment(); err != nil {
-		lggr.Errorw("Failed to load configuration from environment", "path", configPath, "error", err)
+	sec, err := secrets.LoadFromEnv(secrets.SecretsPathEnvVar, secrets.DefaultSecretsPath)
+	if err != nil {
+		lggr.Errorw("Failed to load secrets", "error", err)
 		os.Exit(1)
 	}
-	lggr.Infow("Successfully loaded configuration from environment variables")
+	if err := config.ResolveSecrets(sec); err != nil {
+		lggr.Errorw("Failed to resolve secrets", "path", configPath, "error", err)
+		os.Exit(1)
+	}
+	lggr.Infow("Successfully resolved secrets")
 
 	var aggMonitoring common.AggregatorMonitoring = monitoring.NewNoopAggregatorMonitoring()
 	if config.Monitoring.Beholder.Enabled {

--- a/aggregator/pkg/model/config.go
+++ b/aggregator/pkg/model/config.go
@@ -458,14 +458,14 @@ type ClientConfig struct {
 	Enabled     bool             `toml:"enabled"`
 	ClientID    string           `toml:"clientId"`
 	// resolvedPairs holds credentials supplied for this client by the aggregator secrets file. When
-	// non-nil it replaces the env-var (APIKeyPairs) source entirely for this client (replace-per-client
-	// file-wins). It is unexported so struct logging (e.g. the "Loaded configuration" log) can never
+	// non-nil it replaces the env-var (APIKeyPairs) source entirely for this client.
+	// It is unexported so struct logging (e.g. the "Loaded configuration" log) can never
 	// leak the plaintext credentials it carries. Populated by AggregatorConfig.ResolveSecrets.
 	resolvedPairs []resolvedAPIKeyPair
 }
 
 // effectivePairs returns the credentials in force for this client: the secrets-file-resolved pairs
-// when present (replace-per-client), otherwise the legacy env-var pairs. This is the single source
+// when present, otherwise the legacy env-var pairs. This is the single source
 // both authentication (GetClientByAPIKey) and validation read from, so behavior is identical
 // regardless of where the credential came from.
 func (c *ClientConfig) effectivePairs() []auth.APIKeyPair {
@@ -981,9 +981,8 @@ func (c *AggregatorConfig) Validate() error {
 // back to the legacy env vars otherwise.
 //
 // s may be nil (equivalent to "no secrets file"), in which case every value resolves purely from the
-// environment — the backwards-compatible path. Client credentials are resolved per client
-// (replace-per-client): a client for which the file supplies any pairs takes those and ignores its
-// env-var pairs entirely.
+// environment — the backwards-compatible path. Client credentials are resolved per client:
+// a client for which the file supplies any pairs takes those and ignores its env-var pairs entirely.
 func (c *AggregatorConfig) ResolveSecrets(s *secrets.Secrets) error {
 	if c.Storage.StorageType == StorageTypePostgreSQL {
 		storageURL := s.StorageURL()
@@ -1004,8 +1003,8 @@ func (c *AggregatorConfig) ResolveSecrets(s *secrets.Secrets) error {
 	return nil
 }
 
-// resolveClientSecrets applies the secrets file's per-client credentials to the config
-// (replace-per-client). Clients absent from fileClients keep their env-var pairs untouched.
+// resolveClientSecrets applies the secrets file's per-client credentials to the config.
+// Clients absent from fileClients keep their env-var pairs untouched.
 func (c *AggregatorConfig) resolveClientSecrets(fileClients secrets.ClientSecrets) {
 	if len(fileClients) == 0 {
 		return

--- a/aggregator/pkg/model/config.go
+++ b/aggregator/pkg/model/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/auth"
+	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/secrets"
 	"github.com/smartcontractkit/chainlink-ccv/common"
 	"github.com/smartcontractkit/chainlink-ccv/common/monitoring"
 	"github.com/smartcontractkit/chainlink-ccv/protocol"
@@ -395,6 +396,10 @@ type AggregatorConfig struct {
 	MaxCommitVerifierNodeResultRequestsPerBatch int                           `toml:"maxCommitVerifierNodeResultRequestsPerBatch"`
 }
 
+// APIKeyPairEnv is the legacy, backwards-compatible source of a client's inbound HMAC credential: it
+// holds the names of two environment variables whose values are read at use. It is superseded, for a
+// given client, by credentials supplied in the aggregator secrets file (see ResolveSecrets); it
+// remains the fallback for any client the file does not cover.
 type APIKeyPairEnv struct {
 	APIKeyEnvVar string `toml:"apiKeyEnvVar"`
 	SecretEnvVar string `toml:"secretEnvVar"`
@@ -407,6 +412,17 @@ func (c *APIKeyPairEnv) GetAPIKey() string {
 func (c *APIKeyPairEnv) GetSecret() string {
 	return os.Getenv(c.SecretEnvVar)
 }
+
+// resolvedAPIKeyPair is an inbound HMAC credential whose api_key/secret values were resolved from the
+// aggregator secrets file. It carries the plaintext credential, so it lives only in an unexported
+// field (ClientConfig.resolvedPairs) that struct logging cannot reach. It satisfies auth.APIKeyPair.
+type resolvedAPIKeyPair struct {
+	apiKey string
+	secret string
+}
+
+func (p resolvedAPIKeyPair) GetAPIKey() string { return p.apiKey }
+func (p resolvedAPIKeyPair) GetSecret() string { return p.secret }
 
 func (c *APIKeyPairEnv) Validate() error {
 	if c.APIKeyEnvVar == "" {
@@ -441,6 +457,30 @@ type ClientConfig struct {
 	Name        string           `toml:"name,omitempty"`
 	Enabled     bool             `toml:"enabled"`
 	ClientID    string           `toml:"clientId"`
+	// resolvedPairs holds credentials supplied for this client by the aggregator secrets file. When
+	// non-nil it replaces the env-var (APIKeyPairs) source entirely for this client (replace-per-client
+	// file-wins). It is unexported so struct logging (e.g. the "Loaded configuration" log) can never
+	// leak the plaintext credentials it carries. Populated by AggregatorConfig.ResolveSecrets.
+	resolvedPairs []resolvedAPIKeyPair
+}
+
+// effectivePairs returns the credentials in force for this client: the secrets-file-resolved pairs
+// when present (replace-per-client), otherwise the legacy env-var pairs. This is the single source
+// both authentication (GetClientByAPIKey) and validation read from, so behavior is identical
+// regardless of where the credential came from.
+func (c *ClientConfig) effectivePairs() []auth.APIKeyPair {
+	if len(c.resolvedPairs) > 0 {
+		pairs := make([]auth.APIKeyPair, 0, len(c.resolvedPairs))
+		for i := range c.resolvedPairs {
+			pairs = append(pairs, c.resolvedPairs[i])
+		}
+		return pairs
+	}
+	pairs := make([]auth.APIKeyPair, 0, len(c.APIKeyPairs))
+	for _, p := range c.APIKeyPairs {
+		pairs = append(pairs, p)
+	}
+	return pairs
 }
 
 func (c *ClientConfig) GetClientID() string { return c.ClientID }
@@ -457,6 +497,22 @@ func (c *ClientConfig) Validate() error {
 	if c.ClientID == "" {
 		return errors.New("clientId cannot be empty")
 	}
+
+	// Credentials resolved from the secrets file are validated by value: the env-var indirection does
+	// not apply, and the error must not echo the credential, so we reference the pair ordinal only.
+	if len(c.resolvedPairs) > 0 {
+		for i, pair := range c.resolvedPairs {
+			if err := hmacutil.ValidateAPIKey(pair.apiKey); err != nil {
+				return fmt.Errorf("invalid api_key for client %s (secrets file pair %d): %w", c.ClientID, i, err)
+			}
+			if err := hmacutil.ValidateSecret(pair.secret); err != nil {
+				return fmt.Errorf("invalid secret_key for client %s (secrets file pair %d): %w", c.ClientID, i, err)
+			}
+		}
+		return nil
+	}
+
+	// Legacy env-var path: APIKeyPairEnv.Validate reads and format-checks the named env vars.
 	if len(c.APIKeyPairs) == 0 {
 		return errors.New("apiKeyPair cannot be empty")
 	}
@@ -470,7 +526,7 @@ func (c *ClientConfig) Validate() error {
 
 func (c *AggregatorConfig) GetClientByAPIKey(apiKey string) (auth.ClientConfig, auth.APIKeyPair, bool) {
 	for _, client := range c.APIClients {
-		for _, apiKeyPair := range client.APIKeyPairs {
+		for _, apiKeyPair := range client.effectivePairs() {
 			if apiKeyPair.GetAPIKey() == apiKey {
 				if !client.IsEnabled() {
 					return nil, nil, false
@@ -919,25 +975,55 @@ func (c *AggregatorConfig) Validate() error {
 	return nil
 }
 
-func (c *AggregatorConfig) LoadFromEnvironment() error {
+// ResolveSecrets resolves the aggregator's credentials into the config, with the secrets file winning
+// over environment variables. It supersedes the former LoadFromEnvironment: the storage URL, the redis
+// password, and the per-client inbound HMAC pairs now come from the secrets file when present, falling
+// back to the legacy env vars otherwise.
+//
+// s may be nil (equivalent to "no secrets file"), in which case every value resolves purely from the
+// environment — the backwards-compatible path. Client credentials are resolved per client
+// (replace-per-client): a client for which the file supplies any pairs takes those and ignores its
+// env-var pairs entirely.
+func (c *AggregatorConfig) ResolveSecrets(s *secrets.Secrets) error {
 	if c.Storage.StorageType == StorageTypePostgreSQL {
-		storageURL := os.Getenv("AGGREGATOR_STORAGE_CONNECTION_URL")
+		storageURL := s.StorageURL()
 		if storageURL == "" {
-			return errors.New("AGGREGATOR_STORAGE_CONNECTION_URL environment variable is required")
+			return errors.New("aggregator storage connection URL is required: set [storage].url in the secrets file or the AGGREGATOR_STORAGE_CONNECTION_URL environment variable")
 		}
 		c.Storage.ConnectionURL = storageURL
 	}
 
+	c.resolveClientSecrets(s.ClientSecrets())
+
 	if c.RateLimiting.Storage.Type == RateLimiterStoreTypeRedis && c.RateLimiting.Enabled {
-		if err := c.loadRateLimiterRedisConfigFromEnvironment(); err != nil {
-			return fmt.Errorf("failed to load rate limiter redis config from environment: %w", err)
+		if err := c.loadRateLimiterRedisConfig(s); err != nil {
+			return fmt.Errorf("failed to load rate limiter redis config: %w", err)
 		}
 	}
 
 	return nil
 }
 
-func (c *AggregatorConfig) loadRateLimiterRedisConfigFromEnvironment() error {
+// resolveClientSecrets applies the secrets file's per-client credentials to the config
+// (replace-per-client). Clients absent from fileClients keep their env-var pairs untouched.
+func (c *AggregatorConfig) resolveClientSecrets(fileClients secrets.ClientSecrets) {
+	if len(fileClients) == 0 {
+		return
+	}
+	for _, client := range c.APIClients {
+		creds, ok := fileClients[client.ClientID]
+		if !ok {
+			continue
+		}
+		resolved := make([]resolvedAPIKeyPair, 0, len(creds))
+		for _, cr := range creds {
+			resolved = append(resolved, resolvedAPIKeyPair{apiKey: cr.APIKey, secret: cr.SecretKey})
+		}
+		client.resolvedPairs = resolved
+	}
+}
+
+func (c *AggregatorConfig) loadRateLimiterRedisConfig(s *secrets.Secrets) error {
 	redisAddress := os.Getenv("AGGREGATOR_REDIS_ADDRESS")
 	if redisAddress == "" {
 		return errors.New("AGGREGATOR_REDIS_ADDRESS environment variable is required")
@@ -947,8 +1033,8 @@ func (c *AggregatorConfig) loadRateLimiterRedisConfigFromEnvironment() error {
 	}
 	c.RateLimiting.Storage.Redis.Address = redisAddress
 
-	redisPassword := os.Getenv("AGGREGATOR_REDIS_PASSWORD")
-	c.RateLimiting.Storage.Redis.Password = redisPassword
+	// Password comes from the secrets file when present, otherwise AGGREGATOR_REDIS_PASSWORD.
+	c.RateLimiting.Storage.Redis.Password = s.RedisPassword()
 
 	redisDBStr := os.Getenv("AGGREGATOR_REDIS_DB")
 	if redisDBStr != "" {

--- a/aggregator/pkg/model/config_test.go
+++ b/aggregator/pkg/model/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/auth"
+	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/secrets"
 	"github.com/smartcontractkit/chainlink-ccv/common"
 	hmacutil "github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
 )
@@ -983,6 +984,81 @@ func TestGetClientByAPIKey(t *testing.T) {
 	})
 }
 
+// loadSecretsFromString writes contents to a temp secrets file and loads it.
+func loadSecretsFromString(t *testing.T, contents string) *secrets.Secrets {
+	t.Helper()
+	path := t.TempDir() + "/secrets.toml"
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	s, err := secrets.Load(path)
+	require.NoError(t, err)
+	return s
+}
+
+func TestResolveSecrets_FileClientCredentialsReplacePerClient(t *testing.T) {
+	fileCreds, _ := hmacutil.GenerateCredentials()
+	envCreds, _ := hmacutil.GenerateCredentials()
+	otherCreds, _ := hmacutil.GenerateCredentials()
+
+	// client1's credentials come from the file; client2 has no file entry and stays on its env vars.
+	t.Setenv("CLIENT1_ENV_KEY", envCreds.APIKey)
+	t.Setenv("CLIENT1_ENV_SECRET", envCreds.Secret)
+	t.Setenv("CLIENT2_ENV_KEY", otherCreds.APIKey)
+	t.Setenv("CLIENT2_ENV_SECRET", otherCreds.Secret)
+
+	cfg := &AggregatorConfig{
+		Storage: &StorageConfig{},
+		APIClients: []*ClientConfig{
+			{
+				ClientID:    "client1",
+				Enabled:     true,
+				APIKeyPairs: []*APIKeyPairEnv{{APIKeyEnvVar: "CLIENT1_ENV_KEY", SecretEnvVar: "CLIENT1_ENV_SECRET"}},
+			},
+			{
+				ClientID:    "client2",
+				Enabled:     true,
+				APIKeyPairs: []*APIKeyPairEnv{{APIKeyEnvVar: "CLIENT2_ENV_KEY", SecretEnvVar: "CLIENT2_ENV_SECRET"}},
+			},
+		},
+	}
+
+	s := loadSecretsFromString(t, `
+[[clients]]
+client_id  = "client1"
+api_key    = "`+fileCreds.APIKey+`"
+secret_key = "`+fileCreds.Secret+`"
+`)
+	require.NoError(t, cfg.ResolveSecrets(s))
+
+	// client1: the file's credential wins and the env credential is no longer accepted (replace-per-client).
+	client, pair, found := cfg.GetClientByAPIKey(fileCreds.APIKey)
+	require.True(t, found)
+	assert.Equal(t, "client1", client.GetClientID())
+	assert.Equal(t, fileCreds.Secret, pair.GetSecret())
+
+	_, _, found = cfg.GetClientByAPIKey(envCreds.APIKey)
+	assert.False(t, found, "env credential must be replaced once the file supplies client1's pairs")
+
+	// client2: untouched by the file, still resolves from its env vars.
+	client2, _, found := cfg.GetClientByAPIKey(otherCreds.APIKey)
+	require.True(t, found)
+	assert.Equal(t, "client2", client2.GetClientID())
+
+	// Validation accepts the resolved (file-sourced) credentials.
+	require.NoError(t, cfg.ValidateClientConfig())
+}
+
+func TestResolveSecrets_FileWinsStorageURL(t *testing.T) {
+	t.Setenv(secrets.StorageURLEnvVar, "postgres://env-host/agg")
+	cfg := &AggregatorConfig{Storage: &StorageConfig{StorageType: StorageTypePostgreSQL}}
+
+	s := loadSecretsFromString(t, `
+[storage]
+url = "postgres://file-host/agg"
+`)
+	require.NoError(t, cfg.ResolveSecrets(s))
+	assert.Equal(t, "postgres://file-host/agg", cfg.Storage.ConnectionURL)
+}
+
 func TestGetClientByClientID(t *testing.T) {
 	t.Run("finds enabled client by ID", func(t *testing.T) {
 		cfg := &AggregatorConfig{
@@ -1191,14 +1267,14 @@ func TestClientConfig_GetClientName(t *testing.T) {
 	})
 }
 
-func TestLoadFromEnvironment(t *testing.T) {
+func TestResolveSecrets_FromEnvironment(t *testing.T) {
 	t.Run("loads postgres connection URL", func(t *testing.T) {
 		t.Setenv("AGGREGATOR_STORAGE_CONNECTION_URL", "postgres://localhost:5432/test")
 
 		cfg := &AggregatorConfig{
 			Storage: &StorageConfig{StorageType: StorageTypePostgreSQL},
 		}
-		err := cfg.LoadFromEnvironment()
+		err := cfg.ResolveSecrets(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "postgres://localhost:5432/test", cfg.Storage.ConnectionURL)
 	})
@@ -1207,7 +1283,7 @@ func TestLoadFromEnvironment(t *testing.T) {
 		cfg := &AggregatorConfig{
 			Storage: &StorageConfig{StorageType: StorageTypePostgreSQL},
 		}
-		err := cfg.LoadFromEnvironment()
+		err := cfg.ResolveSecrets(nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "AGGREGATOR_STORAGE_CONNECTION_URL")
 	})
@@ -1224,7 +1300,7 @@ func TestLoadFromEnvironment(t *testing.T) {
 				Storage: RateLimiterStoreConfig{Type: RateLimiterStoreTypeRedis},
 			},
 		}
-		err := cfg.LoadFromEnvironment()
+		err := cfg.ResolveSecrets(nil)
 		require.NoError(t, err)
 		assert.Equal(t, "localhost:6379", cfg.RateLimiting.Storage.Redis.Address)
 		assert.Equal(t, "secret", cfg.RateLimiting.Storage.Redis.Password)
@@ -1239,7 +1315,7 @@ func TestLoadFromEnvironment(t *testing.T) {
 				Storage: RateLimiterStoreConfig{Type: RateLimiterStoreTypeRedis},
 			},
 		}
-		err := cfg.LoadFromEnvironment()
+		err := cfg.ResolveSecrets(nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "AGGREGATOR_REDIS_ADDRESS")
 	})
@@ -1255,7 +1331,7 @@ func TestLoadFromEnvironment(t *testing.T) {
 				Storage: RateLimiterStoreConfig{Type: RateLimiterStoreTypeRedis},
 			},
 		}
-		err := cfg.LoadFromEnvironment()
+		err := cfg.ResolveSecrets(nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid AGGREGATOR_REDIS_DB value")
 	})

--- a/aggregator/pkg/model/config_test.go
+++ b/aggregator/pkg/model/config_test.go
@@ -1029,7 +1029,7 @@ secret_key = "`+fileCreds.Secret+`"
 `)
 	require.NoError(t, cfg.ResolveSecrets(s))
 
-	// client1: the file's credential wins and the env credential is no longer accepted (replace-per-client).
+	// client1: the file's credential wins and the env credential is no longer accepted.
 	client, pair, found := cfg.GetClientByAPIKey(fileCreds.APIKey)
 	require.True(t, found)
 	assert.Equal(t, "client1", client.GetClientID())

--- a/aggregator/pkg/secrets/secrets.go
+++ b/aggregator/pkg/secrets/secrets.go
@@ -1,0 +1,202 @@
+// Package secrets defines the aggregator secrets file: an optional, operator-provided TOML file
+// carrying the aggregator's own credentials — the application storage DB URL, the redis password used
+// by rate limiting, and the per-client inbound HMAC api_key/secret_key pairs. It is a leaf package
+// (depending only on the TOML decoder) so the aggregator app and the devenv harness can share one
+// schema definition without pulling in heavier dependencies.
+//
+// Secrets resolve backwards-compatibly: an absent file is never an error and falls back entirely to
+// environment variables, and when a value is present in both the file and an env var the file wins.
+// For client credentials this is resolved per client (replace-per-client): if the file supplies any
+// pairs for a client_id, that set is authoritative and the env-derived pairs for that client are
+// ignored.
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Environment variables and the default path for the aggregator secrets file.
+const (
+	// StorageURLEnvVar is the legacy environment variable for the application storage DB URL, used as
+	// the fallback when the secrets file does not supply [storage].url.
+	StorageURLEnvVar = "AGGREGATOR_STORAGE_CONNECTION_URL"
+
+	// RedisPasswordEnvVar is the legacy environment variable for the rate limiter's redis password,
+	// used as the fallback when the secrets file does not supply [redis].password.
+	RedisPasswordEnvVar = "AGGREGATOR_REDIS_PASSWORD" //nolint:gosec // G101: env var name, not a credential
+
+	// SecretsPathEnvVar is the env var naming the secrets file path; it follows the repo's
+	// <APP>_SECRETS_PATH convention and pairs with AGGREGATOR_CONFIG_PATH.
+	SecretsPathEnvVar = "AGGREGATOR_SECRETS_PATH" //nolint:gosec // G101: env var name, not a credential
+
+	// DefaultSecretsPath is the namespaced default location of the secrets.toml file.
+	DefaultSecretsPath = "/etc/aggregator/secrets.toml" //nolint:gosec // G101: file path, not a credential
+)
+
+// File is the on-disk schema of the aggregator secrets file. It carries only credential-bearing
+// values: the application storage DB URL, the rate limiter's redis password, and the per-client
+// inbound HMAC pairs. Non-secret knobs (redis address/db) stay as environment variables and are
+// intentionally absent here.
+type File struct {
+	Storage StorageSecrets `toml:"storage"`
+	Redis   RedisSecrets   `toml:"redis"`
+	Clients []ClientSecret `toml:"clients"`
+}
+
+// StorageSecrets holds the aggregator's application storage DB URL (formerly
+// AGGREGATOR_STORAGE_CONNECTION_URL). Named [storage] to match the aggregator's own config section.
+type StorageSecrets struct {
+	URL string `toml:"url"`
+}
+
+// RedisSecrets holds the redis password used by the rate limiter (formerly AGGREGATOR_REDIS_PASSWORD).
+// The non-secret redis knobs (address, db) are deliberately not here.
+type RedisSecrets struct {
+	Password string `toml:"password"`
+}
+
+// ClientSecret is one client's inbound HMAC credential as declared in the [[clients]] array of tables.
+// A client_id may appear more than once to declare multiple pairs (e.g. during key rotation); the
+// aggregator accepts any of a client's pairs. Unlike the verifier's [[aggregators]], there is no join
+// key: the pair is a pure credential and client_id is the only association it needs.
+type ClientSecret struct {
+	ClientID  string `toml:"client_id"`
+	APIKey    string `toml:"api_key"`
+	SecretKey string `toml:"secret_key"`
+}
+
+// ClientCredential is one resolved (api_key, secret_key) pair for a client.
+type ClientCredential struct {
+	APIKey    string
+	SecretKey string
+}
+
+// ClientSecrets is the resolved per-client credential set, indexed by client_id. A nil map means the
+// file supplied no client credentials, in which case each client falls back entirely to its env vars.
+type ClientSecrets map[string][]ClientCredential
+
+// Secrets is the parsed, validated aggregator secrets, ready to hand to the read sites. An absent file
+// yields a zero value whose accessors all fall back to environment variables (the backwards-compatible
+// path).
+type Secrets struct {
+	// storageURL is the DB URL from the file; empty when the file omits it (env is then used).
+	storageURL string
+	// redisPassword is the redis password from the file; empty when omitted (env is then used).
+	redisPassword string
+	// clients is nil when the file supplied no [[clients]] (env is then used for every client).
+	clients ClientSecrets
+}
+
+// newClientSecrets groups the given entries by client_id, enforcing that a present file is
+// well-formed: every entry must carry a non-empty client_id, api_key, and secret_key, and no api_key
+// may appear twice (an api_key is the auth lookup key, so a collision is genuinely ambiguous). A
+// repeated client_id is allowed — that is rotation. Returns a nil map (not an error) when entries is
+// empty. Error messages reference entry ordinals and client_id, never the credential value.
+func newClientSecrets(entries []ClientSecret) (ClientSecrets, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	seenAPIKey := make(map[string]int, len(entries))
+	result := make(ClientSecrets)
+	for i, e := range entries {
+		clientID := strings.TrimSpace(e.ClientID)
+		if clientID == "" {
+			return nil, fmt.Errorf("clients entry #%d: client_id is required", i)
+		}
+		if strings.TrimSpace(e.APIKey) == "" {
+			return nil, fmt.Errorf("clients entry #%d (client_id %q): api_key is required", i, clientID)
+		}
+		if strings.TrimSpace(e.SecretKey) == "" {
+			return nil, fmt.Errorf("clients entry #%d (client_id %q): secret_key is required", i, clientID)
+		}
+		if prev, dup := seenAPIKey[e.APIKey]; dup {
+			return nil, fmt.Errorf("duplicate api_key in clients entries #%d and #%d (client_id %q)", prev, i, clientID)
+		}
+		seenAPIKey[e.APIKey] = i
+		result[clientID] = append(result[clientID], ClientCredential{APIKey: e.APIKey, SecretKey: e.SecretKey})
+	}
+	return result, nil
+}
+
+// ResolveSecretsPath returns the secrets file path from envVar, or defaultPath when unset.
+func ResolveSecretsPath(envVar, defaultPath string) string {
+	if p := os.Getenv(envVar); p != "" {
+		return p
+	}
+	return defaultPath
+}
+
+// LoadFromEnv resolves the secrets path from envVar (falling back to defaultPath) and loads it.
+func LoadFromEnv(envVar, defaultPath string) (*Secrets, error) {
+	return Load(ResolveSecretsPath(envVar, defaultPath))
+}
+
+// Load reads and validates the aggregator secrets file at path.
+//
+// An absent file is never an error: it returns an empty *Secrets so callers uniformly fall back to
+// environment variables (the backwards-compatible default). A present file is decoded strictly —
+// malformed TOML, unknown/misspelled keys, a half-filled [[clients]] entry, or a duplicate api_key are
+// hard errors, so a real secrets file is never silently half-ignored. Credential-value validation
+// (api_key/secret_key format) and DB URL correctness are deferred to their use sites, so those errors
+// read identically whether the value came from the file or the environment.
+func Load(path string) (*Secrets, error) {
+	tomlBytes, err := os.ReadFile(path) //nolint:gosec // G304: path is operator-provided (env var / default), trusted.
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// Absent file: env-only, backwards-compatible path.
+			return &Secrets{}, nil
+		}
+		return nil, fmt.Errorf("failed to read aggregator secrets file %q: %w", path, err)
+	}
+
+	var file File
+	md, err := toml.Decode(string(tomlBytes), &file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode aggregator secrets file %q: %w", path, err)
+	}
+	if undecoded := md.Undecoded(); len(undecoded) > 0 {
+		return nil, fmt.Errorf("aggregator secrets file %q has unknown keys: %+v", path, undecoded)
+	}
+
+	clients, err := newClientSecrets(file.Clients)
+	if err != nil {
+		return nil, fmt.Errorf("invalid aggregator secrets file %q: %w", path, err)
+	}
+
+	return &Secrets{storageURL: file.Storage.URL, redisPassword: file.Redis.Password, clients: clients}, nil
+}
+
+// StorageURL returns the application storage DB URL: the secrets file value when present, otherwise
+// the AGGREGATOR_STORAGE_CONNECTION_URL environment variable (backwards-compatible). The file wins. An
+// empty result means no storage URL is configured.
+func (s *Secrets) StorageURL() string {
+	if s != nil && s.storageURL != "" {
+		return s.storageURL
+	}
+	return os.Getenv(StorageURLEnvVar)
+}
+
+// RedisPassword returns the rate limiter's redis password: the secrets file value when present,
+// otherwise the AGGREGATOR_REDIS_PASSWORD environment variable. The file wins. An empty result means
+// no password (redis auth disabled), preserving the existing behavior.
+func (s *Secrets) RedisPassword() string {
+	if s != nil && s.redisPassword != "" {
+		return s.redisPassword
+	}
+	return os.Getenv(RedisPasswordEnvVar)
+}
+
+// ClientSecrets returns the per-client credentials from the file, or nil when the file supplied none
+// (in which case every client's credentials resolve from env vars).
+func (s *Secrets) ClientSecrets() ClientSecrets {
+	if s == nil {
+		return nil
+	}
+	return s.clients
+}

--- a/aggregator/pkg/secrets/secrets.go
+++ b/aggregator/pkg/secrets/secrets.go
@@ -1,12 +1,10 @@
 // Package secrets defines the aggregator secrets file: an optional, operator-provided TOML file
 // carrying the aggregator's own credentials — the application storage DB URL, the redis password used
-// by rate limiting, and the per-client inbound HMAC api_key/secret_key pairs. It is a leaf package
-// (depending only on the TOML decoder) so the aggregator app and the devenv harness can share one
-// schema definition without pulling in heavier dependencies.
+// by rate limiting, and the per-client inbound HMAC api_key/secret_key pairs.
 //
 // Secrets resolve backwards-compatibly: an absent file is never an error and falls back entirely to
 // environment variables, and when a value is present in both the file and an env var the file wins.
-// For client credentials this is resolved per client (replace-per-client): if the file supplies any
+// For client credentials this is resolved per client: if the file supplies any
 // pairs for a client_id, that set is authoritative and the env-derived pairs for that client are
 // ignored.
 package secrets
@@ -40,9 +38,7 @@ const (
 )
 
 // File is the on-disk schema of the aggregator secrets file. It carries only credential-bearing
-// values: the application storage DB URL, the rate limiter's redis password, and the per-client
-// inbound HMAC pairs. Non-secret knobs (redis address/db) stay as environment variables and are
-// intentionally absent here.
+// values.
 type File struct {
 	Storage StorageSecrets `toml:"storage"`
 	Redis   RedisSecrets   `toml:"redis"`
@@ -50,21 +46,20 @@ type File struct {
 }
 
 // StorageSecrets holds the aggregator's application storage DB URL (formerly
-// AGGREGATOR_STORAGE_CONNECTION_URL). Named [storage] to match the aggregator's own config section.
+// AGGREGATOR_STORAGE_CONNECTION_URL).
 type StorageSecrets struct {
 	URL string `toml:"url"`
 }
 
 // RedisSecrets holds the redis password used by the rate limiter (formerly AGGREGATOR_REDIS_PASSWORD).
-// The non-secret redis knobs (address, db) are deliberately not here.
+// The non-secret redis configuration (address, db) are deliberately not here.
 type RedisSecrets struct {
 	Password string `toml:"password"`
 }
 
 // ClientSecret is one client's inbound HMAC credential as declared in the [[clients]] array of tables.
 // A client_id may appear more than once to declare multiple pairs (e.g. during key rotation); the
-// aggregator accepts any of a client's pairs. Unlike the verifier's [[aggregators]], there is no join
-// key: the pair is a pure credential and client_id is the only association it needs.
+// aggregator accepts any of a client's pairs.
 type ClientSecret struct {
 	ClientID  string `toml:"client_id"`
 	APIKey    string `toml:"api_key"`
@@ -82,8 +77,7 @@ type ClientCredential struct {
 type ClientSecrets map[string][]ClientCredential
 
 // Secrets is the parsed, validated aggregator secrets, ready to hand to the read sites. An absent file
-// yields a zero value whose accessors all fall back to environment variables (the backwards-compatible
-// path).
+// yields a zero value whose accessors all fall back to environment variables.
 type Secrets struct {
 	// storageURL is the DB URL from the file; empty when the file omits it (env is then used).
 	storageURL string
@@ -96,8 +90,8 @@ type Secrets struct {
 // newClientSecrets groups the given entries by client_id, enforcing that a present file is
 // well-formed: every entry must carry a non-empty client_id, api_key, and secret_key, and no api_key
 // may appear twice (an api_key is the auth lookup key, so a collision is genuinely ambiguous). A
-// repeated client_id is allowed — that is rotation. Returns a nil map (not an error) when entries is
-// empty. Error messages reference entry ordinals and client_id, never the credential value.
+// repeated client_id is allowed. Returns a nil map (not an error) when entries is
+// empty.
 func newClientSecrets(entries []ClientSecret) (ClientSecrets, error) {
 	if len(entries) == 0 {
 		return nil, nil
@@ -151,7 +145,7 @@ func LoadFromEnv(envVar, defaultPath string) (*Secrets, error) {
 // Load reads and validates the aggregator secrets file at path.
 //
 // An absent file is never an error: it returns an empty *Secrets so callers uniformly fall back to
-// environment variables (the backwards-compatible default). A present file is decoded strictly —
+// environment variables. A present file is decoded strictly —
 // malformed TOML, unknown/misspelled keys, a half-filled [[clients]] entry, or a duplicate api_key are
 // hard errors, so a real secrets file is never silently half-ignored. Credential-value validation
 // (api_key/secret_key format) and DB URL correctness are deferred to their use sites, so those errors
@@ -184,7 +178,7 @@ func Load(path string) (*Secrets, error) {
 }
 
 // StorageURL returns the application storage DB URL: the secrets file value when present, otherwise
-// the AGGREGATOR_STORAGE_CONNECTION_URL environment variable (backwards-compatible). The file wins. An
+// the AGGREGATOR_STORAGE_CONNECTION_URL environment variable. The file wins. An
 // empty result means no storage URL is configured.
 func (s *Secrets) StorageURL() string {
 	if s != nil && s.storageURL != "" {

--- a/aggregator/pkg/secrets/secrets.go
+++ b/aggregator/pkg/secrets/secrets.go
@@ -124,6 +124,17 @@ func newClientSecrets(entries []ClientSecret) (ClientSecrets, error) {
 	return result, nil
 }
 
+// decodeError turns a TOML decode failure into an error safe to log. BurntSushi's ParseError.Error()
+// (and its Message/input fields) can echo a snippet of the offending source line, which for a sensitive file
+// may be a credential value.
+func decodeError(path string, err error) error {
+	if pe, ok := errors.AsType[toml.ParseError](err); ok {
+		return fmt.Errorf("failed to decode aggregator secrets file %q: TOML parse error at line %d, column %d (last key %q)",
+			path, pe.Position.Line, pe.Position.Col, pe.LastKey)
+	}
+	return fmt.Errorf("failed to decode aggregator secrets file %q: malformed or invalid TOML (details omitted to avoid logging secret values)", path)
+}
+
 // ResolveSecretsPath returns the secrets file path from envVar, or defaultPath when unset.
 func ResolveSecretsPath(envVar, defaultPath string) string {
 	if p := os.Getenv(envVar); p != "" {
@@ -158,7 +169,7 @@ func Load(path string) (*Secrets, error) {
 	var file File
 	md, err := toml.Decode(string(tomlBytes), &file)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode aggregator secrets file %q: %w", path, err)
+		return nil, decodeError(path, err)
 	}
 	if undecoded := md.Undecoded(); len(undecoded) > 0 {
 		return nil, fmt.Errorf("aggregator secrets file %q has unknown keys: %+v", path, undecoded)

--- a/aggregator/pkg/secrets/secrets_test.go
+++ b/aggregator/pkg/secrets/secrets_test.go
@@ -143,6 +143,23 @@ func TestLoad_RejectsMalformedTOML(t *testing.T) {
 	require.Contains(t, err.Error(), "decode")
 }
 
+func TestLoad_MalformedTOMLDoesNotLeakValue(t *testing.T) {
+	// An unterminated string on the api_key line would normally make the TOML decoder echo the source
+	// line (and thus the secret) in its error. The decode error must surface only the position, never
+	// the value.
+	path := writeSecretsFile(t, `
+[[clients]]
+client_id = "verifier-1"
+api_key = "SUPERSECRETVALUE
+secret_key = "s"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "SUPERSECRETVALUE")
+	require.Contains(t, err.Error(), "line")
+}
+
 func TestLoad_RejectsDuplicateAPIKeyWithoutLeakingValue(t *testing.T) {
 	path := writeSecretsFile(t, `
 [[clients]]

--- a/aggregator/pkg/secrets/secrets_test.go
+++ b/aggregator/pkg/secrets/secrets_test.go
@@ -1,0 +1,212 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeSecretsFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "secrets.toml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestLoad_AbsentFileIsEnvOnly(t *testing.T) {
+	// An absent file is not an error; every value falls back to its env var and clients are nil.
+	t.Setenv(StorageURLEnvVar, "postgres://env-host/agg")
+	t.Setenv(RedisPasswordEnvVar, "env-redis-pw")
+
+	s, err := Load(filepath.Join(t.TempDir(), "does-not-exist.toml"))
+	require.NoError(t, err)
+	require.Equal(t, "postgres://env-host/agg", s.StorageURL())
+	require.Equal(t, "env-redis-pw", s.RedisPassword())
+	require.Nil(t, s.ClientSecrets())
+}
+
+func TestLoad_PresentFile(t *testing.T) {
+	// With no env set, the file supplies the storage URL, redis password, and client credentials.
+	t.Setenv(StorageURLEnvVar, "")
+	t.Setenv(RedisPasswordEnvVar, "")
+
+	path := writeSecretsFile(t, `
+[storage]
+url = "postgres://file-host/agg"
+
+[redis]
+password = "file-redis-pw"
+
+[[clients]]
+client_id  = "verifier-1"
+api_key    = "key-a"
+secret_key = "secret-a"
+
+[[clients]]
+client_id  = "verifier-2"
+api_key    = "key-b"
+secret_key = "secret-b"
+`)
+
+	s, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://file-host/agg", s.StorageURL())
+	require.Equal(t, "file-redis-pw", s.RedisPassword())
+
+	clients := s.ClientSecrets()
+	require.Len(t, clients, 2)
+	require.Equal(t, []ClientCredential{{APIKey: "key-a", SecretKey: "secret-a"}}, clients["verifier-1"])
+	require.Equal(t, []ClientCredential{{APIKey: "key-b", SecretKey: "secret-b"}}, clients["verifier-2"])
+}
+
+func TestLoad_FileWinsOverEnv(t *testing.T) {
+	// When both env and file supply a value, the file wins.
+	t.Setenv(StorageURLEnvVar, "postgres://env-host/agg")
+	t.Setenv(RedisPasswordEnvVar, "env-redis-pw")
+
+	path := writeSecretsFile(t, `
+[storage]
+url = "postgres://file-host/agg"
+
+[redis]
+password = "file-redis-pw"
+`)
+
+	s, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://file-host/agg", s.StorageURL())
+	require.Equal(t, "file-redis-pw", s.RedisPassword())
+}
+
+func TestLoad_ValuesFallBackToEnvWhenFileOmitsThem(t *testing.T) {
+	// A file with clients but no [storage]/[redis] leaves those to the env vars.
+	t.Setenv(StorageURLEnvVar, "postgres://env-host/agg")
+	t.Setenv(RedisPasswordEnvVar, "env-redis-pw")
+
+	path := writeSecretsFile(t, `
+[[clients]]
+client_id  = "verifier-1"
+api_key    = "key-a"
+secret_key = "secret-a"
+`)
+
+	s, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://env-host/agg", s.StorageURL())
+	require.Equal(t, "env-redis-pw", s.RedisPassword())
+	require.Len(t, s.ClientSecrets(), 1)
+}
+
+func TestLoad_RotationRepeatsClientID(t *testing.T) {
+	// A repeated client_id is allowed and declares multiple accepted pairs (key rotation).
+	path := writeSecretsFile(t, `
+[[clients]]
+client_id  = "verifier-1"
+api_key    = "key-primary"
+secret_key = "secret-primary"
+
+[[clients]]
+client_id  = "verifier-1"
+api_key    = "key-rotating"
+secret_key = "secret-rotating"
+`)
+
+	s, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, []ClientCredential{
+		{APIKey: "key-primary", SecretKey: "secret-primary"},
+		{APIKey: "key-rotating", SecretKey: "secret-rotating"},
+	}, s.ClientSecrets()["verifier-1"])
+}
+
+func TestLoad_StrictRejectsUnknownKey(t *testing.T) {
+	// A misspelled key (api_ky) must fail loudly rather than silently leave the credential empty.
+	path := writeSecretsFile(t, `
+[[clients]]
+client_id  = "verifier-1"
+api_ky     = "typo"
+secret_key = "secret-a"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown keys")
+}
+
+func TestLoad_RejectsMalformedTOML(t *testing.T) {
+	path := writeSecretsFile(t, `[storage] this is not valid toml`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode")
+}
+
+func TestLoad_RejectsDuplicateAPIKeyWithoutLeakingValue(t *testing.T) {
+	path := writeSecretsFile(t, `
+[[clients]]
+client_id  = "verifier-1"
+api_key    = "shared-key"
+secret_key = "secret-a"
+
+[[clients]]
+client_id  = "verifier-2"
+api_key    = "shared-key"
+secret_key = "secret-b"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate api_key")
+	// The error references ordinals and client_id, never the credential value itself.
+	require.NotContains(t, err.Error(), "shared-key")
+}
+
+func TestLoad_RejectsMissingFields(t *testing.T) {
+	tests := map[string]string{
+		"missing client_id": `
+[[clients]]
+api_key    = "key-a"
+secret_key = "secret-a"
+`,
+		"missing api_key": `
+[[clients]]
+client_id  = "verifier-1"
+secret_key = "secret-a"
+`,
+		"missing secret_key": `
+[[clients]]
+client_id  = "verifier-1"
+api_key    = "key-a"
+`,
+	}
+	for name, contents := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := Load(writeSecretsFile(t, contents))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "is required")
+		})
+	}
+}
+
+func TestResolveSecretsPath(t *testing.T) {
+	t.Run("env set", func(t *testing.T) {
+		t.Setenv(SecretsPathEnvVar, "/custom/secrets.toml")
+		require.Equal(t, "/custom/secrets.toml", ResolveSecretsPath(SecretsPathEnvVar, DefaultSecretsPath))
+	})
+	t.Run("env unset uses default", func(t *testing.T) {
+		t.Setenv(SecretsPathEnvVar, "")
+		require.Equal(t, DefaultSecretsPath, ResolveSecretsPath(SecretsPathEnvVar, DefaultSecretsPath))
+	})
+}
+
+func TestAccessors_NilReceiver(t *testing.T) {
+	// A nil *Secrets is the env-only path (defensive; callers normally pass a non-nil value).
+	t.Setenv(StorageURLEnvVar, "postgres://env-host/agg")
+	t.Setenv(RedisPasswordEnvVar, "env-redis-pw")
+	var s *Secrets
+	require.Equal(t, "postgres://env-host/agg", s.StorageURL())
+	require.Equal(t, "env-redis-pw", s.RedisPassword())
+	require.Nil(t, s.ClientSecrets())
+}

--- a/bootstrap/job_test.go
+++ b/bootstrap/job_test.go
@@ -51,7 +51,7 @@ type testAppConfig struct {
 	Value int    `toml:"value"`
 }
 
-//nolint:staticcheck // exercises deprecated GetGenericConfig before it's fully removed
+// Exercises deprecated GetGenericConfig before it's fully removed.
 func TestJobSpec_GetGenericConfig(t *testing.T) {
 	t.Run("decodes known GenericConfig fields", func(t *testing.T) {
 		js := JobSpec{

--- a/build/devenv/services/aggregator.go
+++ b/build/devenv/services/aggregator.go
@@ -236,7 +236,7 @@ func validateAggregatorInput(in *AggregatorInput) error {
 type GenerateConfigResult struct {
 	MainConfig      []byte
 	GeneratedConfig []byte
-	// SecretsConfig is the aggregator secrets file (ADR-0010): the storage URL, redis password, and
+	// SecretsConfig is the aggregator secrets file: the storage URL, redis password, and
 	// per-client HMAC pairs. devenv dogfoods the file rather than the legacy env vars.
 	SecretsConfig []byte
 }
@@ -275,7 +275,7 @@ func (a *AggregatorInput) GenerateConfigs(generatedConfigFileName string) (*Gene
 	}
 
 	// Build the client list for the config (client_id/enabled/groups only) and, in parallel, the
-	// per-client HMAC credentials for the secrets file. devenv dogfoods the secrets file (ADR-0010),
+	// per-client HMAC credentials for the secrets file. devenv dogfoods the secrets file,
 	// so the credentials live in secrets.toml rather than in config-declared env vars.
 	secretsFile := secrets.File{}
 	if a.Env != nil {
@@ -475,7 +475,7 @@ func NewAggregator(in *AggregatorInput) (*AggregatorOutput, error) {
 
 	if in.Env != nil {
 		// Use explicit configuration from env.toml. The storage URL, redis password, and per-client
-		// HMAC pairs are now delivered via the mounted secrets file (ADR-0010), so they are no longer
+		// HMAC pairs are now delivered via the mounted secrets file, so they are no longer
 		// set as env vars here — devenv dogfoods the file path. The non-secret redis knobs (address,
 		// db) remain env vars until a follow-up relocates them into the main config TOML.
 		if in.Env.StorageConnectionURL == "" {

--- a/build/devenv/services/aggregator.go
+++ b/build/devenv/services/aggregator.go
@@ -18,6 +18,7 @@ import (
 	aggregator "github.com/smartcontractkit/chainlink-ccv/aggregator/pkg"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/configuration"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/model"
+	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/secrets"
 	"github.com/smartcontractkit/chainlink-ccv/build/devenv/util"
 	hmacutil "github.com/smartcontractkit/chainlink-ccv/protocol/common/hmac"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
@@ -235,6 +236,9 @@ func validateAggregatorInput(in *AggregatorInput) error {
 type GenerateConfigResult struct {
 	MainConfig      []byte
 	GeneratedConfig []byte
+	// SecretsConfig is the aggregator secrets file (ADR-0010): the storage URL, redis password, and
+	// per-client HMAC pairs. devenv dogfoods the file rather than the legacy env vars.
+	SecretsConfig []byte
 }
 
 // GenerateConfigs generates the aggregator service configuration using the inputs.
@@ -270,17 +274,25 @@ func (a *AggregatorInput) GenerateConfigs(generatedConfigFileName string) (*Gene
 		config.Aggregation.BackgroundWorkerCount = a.BackgroundWorkerCount
 	}
 
+	// Build the client list for the config (client_id/enabled/groups only) and, in parallel, the
+	// per-client HMAC credentials for the secrets file. devenv dogfoods the secrets file (ADR-0010),
+	// so the credentials live in secrets.toml rather than in config-declared env vars.
+	secretsFile := secrets.File{}
+	if a.Env != nil {
+		secretsFile.Storage = secrets.StorageSecrets{URL: a.Env.StorageConnectionURL}
+		secretsFile.Redis = secrets.RedisSecrets{Password: a.Env.RedisPassword}
+	}
 	for _, client := range a.APIClients {
 		config.APIClients = append(config.APIClients, &model.ClientConfig{
-			ClientID:    client.ClientID,
-			Enabled:     client.Enabled,
-			Groups:      client.Groups,
-			APIKeyPairs: make([]*model.APIKeyPairEnv, 0, len(client.APIKeyPairs)),
+			ClientID: client.ClientID,
+			Enabled:  client.Enabled,
+			Groups:   client.Groups,
 		})
-		for i := range client.APIKeyPairs {
-			config.APIClients[len(config.APIClients)-1].APIKeyPairs = append(config.APIClients[len(config.APIClients)-1].APIKeyPairs, &model.APIKeyPairEnv{
-				APIKeyEnvVar: fmt.Sprintf("AGGREGATOR_API_KEY_%s_%d", client.ClientID, i),
-				SecretEnvVar: fmt.Sprintf("AGGREGATOR_SECRET_%s_%d", client.ClientID, i),
+		for _, pair := range client.APIKeyPairs {
+			secretsFile.Clients = append(secretsFile.Clients, secrets.ClientSecret{
+				ClientID:  client.ClientID,
+				APIKey:    pair.APIKey,
+				SecretKey: pair.Secret,
 			})
 		}
 	}
@@ -300,9 +312,15 @@ func (a *AggregatorInput) GenerateConfigs(generatedConfigFileName string) (*Gene
 		return nil, fmt.Errorf("failed to marshal generated config to TOML: %w", err)
 	}
 
+	secretsBytes, err := toml.Marshal(secretsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal aggregator secrets to TOML: %w", err)
+	}
+
 	return &GenerateConfigResult{
 		MainConfig:      mainCfg,
 		GeneratedConfig: genCfgBytes,
+		SecretsConfig:   secretsBytes,
 	}, nil
 }
 
@@ -353,6 +371,12 @@ func NewAggregator(in *AggregatorInput) (*AggregatorOutput, error) {
 	generatedConfigFilePath := filepath.Join(confDir, generatedConfigFileName)
 	if err := os.WriteFile(generatedConfigFilePath, configResult.GeneratedConfig, 0o644); err != nil {
 		return nil, fmt.Errorf("failed to write aggregator generated config to file: %w", err)
+	}
+
+	secretsFilePath := filepath.Join(confDir,
+		fmt.Sprintf("aggregator-%s-secrets.toml", instanceName))
+	if err := os.WriteFile(secretsFilePath, configResult.SecretsConfig, 0o644); err != nil {
+		return nil, fmt.Errorf("failed to write aggregator secrets to file: %w", err)
 	}
 
 	aggregatorContainerName := fmt.Sprintf("%s-%s", instanceName, AggregatorContainerNameSuffix)
@@ -450,25 +474,18 @@ func NewAggregator(in *AggregatorInput) (*AggregatorOutput, error) {
 	envVars := make(map[string]string)
 
 	if in.Env != nil {
-		// Use explicit configuration from env.toml
+		// Use explicit configuration from env.toml. The storage URL, redis password, and per-client
+		// HMAC pairs are now delivered via the mounted secrets file (ADR-0010), so they are no longer
+		// set as env vars here — devenv dogfoods the file path. The non-secret redis knobs (address,
+		// db) remain env vars until a follow-up relocates them into the main config TOML.
 		if in.Env.StorageConnectionURL == "" {
-			return nil, fmt.Errorf("AGGREGATOR_STORAGE_CONNECTION_URL is required in env config")
-		}
-		envVars["AGGREGATOR_STORAGE_CONNECTION_URL"] = in.Env.StorageConnectionURL
-
-		for _, client := range in.APIClients {
-			for i, apiKeyPair := range client.APIKeyPairs {
-				envVars[fmt.Sprintf("AGGREGATOR_API_KEY_%s_%d", client.ClientID, i)] = apiKeyPair.APIKey
-				envVars[fmt.Sprintf("AGGREGATOR_SECRET_%s_%d", client.ClientID, i)] = apiKeyPair.Secret
-			}
+			return nil, fmt.Errorf("aggregator storage connection URL is required in env config")
 		}
 
 		if in.Env.RedisAddress == "" {
 			return nil, fmt.Errorf("AGGREGATOR_REDIS_ADDRESS is required in env config")
 		}
 		envVars["AGGREGATOR_REDIS_ADDRESS"] = in.Env.RedisAddress
-
-		envVars["AGGREGATOR_REDIS_PASSWORD"] = in.Env.RedisPassword
 		envVars["AGGREGATOR_REDIS_DB"] = in.Env.RedisDB
 	}
 
@@ -510,6 +527,11 @@ func NewAggregator(in *AggregatorInput) (*AggregatorOutput, error) {
 		{
 			HostFilePath:      generatedConfigFilePath,
 			ContainerFilePath: filepath.Join(filepath.Dir(aggregator.DefaultConfigFile), generatedConfigFileName),
+			FileMode:          0o644,
+		},
+		{
+			HostFilePath:      secretsFilePath,
+			ContainerFilePath: secrets.DefaultSecretsPath,
 			FileMode:          0o644,
 		},
 	}

--- a/cmd/executor/service_test.go
+++ b/cmd/executor/service_test.go
@@ -38,7 +38,8 @@ func init() {
 	// Register a test EVM factory so that NewRegistry picks it up.
 	// Default nil evmFactory keeps existing tests working (GetAccessor returns error);
 	// tests that need a working accessor assign evmFactory before calling Start.
-	chainaccess.Register("evm", func(_ logger.Logger, _ chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) { //nolint:staticcheck
+	// Register uses GenericConfig because the registry still decodes it.
+	chainaccess.Register("evm", func(_ logger.Logger, _ chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) {
 		return &evmFactoryProxy{}, nil
 	})
 }

--- a/integration/pkg/accessors/evm/factory_constructor.go
+++ b/integration/pkg/accessors/evm/factory_constructor.go
@@ -34,7 +34,8 @@ var _ chainaccess.AccessorFactoryConstructor = CreateEVMAccessorFactory
 //
 // It will take all config values it needs from all available config. Note that it would be
 // very unusual for a config to have more than one of Committee/Token/Executor configs.
-func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) { //nolint:staticcheck // registry still decodes GenericConfig util local config supported
+// Registry still decodes GenericConfig until local config is supported.
+func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.GenericConfig) (chainaccess.AccessorFactory, error) {
 	// Convert generic chain config -> Infos[evm.Info]
 	evmInfos := make(chainaccess.Infos[Info])
 	// TODO: To support standalone mode, need to support local config, GenericConfig will be deprecated as JD job will not have rpc info.
@@ -48,8 +49,7 @@ func CreateEVMAccessorFactory(lggr logger.Logger, genericConfig chainaccess.Gene
 
 // CreateAccessorFactory creates a factory that can build EVM chain accessors.
 // TODO: Defer geth client and head tracker creation until GetAccessor is called.
-//
-//nolint:staticcheck // generic param is chainaccess.GenericConfig until CCIP-11840.
+// generic param is chainaccess.GenericConfig until CCIP-11840.
 func CreateAccessorFactory(
 	ctx context.Context,
 	lggr logger.Logger,


### PR DESCRIPTION
## Description

Moves the aggregator's credentials out of the process environment and into an optional, operator-owned secrets file (a mounted k8s Secret with its own lifecycle/RBAC), backwards-compatibly.

What moves into `secrets.toml`:
- `[storage].url` — the app storage DB URL (was `AGGREGATOR_STORAGE_CONNECTION_URL`)
- `[redis].password` — the rate limiter's redis password (was `AGGREGATOR_REDIS_PASSWORD`)
- `[[clients]]` — the per-client inbound HMAC `api_key`/`secret_key` pairs (were the `AGGREGATOR_API_KEY_*` / `AGGREGATOR_SECRET_*` env vars)

Key design choices (and where they differ from the verifier):
- **Backwards compatible**: an absent file is never an error and everything falls back to the existing env vars. When both supply a value, the file wins — enabling a staged cutover (add file, verify, strip env).
- **Replace-per-client precedence**: if the file supplies any pairs for a `client_id`, that set is authoritative and the env pairs for that client are ignored (no merge).
- **Scope**: every secret goes to the file for operator consistency, including the redis password. The non-secret redis knobs (`address`, `db`) stay on env vars for now (a follow-up should relocate them into the main config TOML, not the secrets file).

No breaking changes: the env-var path remains fully supported and is the only path exercised when no file is mounted.

## Testing

- Unit tests: `go test ./aggregator/pkg/secrets/... ./aggregator/pkg/model/...`
- Devenv E2E

<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [x] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date