### PR TITLE
refactor(bootstrap)!: prune With* options in favor of config

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -168,8 +168,8 @@ func main() {
     if err := bootstrap.Run(
         "MyApp",
         &serviceFactory{},
-        bootstrap.WithLogLevelFromEnv(zapcore.InfoLevel),
         // Declare every key the app needs. The bootstrapper creates them on first boot.
+        // A CSA key for JD auth is injected automatically if you don't declare one.
         bootstrap.WithKey("my-signing-key", "signing", keystore.ECDSA_S256),
     ); err != nil {
         panic(err)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/pyroscope-go"
 	"github.com/jmoiron/sqlx"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.uber.org/zap/zapcore"
 
 	pb "github.com/smartcontractkit/chainlink-protos/orchestrator/feedsmanager"
 
@@ -53,18 +52,18 @@ const (
 )
 
 // AppConfigMode is how the bootstrapper loads application config. It is operator-provided via the
-// top-level app_config_mode key in the bootstrap config.toml (see NonSecretConfig) — not an env var
-// — so switching a service between JD and local is a config change, not an image rebuild. It drives
+// top-level app_config_mode key in the bootstrap config.toml (see NonSecretConfig)
+// so switching a service between JD and local is a config change, not an image rebuild. It drives
 // both config validation (see Config.validate) and startup routing (see Start).
 type AppConfigMode string
 
 const (
 	// AppConfigModeJD loads the app config from a Job Distributor and runs the full job lifecycle.
-	// This is the default when app_config_mode is unset, so existing JD deployments are unaffected.
+	// This is the default when app_config_mode is unset.
 	AppConfigModeJD AppConfigMode = "jd_app_config"
 	// AppConfigModeLocal reads the app config from a local file (local_app_config_path) with no JD.
 	// A [db]+[keystore] bootstrap config is optional and, when present, initializes a Postgres-backed
-	// keystore so the service can sign; a service that needs no keystore (the token verifier) omits it.
+	// keystore so the service can sign; a service that needs no keystore (i.e. the token verifier) omits it.
 	AppConfigModeLocal AppConfigMode = "local_app_config"
 )
 
@@ -186,8 +185,6 @@ type Bootstrapper struct {
 	localStartErr chan error
 	// pyroscope is a saved reference to profiler to close it on stop
 	pyroscope *pyroscope.Profiler
-
-	logLevel zapcore.Level
 }
 
 // NewBootstrapper creates a new [Bootstrapper] with the given config and service factory.
@@ -197,23 +194,12 @@ func NewBootstrapper(
 	opts ...Option,
 ) (*Bootstrapper, error) {
 	b := &Bootstrapper{
-		fac:      fac,
-		name:     name,
-		logLevel: zapcore.InfoLevel,
+		fac:  fac,
+		name: name,
 	}
 	for _, opt := range opts {
 		if err := opt(b); err != nil {
 			return nil, fmt.Errorf("failed to apply option: %w", err)
-		}
-	}
-
-	// Backwards compatibility: if no keys are declared, initialize the original default set.
-	// Deprecated: we should remove these once all apps and integrations define required keys.
-	if len(b.keys) == 0 {
-		b.keys = []keyToInit{
-			{DefaultCSAKeyName, "csa", keystore.Ed25519},
-			{defaultECDSASigningKeyName, "signing", keystore.ECDSA_S256},
-			{defaultEdDSASigningKeyName, "signing", keystore.Ed25519},
 		}
 	}
 
@@ -450,13 +436,11 @@ func (b *Bootstrapper) startWithJDLifecycle(ctx context.Context) error {
 // The app config is read from a local file. Two delivery modes are supported, chosen by whether the
 // file is present at startup:
 //
-//   - present: the service starts synchronously, exactly as before. This is the token verifier and
+//   - present: the service starts synchronously. This is the token verifier and
 //     the existing local-mode callers that mount the config at container start.
 //   - absent (keystore + info server only): the keystore and info server come up immediately and
 //     startLocal returns, then a background watcher waits for the file to appear and starts the
-//     service once it does. This mirrors JD mode, where the info server and lifecycle manager come up
-//     first and the factory starts only when a job (the app config) arrives — letting an operator, or
-//     devenv, discover the node's signing key from the info server and provision the config afterward.
+//     service once it does.
 func (b *Bootstrapper) startLocal(ctx context.Context) error {
 	// A keystore is initialized only when both the DB URL and keystore password are configured.
 	// Services that sign (committee verifier, executor) supply them; the token verifier does not.
@@ -597,7 +581,7 @@ func localConfigFileReady(path string) bool {
 	return err == nil && !info.IsDir() && info.Size() > 0
 }
 
-// Start routes to the mode-specific startup path resolved in NewBootstrapper.
+// Start routes to the mode-specific startup path resolved in [NewBootstrapper].
 func (b *Bootstrapper) Start(ctx context.Context) error {
 	if b.lggr == nil {
 		return fmt.Errorf("bootstrapper has no logger")
@@ -750,41 +734,17 @@ func initializeKeystore(ctx context.Context, lggr logger.Logger, db *sqlx.DB, ks
 // Option configures a [Bootstrapper].
 type Option func(*Bootstrapper) error
 
-// WithLogLevel sets the log level for the logger passed to the application.
-func WithLogLevel(logLevel zapcore.Level) Option {
-	return func(b *Bootstrapper) error {
-		b.logLevel = logLevel
-		return nil
-	}
-}
-
-// WithLogLevelFromEnv sets the log level from the LOG_LEVEL environment variable,
-// falling back to defaultLevel if the variable is unset or invalid.
-func WithLogLevelFromEnv(defaultLevel zapcore.Level) Option {
-	return func(b *Bootstrapper) error {
-		b.logLevel = defaultLevel
-		if lvlStr := os.Getenv("LOG_LEVEL"); lvlStr != "" {
-			var lvl zapcore.Level
-			if err := lvl.UnmarshalText([]byte(lvlStr)); err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "Invalid LOG_LEVEL '%s', defaulting to '%s'\n", lvlStr, defaultLevel)
-			} else {
-				b.logLevel = lvl
-			}
-		}
-		return nil
-	}
-}
-
 type keyToInit struct {
 	name    string
 	purpose string
 	keyType keystore.KeyType
 }
 
-// WithKey declares a key that the bootstrapper must ensure exists, creating it if absent.
-// When no WithKey options are provided, the bootstrapper applies a deprecated default set of
-// three keys (CSA, ECDSA signing, EdDSA signing). Passing one or more WithKey options suppresses
-// those defaults entirely; the caller is responsible for declaring every key it requires.
+// WithKey declares a key that the bootstrapper must ensure exists, creating it if absent. The caller
+// is responsible for declaring every key it requires; there is no default signing-key set.
+//
+// The exception is the CSA key used for JD authentication: if no CSA-purpose key is declared, the
+// default CSA key (DefaultCSAKeyName) is injected automatically.
 func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 	return func(b *Bootstrapper) error {
 		b.keys = append(b.keys, keyToInit{
@@ -796,29 +756,25 @@ func WithKey(name, purpose string, keyType keystore.KeyType) Option {
 	}
 }
 
-// WithBootstrapperConfigPath sets the bootstrapper config file path. If not set, the bootstrapper will look
-// for the config path in the BOOTSTRAPPER_CONFIG_PATH environment variable, and if that is not
-// set, it will default to DefaultConfigPath.
-func WithBootstrapperConfigPath(path string) Option {
+// withBootstrapperConfigPath is a test-only injection seam.
+// We have this so that we can run parallel tests w/out t.Setenv, which is not thread-safe.
+func withBootstrapperConfigPath(path string) Option {
 	return func(b *Bootstrapper) error {
 		b.configPath = path
 		return nil
 	}
 }
 
-// WithBootstrapperSecretsPath sets the bootstrapper secrets file path. If not set, the bootstrapper
-// looks for the path in the BOOTSTRAPPER_SECRETS_PATH environment variable, and if that is not set,
-// it defaults to DefaultSecretsPath. The secrets file is optional: if the resolved path does not
-// exist, it is skipped (which is how a legacy monolithic config remains valid). Applies when a
-// bootstrap operator config is loaded (JD mode, and local mode with a keystore).
-func WithBootstrapperSecretsPath(path string) Option {
+// withBootstrapperSecretsPath is a test-only injection seam.
+// We have this so that we can run parallel tests w/out t.Setenv, which is not thread-safe.
+func withBootstrapperSecretsPath(path string) Option {
 	return func(b *Bootstrapper) error {
 		b.secretsPath = path
 		return nil
 	}
 }
 
-// Run is a convenience function that loads config, creates a bootstrapper,
+// Run is a convenience function that loads config, creates a [Bootstrapper],
 // starts it, and blocks until SIGINT or SIGTERM is received.
 func Run(
 	name string,

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -150,22 +150,22 @@ var _ ServiceFactory = (*spyServiceFactoryDummy)(nil)
 
 // --- WithKey / NewBootstrapper key tests ---
 
-func TestNewBootstrapper_WithKey_Defaults(t *testing.T) {
+func TestNewBootstrapper_CSAAutoInjected(t *testing.T) {
 	t.Parallel()
 
 	// A local-mode bootstrap config avoids hitting JD config at construction.
 	cfgPath, secretsPath := writeBootstrapConfigFiles(t, localBootstrapTOML("/nonexistent/app.toml", ""))
 	b, err := NewBootstrapper("test", &mockServiceFactory{},
-		WithBootstrapperConfigPath(cfgPath),
-		WithBootstrapperSecretsPath(secretsPath),
+		withBootstrapperConfigPath(cfgPath),
+		withBootstrapperSecretsPath(secretsPath),
 	)
 	require.NoError(t, err)
 
-	// No WithKey options → the three original defaults must be applied.
-	require.Len(t, b.keys, 3)
+	// No WithKey options → only the default CSA key is auto-injected (JD auth needs it). There is no
+	// longer a default signing-key set; apps declare every signing key explicitly via WithKey.
+	require.Len(t, b.keys, 1)
 	require.Equal(t, DefaultCSAKeyName, b.keys[0].name)
-	require.Equal(t, defaultECDSASigningKeyName, b.keys[1].name)
-	require.Equal(t, defaultEdDSASigningKeyName, b.keys[2].name)
+	require.Equal(t, "csa", b.keys[0].purpose)
 }
 
 func TestNewBootstrapper_WithKey_Explicit(t *testing.T) {
@@ -173,14 +173,14 @@ func TestNewBootstrapper_WithKey_Explicit(t *testing.T) {
 
 	cfgPath, secretsPath := writeBootstrapConfigFiles(t, localBootstrapTOML("/nonexistent/app.toml", ""))
 	b, err := NewBootstrapper("test", &mockServiceFactory{},
-		WithBootstrapperConfigPath(cfgPath),
-		WithBootstrapperSecretsPath(secretsPath),
+		withBootstrapperConfigPath(cfgPath),
+		withBootstrapperSecretsPath(secretsPath),
 		WithKey("my_csa", "csa", keystore.Ed25519),
 		WithKey("my_signing", "signing", keystore.ECDSA_S256),
 	)
 	require.NoError(t, err)
 
-	// Explicit WithKey options must suppress defaults and preserve order.
+	// An explicit CSA WithKey suppresses the CSA auto-injection, and declaration order is preserved.
 	require.Len(t, b.keys, 2)
 	require.Equal(t, "my_csa", b.keys[0].name)
 	require.Equal(t, "my_signing", b.keys[1].name)
@@ -330,8 +330,8 @@ func TestBootstrapper_Stop_LocalKeystoreless_ClosesAccessors(t *testing.T) {
 	appPath := writeAppConfigFile(t, "")
 	cfgPath, secretsPath := writeBootstrapConfigFiles(t, localBootstrapTOML(appPath, ""))
 	b, err := NewBootstrapper("t", fac,
-		WithBootstrapperConfigPath(cfgPath),
-		WithBootstrapperSecretsPath(secretsPath),
+		withBootstrapperConfigPath(cfgPath),
+		withBootstrapperSecretsPath(secretsPath),
 	)
 	require.NoError(t, err)
 	require.NoError(t, b.Start(t.Context()))
@@ -501,8 +501,8 @@ func TestNewBootstrapper_ModeResolution(t *testing.T) {
 		// happens in Start.
 		cfgPath, secretsPath := writeBootstrapConfigFiles(t, localBootstrapTOML("/etc/myapp/app.toml", "postgres://localhost:5432/db"))
 		b, err := NewBootstrapper("t", &mockServiceFactory{},
-			WithBootstrapperConfigPath(cfgPath),
-			WithBootstrapperSecretsPath(secretsPath),
+			withBootstrapperConfigPath(cfgPath),
+			withBootstrapperSecretsPath(secretsPath),
 		)
 		require.NoError(t, err)
 		require.Equal(t, AppConfigModeLocal, b.mode)
@@ -515,8 +515,8 @@ func TestNewBootstrapper_ModeResolution(t *testing.T) {
 		// that the default is JD (a local default would have passed, since local ignores [jd]).
 		cfgPath, secretsPath := writeBootstrapConfigFiles(t, "[db]\nurl = \"postgres://localhost:5432/db\"\n[keystore]\npassword = \"x\"\n")
 		_, err := NewBootstrapper("t", &mockServiceFactory{},
-			WithBootstrapperConfigPath(cfgPath),
-			WithBootstrapperSecretsPath(secretsPath),
+			withBootstrapperConfigPath(cfgPath),
+			withBootstrapperSecretsPath(secretsPath),
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to validate 'jd' section")
@@ -526,8 +526,8 @@ func TestNewBootstrapper_ModeResolution(t *testing.T) {
 		t.Parallel()
 		cfgPath, secretsPath := writeBootstrapConfigFiles(t, "app_config_mode = \"local_app_config\"\n")
 		_, err := NewBootstrapper("t", &mockServiceFactory{},
-			WithBootstrapperConfigPath(cfgPath),
-			WithBootstrapperSecretsPath(secretsPath),
+			withBootstrapperConfigPath(cfgPath),
+			withBootstrapperSecretsPath(secretsPath),
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "local_app_config_path")
@@ -537,8 +537,8 @@ func TestNewBootstrapper_ModeResolution(t *testing.T) {
 		t.Parallel()
 		cfgPath, secretsPath := writeBootstrapConfigFiles(t, "app_config_mode = \"bogus\"\n")
 		_, err := NewBootstrapper("t", &mockServiceFactory{},
-			WithBootstrapperConfigPath(cfgPath),
-			WithBootstrapperSecretsPath(secretsPath),
+			withBootstrapperConfigPath(cfgPath),
+			withBootstrapperSecretsPath(secretsPath),
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "app_config_mode")
@@ -572,8 +572,8 @@ func TestBootstrapper_LocalMode_StartStop(t *testing.T) {
 	}
 
 	b, err := NewBootstrapper("local-test", fac,
-		WithBootstrapperConfigPath(cfgPath),
-		WithBootstrapperSecretsPath(secretsPath),
+		withBootstrapperConfigPath(cfgPath),
+		withBootstrapperSecretsPath(secretsPath),
 	)
 	require.NoError(t, err)
 	require.Equal(t, AppConfigModeLocal, b.mode)
@@ -655,8 +655,8 @@ func TestBootstrapper_LocalMode_WaitsForConfig(t *testing.T) {
 	}
 
 	b, err := NewBootstrapper("wait-test", fac,
-		WithBootstrapperConfigPath(cfgPath),
-		WithBootstrapperSecretsPath(secretsPath),
+		withBootstrapperConfigPath(cfgPath),
+		withBootstrapperSecretsPath(secretsPath),
 	)
 	require.NoError(t, err)
 	require.Equal(t, AppConfigModeLocal, b.mode)

--- a/bootstrap/keynames.go
+++ b/bootstrap/keynames.go
@@ -3,10 +3,3 @@ package bootstrap
 // DefaultCSAKeyName is the keystore key name for the JD CSA authentication key.
 // It is exported so that external tools (e.g. devenv) can look up the key by name.
 const DefaultCSAKeyName = "bootstrap_default_csa_key"
-
-// Deprecated key names retained only for the backwards-compat initialization block.
-// Remove once all callers declare their required keys explicitly via WithKey.
-const (
-	defaultECDSASigningKeyName = "bootstrap_default_ecdsa_signing_key"
-	defaultEdDSASigningKeyName = "bootstrap_default_eddsa_signing_key"
-)

--- a/build/devenv/services/committeeverifier/base.go
+++ b/build/devenv/services/committeeverifier/base.go
@@ -306,11 +306,6 @@ func launchVerifier(ctx context.Context, in *Input, outputs []*blockchain.Output
 		return nil, fmt.Errorf("failed to generate verifier secrets: %w", err)
 	}
 
-	envVars := make(map[string]string)
-	if lvl := os.Getenv("LOG_LEVEL"); lvl != "" {
-		envVars["LOG_LEVEL"] = lvl
-	}
-
 	// Register each matching chain family blockchain output as a chain the node has a signing identity on.
 	// This causes the bootstrapper to sync the node's signing key to JD on connect,
 	// making it available to deployment changesets via ListNodeChainConfigs.
@@ -355,7 +350,7 @@ func launchVerifier(ctx context.Context, in *Input, outputs []*blockchain.Output
 	// delivered by copying it into the running container (below / DeliverLocalAppConfig), not via a bind
 	// mount, so the container boots serving keys and the config can arrive at launch (in.LocalAppConfig
 	// set) or later (no-JD path: once contracts are deployed and the config is known).
-	req, err := baseImageRequest(in, envVars, bootstrapConfigFilePath, bootstrapSecretsFilePath, verifierSecretsFilePath)
+	req, err := baseImageRequest(in, nil, bootstrapConfigFilePath, bootstrapSecretsFilePath, verifierSecretsFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base image request: %w", err)
 	}

--- a/build/devenv/services/tokenVerifier.go
+++ b/build/devenv/services/tokenVerifier.go
@@ -201,9 +201,6 @@ func NewTokenVerifier(in *TokenVerifierInput, blockchainOutputs []*blockchain.Ou
 	// not an env var; only the bootstrap config path itself is pointed at via env.
 	envVars := make(map[string]string)
 	envVars["BOOTSTRAPPER_CONFIG_PATH"] = bootstrap.DefaultConfigPath
-	if lvl := os.Getenv("LOG_LEVEL"); lvl != "" {
-		envVars["LOG_LEVEL"] = lvl
-	}
 
 	/* Service */
 	req := testcontainers.ContainerRequest{

--- a/changelog/2026-07-13_bootstrap_prune_functional_options.md
+++ b/changelog/2026-07-13_bootstrap_prune_functional_options.md
@@ -1,0 +1,81 @@
+# Bootstrap: prune `With*` functional options in favor of config
+
+## Summary
+
+The bootstrapper's `With*` functional options are being pared back to a single principle:
+**operator/environment tuning lives in the bootstrap config; source-level options are reserved for
+the app's cryptographic identity (`WithKey`)**.
+
+As a result, the two log-level options are removed (they were no-ops), the two path options are
+unexported (they were only ever a test seam), and the deprecated default signing-key set is removed.
+`WithKey` is unchanged.
+
+---
+
+## Breaking change: `WithLogLevel` and `WithLogLevelFromEnv` are removed
+
+Both options wrote an internal field that nothing read — the effective log level has always come
+from `[Monitoring].LogLevel` in the bootstrap config. They were no-ops, so **removing them changes
+no runtime behavior**; only the call sites stop compiling.
+
+**Migration:** delete the call. Set the level in your bootstrap `config.toml`:
+
+```toml
+[Monitoring]
+LogLevel = "info"
+```
+
+Before:
+```go
+bootstrap.Run("MyApp", &factory{},
+    bootstrap.WithLogLevelFromEnv(zapcore.InfoLevel),
+    bootstrap.WithKey(commit.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256),
+)
+```
+
+After:
+```go
+bootstrap.Run("MyApp", &factory{},
+    bootstrap.WithKey(commit.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256),
+)
+```
+
+---
+
+## Breaking change: the default signing-key set is removed
+
+Previously, calling `NewBootstrapper`/`Run` with **no** `WithKey` options initialized a default set
+of three keys (CSA, ECDSA signing, EdDSA signing). That fallback is gone:
+
+- Apps must now declare every signing key they need explicitly via `WithKey`.
+- The EdDSA default key was used by no one and is simply dropped.
+- The **CSA key is still auto-injected** when no CSA-purpose key is declared — every JD app needs it
+  and it is harmless.
+
+**Who is affected:** any app that relied on the default ECDSA signing key
+(`bootstrap_default_ecdsa_signing_key` = `commit.DefaultECDSASigningKeyName`) without declaring it.
+In practice this is the **Canton committee verifier**, which reuses the shared committee-verifier
+factory. It signed correctly only because the default key name coincided with the constant the
+factory signs with.
+
+**Migration:** declare the key explicitly, matching the EVM committee verifier:
+
+```go
+bootstrap.Run("CantonCommitteeVerifier", cmd.NewCommitteeVerifierServiceFactory(),
+    bootstrap.WithKey(commit.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256),
+)
+```
+
+> ⚠️ This is a **silent** break: without the explicit `WithKey`, the signing key is never created and
+> signing fails at runtime rather than at compile time. Add the declaration when you bump the
+> bootstrap dependency.
+
+---
+
+## Internal: `WithBootstrapperConfigPath` / `WithBootstrapperSecretsPath` unexported
+
+These options were only ever called from the package's own tests (a parallel-safe, construction-time
+path-injection seam). No production or downstream caller used them. They are now
+`withBootstrapperConfigPath` / `withBootstrapperSecretsPath`. Production callers select these paths
+via `BOOTSTRAPPER_CONFIG_PATH` / `BOOTSTRAPPER_SECRETS_PATH` (or the defaults), which is unchanged.
+</content>

--- a/cmd/verifier/committee/main.go
+++ b/cmd/verifier/committee/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	_ "github.com/lib/pq"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-ccv/bootstrap"
 	cmd "github.com/smartcontractkit/chainlink-ccv/cmd/verifier"
@@ -17,19 +16,13 @@ import (
 
 func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "ccv" {
-		// The CLI loads the verifier secrets itself from the committee verifier's path (it runs
-		// before bootstrap.Run, so the service factory has not loaded them yet).
 		cmd.RunCCVCLI(os.Args[1:], vsecrets.CommitteeVerifierSecretsPathEnv, vsecrets.DefaultCommitteeVerifierSecretsPath)
 		return
 	}
 
-	// The lifecycle is chosen by the bootstrap config's app_config_mode key (not a flag or env var):
-	// "jd_app_config" (default) runs against a Job Distributor; "local_app_config" reads the app
-	// config from local_app_config_path with no JD, for the CCV starter kit / local testing.
 	if err := bootstrap.Run(
 		"EVMCommitteeVerifier",
 		cmd.NewCommitteeVerifierServiceFactory(),
-		bootstrap.WithLogLevelFromEnv(zapcore.InfoLevel),
 		bootstrap.WithKey(commit.DefaultECDSASigningKeyName, "signing", keystore.ECDSA_S256), // ECDSA key for signing verification results
 	); err != nil {
 		panic(fmt.Sprintf("failed to run EVM committee verifier: %s", err.Error()))

--- a/cmd/verifier/token/main.go
+++ b/cmd/verifier/token/main.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
@@ -39,15 +38,10 @@ func main() {
 		cmd.RunCCVCLI(os.Args[1:], vsecrets.TokenVerifierSecretsPathEnv, vsecrets.DefaultTokenVerifierSecretsPath)
 		return
 	}
-	// The token verifier has no JD support and needs no keystore. Its bootstrap config
-	// (BOOTSTRAPPER_CONFIG_PATH, default /etc/config.toml) must set app_config_mode =
-	// "local_app_config" and point local_app_config_path at the token verifier app config; the
-	// bootstrapper reads the app config from there and hands it to the factory. Mode selection is
-	// entirely config-driven — there is no mode env var or functional option here.
+
 	err := bootstrap.Run(
 		"TokenVerifier",
 		&tokenVerifierFactory{},
-		bootstrap.WithLogLevelFromEnv(zapcore.InfoLevel),
 	)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to run token verifier: %v\n", err)


### PR DESCRIPTION
## Description

Spring cleaning of bootstrap's With* functional options:

- Remove WithLogLevel/WithLogLevelFromEnv (no-ops; level comes from [Monitoring].LogLevel) and the dead logLevel field
- Remove the no-WithKey default signing-key set; keep CSA auto-injection so apps declare only the keys they need
- Unexport the config/secrets path options to withBootstrapper*; they were only ever a parallel-safe test helper
- Drop WithLogLevelFromEnv from the token and committee mains
- Update bootstrap_test.go, README example, and add a changelog

I also took the liberty to trim some overly verbose comments.

<!-- Describe how you verified this change works. Include the env file used (e.g.
     env.toml,env-cl.toml), the test or scenario run, and what you observed.
     "Passes CI" alone is not sufficient. -->
## Testing

Unit + devenv bringup success.


<!-- Run through this list before requesting review. -->
## Checklist

- [x] PR title follows Conventional Commits (see `CONTRIBUTING.md`); breaking changes marked with `!` / `BREAKING CHANGE:`
- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
