### PR TITLE
feat(jd-lifecycle): instrument job proposal error paths

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -441,11 +441,16 @@ func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 			return jdClient.UpdateNode(ctx, req)
 		}
 	}
+	jdMetrics, err := lifecycle.InitMetrics()
+	if err != nil {
+		return fmt.Errorf("failed to init JD lifecycle metrics: %w", err)
+	}
 	lifecycleManager, err := lifecycle.NewManager(lifecycle.Config{
 		JDClient:      jdClient,
 		JobStore:      jobstore.NewPostgresStore(db),
 		Runner:        jobRunner,
 		Logger:        logger.Named(b.lggr, "LifecycleManager"),
+		Metrics:       jdMetrics,
 		OnConnectHook: onConnectHook,
 	})
 	if err != nil {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -443,7 +443,8 @@ func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 	}
 	jdMetrics, err := lifecycle.InitMetrics()
 	if err != nil {
-		return fmt.Errorf("failed to init JD lifecycle metrics: %w", err)
+		b.lggr.Warnw("Failed to init JD lifecycle metrics; continuing without metrics", "error", err)
+		jdMetrics = nil
 	}
 	lifecycleManager, err := lifecycle.NewManager(lifecycle.Config{
 		JDClient:      jdClient,

--- a/common/jd/lifecycle/manager.go
+++ b/common/jd/lifecycle/manager.go
@@ -66,6 +66,8 @@ type Config struct {
 	Runner JobRunner
 	// Logger is the logger for the lifecycle manager.
 	Logger logger.Logger
+	// Metrics records proposal outcomes. Defaults to a no-op when nil.
+	Metrics Metrics
 	// OnConnectHook is an optional function called each time the JD connection is established.
 	// A non-nil error is logged as a warning but does not prevent job processing.
 	OnConnectHook func(ctx context.Context) error
@@ -85,6 +87,7 @@ type Manager struct {
 	jobStore      store.StoreInterface
 	runner        JobRunner
 	lggr          logger.Logger
+	metrics       Metrics
 	onConnectHook func(ctx context.Context) error
 
 	mu            sync.Mutex
@@ -112,11 +115,16 @@ func NewManager(cfg Config) (*Manager, error) {
 	if cfg.Logger == nil {
 		return nil, errors.New("logger is required")
 	}
+	metrics := cfg.Metrics
+	if metrics == nil {
+		metrics = noopMetrics{}
+	}
 	return &Manager{
 		jdClient:      cfg.JDClient,
 		jobStore:      cfg.JobStore,
 		runner:        cfg.Runner,
 		lggr:          logger.With(cfg.Logger, "component", "JobLifecycleManager"),
+		metrics:       metrics,
 		onConnectHook: cfg.OnConnectHook,
 		state:         StateWaitingForJob,
 		shutdownCh:    make(chan struct{}),
@@ -262,7 +270,7 @@ func (m *Manager) eventLoop() {
 // On StartJob failure with no prior job: the pending store record survives for restart recovery.
 // On StartJob failure during a replacement: the pending record is deleted and the old job is
 // restarted from the in-memory snapshot so the job keeps running.
-func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
+func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) (retErr error) {
 	m.lggr.Infow("Handling job proposal",
 		"proposalID", proposal.Id,
 		"version", proposal.Version,
@@ -272,25 +280,35 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 	ctx, cancel := context.WithTimeout(context.Background(), handleTimeout)
 	defer cancel()
 
+	m.mu.Lock()
+	wasRunning := m.state == StateRunning
+	currentJob := m.currentJob // snapshot for fallback; non-nil when wasRunning
+	m.mu.Unlock()
+	replacement := wasRunning
+	defer func() {
+		result := resultSuccess
+		if retErr != nil {
+			result = resultError
+		}
+		m.metrics.IncProposal(ctx, result, replacement)
+	}()
+
 	// Persist the proposal as pending BEFORE attempting StartJob. This ensures
 	// that a crash between here and MarkJobApproved leaves a recoverable record.
 	// SavePendingJob only removes the previous pending row; any approved (old) row is preserved.
 	if err := m.jobStore.SavePendingJob(ctx, proposal.Id, proposal.Version, proposal.Spec); err != nil {
 		// The job will need to be re-proposed after fixing the error (whatever it may be).
 		m.lggr.Warnw("Failed to persist pending proposal", "error", err)
+		m.metrics.IncStepError(ctx, stepSavePending, replacement)
 	} else {
 		m.lggr.Infow("Proposal persisted as pending", "proposalID", proposal.Id)
 	}
-
-	m.mu.Lock()
-	wasRunning := m.state == StateRunning
-	currentJob := m.currentJob // snapshot for fallback; non-nil when wasRunning
-	m.mu.Unlock()
 
 	// If we have a running job, stop it first
 	if wasRunning {
 		m.lggr.Infow("Stopping current job for replacement")
 		if err := m.runner.StopJob(ctx); err != nil {
+			m.metrics.IncStepError(ctx, stepStopJob, replacement)
 			return fmt.Errorf("failed to stop current job: %w", err)
 		}
 	}
@@ -298,9 +316,11 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 	// Start the new job
 	if err := m.runner.StartJob(ctx, proposal.Spec); err != nil {
 		if wasRunning {
+			m.metrics.IncStepError(ctx, stepStartReplacement, replacement)
 			return m.rollbackReplacement(ctx, proposal.Id, err, currentJob)
 		}
 		// No old job to fall back to: leave pending record for restart recovery.
+		m.metrics.IncStepError(ctx, stepStartJob, replacement)
 		m.mu.Lock()
 		m.state = StateWaitingForJob
 		m.currentJob = nil
@@ -319,10 +339,12 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 	// StartJob succeeded - promote the pending record to approved.
 	if promoted, err := m.jobStore.AcceptPendingJob(ctx); err != nil {
 		m.lggr.Warnw("Failed to accept pending job in store", "error", err)
+		m.metrics.IncStepError(ctx, stepAcceptPending, replacement)
 		// Continue anyway - the job is running. The store record stays 'pending', so the
 		// next restart will retry via the pending recovery path.
 	} else if !promoted {
 		m.lggr.Warnw("AcceptPendingJob reported no pending row — store may be inconsistent")
+		m.metrics.IncStepError(ctx, stepAcceptPending, replacement)
 	}
 
 	// Update in-memory state
@@ -340,6 +362,7 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 	// Approve the job with JD
 	if err := m.jdClient.ApproveJob(ctx, proposal.Id, proposal.Version); err != nil {
 		m.lggr.Warnw("Failed to approve job with JD", "error", err)
+		m.metrics.IncStepError(ctx, stepApproveJob, replacement)
 		// Continue anyway - job is running.
 	}
 
@@ -356,6 +379,7 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) error {
 func (m *Manager) rollbackReplacement(ctx context.Context, newProposalID string, startErr error, oldJob *store.Job) error {
 	if delErr := m.jobStore.DeletePendingJob(ctx); delErr != nil {
 		m.lggr.Warnw("Failed to remove pending record during rollback", "error", delErr)
+		m.metrics.IncStepError(ctx, stepRollbackDeletePending, true)
 	}
 	m.lggr.Infow("Restarting previous job after replacement failure",
 		"newProposalID", newProposalID,
@@ -363,6 +387,7 @@ func (m *Manager) rollbackReplacement(ctx context.Context, newProposalID string,
 	)
 	if restartErr := m.runner.StartJob(ctx, oldJob.Spec); restartErr != nil {
 		m.lggr.Errorw("Failed to restart previous job after replacement failure", "error", restartErr)
+		m.metrics.IncStepError(ctx, stepRollbackRestart, true)
 		m.mu.Lock()
 		m.state = StateWaitingForJob
 		m.currentJob = nil
@@ -374,7 +399,7 @@ func (m *Manager) rollbackReplacement(ctx context.Context, newProposalID string,
 // retryPendingJob attempts to start the pending job after JD has reconnected.
 // On success it marks the store record approved, updates in-memory state, and calls ApproveJob.
 // On failure the pending record in the store is preserved for the next restart.
-func (m *Manager) retryPendingJob(job *store.Job) error {
+func (m *Manager) retryPendingJob(job *store.Job) (retErr error) {
 	m.lggr.Infow("Retrying pending job after JD connect",
 		"proposalID", job.ProposalID,
 		"version", job.Version,
@@ -382,15 +407,25 @@ func (m *Manager) retryPendingJob(job *store.Job) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), handleTimeout)
 	defer cancel()
+	defer func() {
+		result := resultSuccess
+		if retErr != nil {
+			result = resultError
+		}
+		m.metrics.IncProposal(ctx, result, false)
+	}()
 
 	if err := m.runner.StartJob(ctx, job.Spec); err != nil {
+		m.metrics.IncStepError(ctx, stepStartJob, false)
 		return fmt.Errorf("failed to start pending job: %w", err)
 	}
 
 	if promoted, err := m.jobStore.AcceptPendingJob(ctx); err != nil {
 		m.lggr.Warnw("Failed to accept pending job in store", "error", err)
+		m.metrics.IncStepError(ctx, stepAcceptPending, false)
 	} else if !promoted {
 		m.lggr.Warnw("AcceptPendingJob reported no pending row — store may be inconsistent")
+		m.metrics.IncStepError(ctx, stepAcceptPending, false)
 	}
 
 	m.mu.Lock()
@@ -406,6 +441,7 @@ func (m *Manager) retryPendingJob(job *store.Job) error {
 
 	if err := m.jdClient.ApproveJob(ctx, job.ProposalID, job.Version); err != nil {
 		m.lggr.Warnw("Failed to approve pending job with JD", "error", err)
+		m.metrics.IncStepError(ctx, stepApproveJob, false)
 	}
 
 	m.lggr.Infow("Pending job started successfully",

--- a/common/jd/lifecycle/manager.go
+++ b/common/jd/lifecycle/manager.go
@@ -281,16 +281,17 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) (retErr error) 
 	defer cancel()
 
 	m.mu.Lock()
+	// wasRunning indicates whether a job was already running when this proposal
+	// arrived. This flag is also used as the "replacement" metric label.
 	wasRunning := m.state == StateRunning
 	currentJob := m.currentJob // snapshot for fallback; non-nil when wasRunning
 	m.mu.Unlock()
-	replacement := wasRunning
 	defer func() {
 		result := resultSuccess
 		if retErr != nil {
 			result = resultError
 		}
-		m.metrics.IncProposal(ctx, result, replacement)
+		m.metrics.IncProposal(ctx, result, wasRunning)
 	}()
 
 	// Persist the proposal as pending BEFORE attempting StartJob. This ensures
@@ -299,7 +300,7 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) (retErr error) 
 	if err := m.jobStore.SavePendingJob(ctx, proposal.Id, proposal.Version, proposal.Spec); err != nil {
 		// The job will need to be re-proposed after fixing the error (whatever it may be).
 		m.lggr.Warnw("Failed to persist pending proposal", "error", err)
-		m.metrics.IncStepError(ctx, stepSavePending, replacement)
+		m.metrics.IncStepError(ctx, stepSavePending, wasRunning)
 	} else {
 		m.lggr.Infow("Proposal persisted as pending", "proposalID", proposal.Id)
 	}
@@ -308,7 +309,7 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) (retErr error) 
 	if wasRunning {
 		m.lggr.Infow("Stopping current job for replacement")
 		if err := m.runner.StopJob(ctx); err != nil {
-			m.metrics.IncStepError(ctx, stepStopJob, replacement)
+			m.metrics.IncStepError(ctx, stepStopJob, wasRunning)
 			return fmt.Errorf("failed to stop current job: %w", err)
 		}
 	}
@@ -316,11 +317,11 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) (retErr error) 
 	// Start the new job
 	if err := m.runner.StartJob(ctx, proposal.Spec); err != nil {
 		if wasRunning {
-			m.metrics.IncStepError(ctx, stepStartReplacement, replacement)
+			m.metrics.IncStepError(ctx, stepStartReplacement, wasRunning)
 			return m.rollbackReplacement(ctx, proposal.Id, err, currentJob)
 		}
 		// No old job to fall back to: leave pending record for restart recovery.
-		m.metrics.IncStepError(ctx, stepStartJob, replacement)
+		m.metrics.IncStepError(ctx, stepStartJob, wasRunning)
 		m.mu.Lock()
 		m.state = StateWaitingForJob
 		m.currentJob = nil
@@ -339,12 +340,12 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) (retErr error) 
 	// StartJob succeeded - promote the pending record to approved.
 	if promoted, err := m.jobStore.AcceptPendingJob(ctx); err != nil {
 		m.lggr.Warnw("Failed to accept pending job in store", "error", err)
-		m.metrics.IncStepError(ctx, stepAcceptPending, replacement)
+		m.metrics.IncStepError(ctx, stepAcceptPending, wasRunning)
 		// Continue anyway - the job is running. The store record stays 'pending', so the
 		// next restart will retry via the pending recovery path.
 	} else if !promoted {
 		m.lggr.Warnw("AcceptPendingJob reported no pending row — store may be inconsistent")
-		m.metrics.IncStepError(ctx, stepAcceptPending, replacement)
+		m.metrics.IncStepError(ctx, stepAcceptPending, wasRunning)
 	}
 
 	// Update in-memory state
@@ -362,7 +363,7 @@ func (m *Manager) handleProposal(proposal *pb.ProposeJobRequest) (retErr error) 
 	// Approve the job with JD
 	if err := m.jdClient.ApproveJob(ctx, proposal.Id, proposal.Version); err != nil {
 		m.lggr.Warnw("Failed to approve job with JD", "error", err)
-		m.metrics.IncStepError(ctx, stepApproveJob, replacement)
+		m.metrics.IncStepError(ctx, stepApproveJob, wasRunning)
 		// Continue anyway - job is running.
 	}
 

--- a/common/jd/lifecycle/manager_test.go
+++ b/common/jd/lifecycle/manager_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -805,4 +806,228 @@ func TestManager_Start_StartOncePreventsSecondStart(t *testing.T) {
 	assert.Contains(t, err.Error(), "already been started")
 
 	require.NoError(t, m.Stop())
+}
+
+type proposalRecord struct {
+	result      string
+	replacement bool
+}
+
+type stepRecord struct {
+	step        string
+	replacement bool
+}
+
+type recordingMetrics struct {
+	mu         sync.Mutex
+	proposals  []proposalRecord
+	stepErrors []stepRecord
+}
+
+func (r *recordingMetrics) IncProposal(_ context.Context, result string, replacement bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.proposals = append(r.proposals, proposalRecord{result, replacement})
+}
+
+func (r *recordingMetrics) IncStepError(_ context.Context, step string, replacement bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stepErrors = append(r.stepErrors, stepRecord{step, replacement})
+}
+
+func (r *recordingMetrics) proposalSnapshot() []proposalRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]proposalRecord, len(r.proposals))
+	copy(out, r.proposals)
+	return out
+}
+
+// recordedSteps returns the step label of every recorded step error, in order.
+func (r *recordingMetrics) recordedSteps() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.stepErrors))
+	for i, s := range r.stepErrors {
+		out[i] = s.step
+	}
+	return out
+}
+
+func TestManager_HandleProposal_Metrics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		setup           func(*mocks.MockStoreInterface, *mocks.MockJobRunner, *mocks.MockClientInterface, *Manager)
+		proposal        *pb.ProposeJobRequest
+		wantErr         bool
+		wantReplacement bool
+		wantSteps       []string
+	}{
+		{
+			name: "success",
+			setup: func(js *mocks.MockStoreInterface, r *mocks.MockJobRunner, jd *mocks.MockClientInterface, _ *Manager) {
+				js.EXPECT().SavePendingJob(mock.Anything, "p1", int64(1), `{"spec":"new"}`).Return(nil)
+				js.EXPECT().AcceptPendingJob(mock.Anything).Return(true, nil)
+				r.EXPECT().StartJob(mock.Anything, `{"spec":"new"}`).Return(nil)
+				jd.EXPECT().ApproveJob(mock.Anything, "p1", int64(1)).Return(nil)
+			},
+			proposal:  &pb.ProposeJobRequest{Id: "p1", Version: 1, Spec: `{"spec":"new"}`},
+			wantSteps: nil,
+		},
+		{
+			name: "start_job",
+			setup: func(js *mocks.MockStoreInterface, r *mocks.MockJobRunner, _ *mocks.MockClientInterface, _ *Manager) {
+				js.EXPECT().SavePendingJob(mock.Anything, "p1", int64(1), `{"spec":"bad"}`).Return(nil)
+				r.EXPECT().StartJob(mock.Anything, `{"spec":"bad"}`).Return(errors.New("start failed"))
+			},
+			proposal:  &pb.ProposeJobRequest{Id: "p1", Version: 1, Spec: `{"spec":"bad"}`},
+			wantErr:   true,
+			wantSteps: []string{stepStartJob},
+		},
+		{
+			name: "start_replacement with failed rollback restart",
+			setup: func(js *mocks.MockStoreInterface, r *mocks.MockJobRunner, _ *mocks.MockClientInterface, m *Manager) {
+				js.EXPECT().SavePendingJob(mock.Anything, "new", int64(2), `{"spec":"new"}`).Return(nil)
+				js.EXPECT().DeletePendingJob(mock.Anything).Return(nil)
+				r.EXPECT().StopJob(mock.Anything).Return(nil)
+				r.EXPECT().StartJob(mock.Anything, `{"spec":"new"}`).Return(errors.New("start failed"))
+				r.EXPECT().StartJob(mock.Anything, `{"spec":"old"}`).Return(errors.New("restart failed"))
+				m.mu.Lock()
+				m.state = StateRunning
+				m.currentJob = &store.Job{ProposalID: "old", Version: 1, Spec: `{"spec":"old"}`}
+				m.mu.Unlock()
+			},
+			proposal:        &pb.ProposeJobRequest{Id: "new", Version: 2, Spec: `{"spec":"new"}`},
+			wantErr:         true,
+			wantReplacement: true,
+			// Old job also failed to restart: node left with no running job.
+			wantSteps: []string{stepStartReplacement, stepRollbackRestart},
+		},
+		{
+			name: "multiple soft failures still succeed",
+			setup: func(js *mocks.MockStoreInterface, r *mocks.MockJobRunner, jd *mocks.MockClientInterface, _ *Manager) {
+				js.EXPECT().SavePendingJob(mock.Anything, "p1", int64(1), `{"spec":"new"}`).Return(errors.New("save failed"))
+				r.EXPECT().StartJob(mock.Anything, `{"spec":"new"}`).Return(nil)
+				js.EXPECT().AcceptPendingJob(mock.Anything).Return(false, errors.New("accept failed"))
+				jd.EXPECT().ApproveJob(mock.Anything, "p1", int64(1)).Return(errors.New("approve failed"))
+			},
+			proposal: &pb.ProposeJobRequest{Id: "p1", Version: 1, Spec: `{"spec":"new"}`},
+			// Job ends up running, so the outcome is success, but every soft
+			// failure is recorded as its own step error.
+			wantSteps: []string{stepSavePending, stepAcceptPending, stepApproveJob},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &recordingMetrics{}
+			jobStore := mocks.NewMockStoreInterface(t)
+			runner := mocks.NewMockJobRunner(t)
+			jdClient := mocks.NewMockClientInterface(t)
+
+			m, err := NewManager(Config{
+				JDClient: jdClient,
+				JobStore: jobStore,
+				Runner:   runner,
+				Logger:   logger.Test(t),
+				Metrics:  rec,
+			})
+			require.NoError(t, err)
+			tt.setup(jobStore, runner, jdClient, m)
+
+			err = m.handleProposal(tt.proposal)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			proposals := rec.proposalSnapshot()
+			require.Len(t, proposals, 1, "exactly one outcome recorded per proposal")
+			wantResult := resultSuccess
+			if tt.wantErr {
+				wantResult = resultError
+			}
+			assert.Equal(t, wantResult, proposals[0].result)
+			assert.Equal(t, tt.wantReplacement, proposals[0].replacement)
+
+			assert.ElementsMatch(t, tt.wantSteps, rec.recordedSteps())
+		})
+	}
+}
+
+func TestManager_RetryPendingJob_Metrics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setup     func(*mocks.MockStoreInterface, *mocks.MockJobRunner, *mocks.MockClientInterface)
+		wantErr   bool
+		wantSteps []string
+	}{
+		{
+			name: "start_job",
+			setup: func(_ *mocks.MockStoreInterface, r *mocks.MockJobRunner, _ *mocks.MockClientInterface) {
+				r.EXPECT().StartJob(mock.Anything, `{"spec":"new"}`).Return(errors.New("start failed"))
+			},
+			wantErr:   true,
+			wantSteps: []string{stepStartJob},
+		},
+		{
+			// Soft failure after StartJob succeeds: job is running, so the
+			// outcome is success even though a step error is recorded.
+			name: "approve_job soft failure",
+			setup: func(js *mocks.MockStoreInterface, r *mocks.MockJobRunner, jd *mocks.MockClientInterface) {
+				r.EXPECT().StartJob(mock.Anything, `{"spec":"new"}`).Return(nil)
+				js.EXPECT().AcceptPendingJob(mock.Anything).Return(true, nil)
+				jd.EXPECT().ApproveJob(mock.Anything, "p1", int64(1)).Return(errors.New("approve failed"))
+			},
+			wantSteps: []string{stepApproveJob},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &recordingMetrics{}
+			jobStore := mocks.NewMockStoreInterface(t)
+			runner := mocks.NewMockJobRunner(t)
+			jdClient := mocks.NewMockClientInterface(t)
+
+			m, err := NewManager(Config{
+				JDClient: jdClient,
+				JobStore: jobStore,
+				Runner:   runner,
+				Logger:   logger.Test(t),
+				Metrics:  rec,
+			})
+			require.NoError(t, err)
+			tt.setup(jobStore, runner, jdClient)
+
+			err = m.retryPendingJob(&store.Job{
+				ProposalID: "p1",
+				Version:    1,
+				Spec:       `{"spec":"new"}`,
+				Status:     store.JobStatusPending,
+			})
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			proposals := rec.proposalSnapshot()
+			require.Len(t, proposals, 1, "exactly one outcome recorded per retry")
+			wantResult := resultSuccess
+			if tt.wantErr {
+				wantResult = resultError
+			}
+			assert.Equal(t, wantResult, proposals[0].result)
+			assert.False(t, proposals[0].replacement, "retries are never replacements")
+
+			assert.ElementsMatch(t, tt.wantSteps, rec.recordedSteps())
+		})
+	}
 }

--- a/common/jd/lifecycle/metrics.go
+++ b/common/jd/lifecycle/metrics.go
@@ -1,0 +1,83 @@
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/beholder"
+)
+
+const (
+	resultSuccess = "success"
+	resultError   = "error"
+
+	// Step labels for jd_lifecycle_proposal_step_errors_total. Each names a
+	// discrete step in handleProposal/retryPendingJob that can fail. A single
+	// proposal may record several of these
+	stepSavePending           = "save_pending"
+	stepStopJob               = "stop_job"
+	stepStartJob              = "start_job"
+	stepStartReplacement      = "start_replacement"
+	stepRollbackDeletePending = "rollback_delete_pending"
+	stepRollbackRestart       = "rollback_restart"
+	stepAcceptPending         = "accept_pending"
+	stepApproveJob            = "approve_job"
+)
+
+// Metrics records JD lifecycle proposal outcomes.
+type Metrics interface {
+	// IncProposal records the terminal outcome of a proposal exactly once.
+	// result is resultSuccess when a job is running at the end of the flow and
+	// resultError when the proposal aborted without a running job.
+	IncProposal(ctx context.Context, result string, replacement bool)
+	// IncStepError records a single failed step within a proposal. It may be
+	// called multiple times per proposal (once per failing step) and is
+	// independent of the terminal outcome recorded by IncProposal.
+	IncStepError(ctx context.Context, step string, replacement bool)
+}
+
+type otelMetrics struct {
+	proposalTotal   metric.Int64Counter
+	stepErrorsTotal metric.Int64Counter
+}
+
+func InitMetrics() (Metrics, error) {
+	meter := beholder.GetMeter()
+	proposalTotal, err := meter.Int64Counter(
+		"jd_lifecycle_proposal_total",
+		metric.WithDescription("JD lifecycle job proposal outcomes"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register jd_lifecycle_proposal_total: %w", err)
+	}
+	stepErrorsTotal, err := meter.Int64Counter(
+		"jd_lifecycle_proposal_step_errors_total",
+		metric.WithDescription("JD lifecycle proposal step failures"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register jd_lifecycle_proposal_step_errors_total: %w", err)
+	}
+	return &otelMetrics{proposalTotal: proposalTotal, stepErrorsTotal: stepErrorsTotal}, nil
+}
+
+func (m *otelMetrics) IncProposal(ctx context.Context, result string, replacement bool) {
+	m.proposalTotal.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("result", result),
+		attribute.Bool("replacement", replacement),
+	))
+}
+
+func (m *otelMetrics) IncStepError(ctx context.Context, step string, replacement bool) {
+	m.stepErrorsTotal.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("step", step),
+		attribute.Bool("replacement", replacement),
+	))
+}
+
+type noopMetrics struct{}
+
+func (noopMetrics) IncProposal(context.Context, string, bool)  {}
+func (noopMetrics) IncStepError(context.Context, string, bool) {}

--- a/common/jd/lifecycle/metrics.go
+++ b/common/jd/lifecycle/metrics.go
@@ -29,9 +29,8 @@ const (
 
 // Metrics records JD lifecycle proposal outcomes.
 type Metrics interface {
-	// IncProposal records the terminal outcome of a proposal exactly once.
-	// result is resultSuccess when a job is running at the end of the flow and
-	// resultError when the proposal aborted without a running job.
+	// IncProposal records the terminal outcome of handling a proposal exactly once.
+	// result is resultSuccess when handleProposal/retryPendingJob returns nil, and resultError otherwise.
 	IncProposal(ctx context.Context, result string, replacement bool)
 	// IncStepError records a single failed step within a proposal. It may be
 	// called multiple times per proposal (once per failing step) and is

--- a/common/jd/lifecycle/metrics.go
+++ b/common/jd/lifecycle/metrics.go
@@ -16,7 +16,7 @@ const (
 
 	// Step labels for jd_lifecycle_proposal_step_errors_total. Each names a
 	// discrete step in handleProposal/retryPendingJob that can fail. A single
-	// proposal may record several of these
+	// proposal may record several of these.
 	stepSavePending           = "save_pending"
 	stepStopJob               = "stop_job"
 	stepStartJob              = "start_job"


### PR DESCRIPTION
<!-- ⚠️ PR TITLE must follow Conventional Commits (e.g. `feat(scope): ...`, `fix: ...`).
     It is enforced by CI and becomes the squash commit that drives releases & changelogs.
     Breaking change? Use `feat!:`/`fix!:` and/or a `BREAKING CHANGE:` footer.
     See CONTRIBUTING.md for the allowed types. -->

<!-- Describe what this PR does and why. Focus on the motivation and intent,
     not a restatement of the diff. Link to any relevant issues or discussions. -->

## Description

Add metrics for JD lifecycle job proposals: `jd_lifecycle_proposal_total` (terminal success/error per proposal) and `jd_lifecycle_proposal_step_errors_total` (per-step failures such as save, start, approve).

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing


<!-- Run through this list before requesting review. -->
## Checklist

- [x] PR title follows Conventional Commits (see `CONTRIBUTING.md`); breaking changes marked with `!` / `BREAKING CHANGE:`
- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
