### PR TITLE
ci: publish GA docker images on release

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -2,7 +2,7 @@ name: Publish GA Image From Release Tag
 
 # Publishes GA (non-RC) service images when release-please cuts a root release.
 # The bare root tag `vX.Y.Z` is produced by release-please under the GATI GitHub App
-# token, which triggers this workflow (see ADR-0007 D7, ADR-0012). In GitHub Actions
+# token, which triggers this workflow. In GitHub Actions
 # tag globs `*` does not match `/`, so `v[0-9]+.[0-9]+.[0-9]+` matches only the bare
 # root tag — never module tags (`deployment/vX.Y.Z`) or RC tags (`<svc>/vX.Y.Z-rc`).
 on:

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,16 +1,25 @@
-name: Publish RC Image From Tag
+name: Publish GA Image From Release Tag
 
+# Publishes GA (non-RC) service images when release-please cuts a root release.
+# The bare root tag `vX.Y.Z` is produced by release-please under the GATI GitHub App
+# token, which triggers this workflow (see ADR-0007 D7, ADR-0012). In GitHub Actions
+# tag globs `*` does not match `/`, so `v[0-9]+.[0-9]+.[0-9]+` matches only the bare
+# root tag — never module tags (`deployment/vX.Y.Z`) or RC tags (`<svc>/vX.Y.Z-rc`).
 on:
   push:
     tags:
-     - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: [verifier, aggregator, indexer, executor]
     permissions:
       id-token: write
       contents: read
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -36,20 +45,18 @@ jobs:
           aws-region: us-east-2
           registry-type: private
 
-      - name: Build & Publish Release Candidate
+      - name: Build & Publish GA Image
         env:
+          MODULE: ${{ matrix.module }}
+          VERSION: ${{ github.ref_name }}
           ECR_REGISTRY_PRIMARY: ${{ secrets.ECR_REGISTRY_PRIMARY }}
           ECR_REGISTRY_SECONDARY: ${{ secrets.ECR_REGISTRY_SECONDARY }}
         run: |
-          MODULE=$(echo "${{ github.ref_name }}" | cut -d'/' -f1)
-          FULL_TAG=$(echo "${{ github.ref_name }}" | cut -d'/' -f2)
-          VERSION=$(echo "$FULL_TAG" | cut -d'-' -f1)
           echo "Module: $MODULE"
           echo "Version: $VERSION"
-          echo "Full Tag: $FULL_TAG"
-          echo "Building Release Candidate Image.."
-          just "$MODULE"/build-rc
-          echo "Publishing Release Candidate Image (primary).."
-          just "$MODULE"/publish-rc "$ECR_REGISTRY_PRIMARY" "$VERSION"
-          echo "Publishing Release Candidate Image (secondary).."
-          just "$MODULE"/publish-rc "$ECR_REGISTRY_SECONDARY" "$VERSION"
+          echo "Building GA Image.."
+          just "$MODULE"/build
+          echo "Publishing GA Image (primary).."
+          just "$MODULE"/publish "$ECR_REGISTRY_PRIMARY" "$VERSION"
+          echo "Publishing GA Image (secondary).."
+          just "$MODULE"/publish "$ECR_REGISTRY_SECONDARY" "$VERSION"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ The importable Go modules in this repo are independently versioned and tagged by
 their tag formats: root (`vX.Y.Z`), `deployment/vX.Y.Z`, `build/devenv/vX.Y.Z`,
 `integration/evm/vX.Y.Z`. All are pre-`1.0`, so breaking changes bump the minor version.
 
-See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the PR-title format and
-[`docs/adr/0007-release-please-multi-module-versioning.md`](./docs/adr/0007-release-please-multi-module-versioning.md)
-for the rationale.
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the PR-title format.
 
 ## Local Dev Environment
 Follow the [README](./build/devenv/README.md)

--- a/aggregator/Justfile
+++ b/aggregator/Justfile
@@ -19,6 +19,10 @@ publish-rc registry version:
     docker tag aggregator:rc {{registry}}/containers/chainlink-ccv-aggregator:{{version}}-rc
     docker push {{registry}}/containers/chainlink-ccv-aggregator:{{version}}-rc
 
+publish registry version:
+    docker tag aggregator:latest {{registry}}/containers/chainlink-ccv-aggregator:{{version}}
+    docker push {{registry}}/containers/chainlink-ccv-aggregator:{{version}}
+
 clean:
     docker rmi aggregator:latest
 

--- a/executor/Justfile
+++ b/executor/Justfile
@@ -19,6 +19,10 @@ publish-rc registry version:
     docker tag executor:rc {{registry}}/containers/chainlink-ccv-executor:{{version}}-rc
     docker push {{registry}}/containers/chainlink-ccv-executor:{{version}}-rc
 
+publish registry version:
+    docker tag executor:latest {{registry}}/containers/chainlink-ccv-executor:{{version}}
+    docker push {{registry}}/containers/chainlink-ccv-executor:{{version}}
+
 clean:
     docker rmi executor:latest
 

--- a/indexer/Justfile
+++ b/indexer/Justfile
@@ -22,6 +22,10 @@ publish-rc registry version:
     docker tag indexer:rc {{registry}}/containers/chainlink-ccv-indexer:{{version}}-rc
     docker push {{registry}}/containers/chainlink-ccv-indexer:{{version}}-rc
 
+publish registry version:
+    docker tag indexer:latest {{registry}}/containers/chainlink-ccv-indexer:{{version}}
+    docker push {{registry}}/containers/chainlink-ccv-indexer:{{version}}
+
 clean:
     docker rmi indexer:latest
 

--- a/verifier/Justfile
+++ b/verifier/Justfile
@@ -25,6 +25,13 @@ publish-rc registry version:
     docker tag token-verifier:rc {{registry}}/containers/chainlink-ccv-token-verifier:{{version}}-rc
     docker push {{registry}}/containers/chainlink-ccv-token-verifier:{{version}}-rc
 
+publish registry version:
+    docker tag verifier:latest {{registry}}/containers/chainlink-ccv-verifier:{{version}}
+    docker push {{registry}}/containers/chainlink-ccv-verifier:{{version}}
+
+    docker tag token-verifier:latest {{registry}}/containers/chainlink-ccv-token-verifier:{{version}}
+    docker push {{registry}}/containers/chainlink-ccv-token-verifier:{{version}}
+
 clean:
     docker rmi verifier:latest
     docker rmi token-verifier:latest


### PR DESCRIPTION
## Description

- Add release-publish.yaml, triggered on bare root tags (v[0-9]+.[0-9]+.[0-9]+) produced by release-please, building and pushing GA (non-rc) service images to both ECR registries
- Retire release-rc-publish.yaml: its <svc>/vX.Y.Z-rc tags are stale and its tags:['*'] trigger collided with release-please tags
- Add GA `publish` Justfile targets (tag :latest, no -rc suffix) to verifier, aggregator, indexer, executor; verifier covers token-verifier too

## Testing

We'll need to merge a release-please PR into main.

<!-- Run through this list before requesting review. -->
## Checklist

- [x] PR title follows Conventional Commits (see `CONTRIBUTING.md`); breaking changes marked with `!` / `BREAKING CHANGE:`
- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
