### PR TITLE
chore(workflows): fix pr-checks on merge_group

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,6 +1,7 @@
 name: Pull Request Checks
 
 on:
+  merge_group:
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened, edited ]
@@ -17,6 +18,8 @@ jobs:
     name: Lint PR title (Conventional Commits)
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      # Skip the PR title linting if the event is a merge_group event - we won't have this information.
+      - if: github.event_name == 'pull_request'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

The pr-checks.yaml workflow is required but didn't have a merge_group trigger. This adds the trigger but skips the PR title validation, since that is done prior to being able to queue the PR for merging.


<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
