### PR TITLE
docs(release): add release-please adoption QUICKSTART

### DIFF
--- a/docs/release/QUICKSTART.md
+++ b/docs/release/QUICKSTART.md
@@ -1,0 +1,281 @@
+<!-- VERSION: 1.0.0 -->
+
+# Release Setup QUICKSTART
+
+**Document version: `1.0.0`** (semver — see [Versioning this document](#versioning-this-document))
+
+This guide brings a chainlink-ccv-family Go repo onto our standard release process:
+**automated per-module semantic versioning driven by Conventional Commits**, with
+generated `CHANGELOG.md`s, `go get`-resolvable tags, and (optionally) GA Docker images
+published on release. It is derived from the reference implementation in this repo.
+
+Copy-paste sample files live in [`samples/`](samples/). Placeholders are marked
+`REPLACE_ME...` (values) or `# EDIT:` (comments). Everything not so marked is the
+standard and should be copied verbatim, including the pinned action SHAs.
+
+---
+
+## Contents
+
+- [Principles](#principles)
+- [Mental model: what release-please manages, and what merely reacts to it](#mental-model-what-release-please-manages-and-what-merely-reacts-to-it)
+- [What you will add](#what-you-will-add)
+- [Prerequisites (do these first, in order)](#prerequisites-do-these-first-in-order)
+- [Adoption steps](#adoption-steps)
+- [Patching a released version (hotfixes)](#patching-a-released-version-hotfixes)
+- [Conventions (the standard, in one place)](#conventions)
+- [Versioning this document](#versioning-this-document)
+- [Changelog](#changelog)
+
+---
+
+## Principles
+
+The setup below follows from a few beliefs. When a specific rule seems fussy, it usually
+traces back to one of these — so they come first.
+
+- **`main` is always shippable.** Every PR clears required checks and Conventional-Commit
+  gating before it merges, and we release frequently, so the tip of `main` is a valid
+  release at any moment. This is what lets us **roll forward** instead of maintaining
+  release branches, and it reframes an unshippable commit as a bug in `main` to fix (revert
+  it, gate it behind a flag) — never a reason to route around `main`.
+
+- **Versioning is derived, not decided.** Authors declare the *intent* of a change
+  (`feat` / `fix` / `!`); release-please computes the version, tag, and `CHANGELOG.md` from
+  that intent. Nobody hand-picks a version number. This removes a class of human error and
+  makes every release reproducible from history alone.
+
+- **The PR title is the release record.** The repo is squash-merge-only, so the PR title
+  becomes the squash subject — the single line release-please reads. That is why it is
+  linted as a Conventional Commit and required from day one: a title that doesn't parse is
+  dropped from the changelog silently and permanently.
+
+- **Prefer the minimal, explicable standard; earn every mechanism.** We default to the
+  boring option and add machinery only against a concrete, reproduced failure — never a
+  hypothetical one. This is why the config carries no unexplained workarounds, why there is
+  no codegen tool yet, and why hotfix branches are documented but not standing. A documented
+  escape hatch beats speculative complexity.
+
+- **One linear history, one source of truth.** Each version is an ancestor of the next, and
+  "what's in prod" is a point on `main` rather than a reconciliation across branches.
+  Anything that forks that narrative (a long-lived release branch) is a deliberate
+  exception, not routine.
+
+---
+
+## Mental model: what release-please manages, and what merely reacts to it
+
+This is the single most important distinction; get it wrong and the config misattributes
+commits.
+
+- **Managed Go modules** — the units release-please versions, tags, and generates a
+  `CHANGELOG.md` for. A module is worth managing if it is **either** consumed downstream
+  via `go get`, **or** builds an executable that ships as a Docker image (the module
+  version becomes the image tag), **or** both — all of these warrant semantic versioning.
+  Each managed unit is a `go.mod` (the root module is the repo root itself). **These are
+  what the release-please config manages.**
+- **Docker image publishing** — orthogonal downstream wiring, not something release-please
+  versions. A release tag *triggers* a GA image build via the optional
+  `release-publish.yaml`. The trigger shape depends on how the repo is laid out:
+  - Services that live as *subdirectories inside the root module* (as in this repo, built
+    via `just <svc>/build` + `publish`) have no `go.mod` of their own, so they are pinned
+    to the **root** version and published when the root release tag is cut.
+  - A repo where the releasable unit *is* its own module publishes its image off that
+    module's own release tag.
+
+A repo that publishes no images simply omits `release-publish.yaml`.
+
+---
+
+## What you will add
+
+| File | Required? | Purpose |
+| ---- | --------- | ------- |
+| `release-please-config.json` | Yes | Declares managed modules + root `exclude-paths`. |
+| `.release-please-manifest.json` | Yes | Current version of each managed module. |
+| `.github/workflows/release-please.yaml` | Yes | Opens release PRs, cuts tags. |
+| `.github/workflows/pr-checks.yaml` | Yes | Required Conventional-Commit PR-title lint. |
+| `.github/workflows/release-publish.yaml` | Only if repo ships Docker services | Publishes GA images on a root release tag. |
+
+---
+
+## Prerequisites (do these first, in order)
+
+1. **Releng: a write-scoped GATI role** (`contents:write` + `pull-requests:write`).
+   Confirm the three secrets referenced by `release-please.yaml` exist in your repo:
+   `GATI_AWS_ROLE_ARN_AUTO_PR_TOKEN_ISSUER`, `GATI_LAMBDA_URL_CCIP_PROTOCOL`,
+   `GATI_AWS_REGION`. A read-only GATI role is **insufficient**.
+
+2. **Repo settings: force the PR title to be the squash subject, with an empty body.**
+   ```bash
+   gh api -X PATCH repos/<org>/<repo> \
+     -f squash_merge_commit_title=PR_TITLE \
+     -f squash_merge_commit_message=BLANK
+   ```
+   `BLANK` is important: `COMMIT_MESSAGES` causes **duplicate changelog entries**,
+   because release-please parses Conventional-Commit lines in the commit *body* as
+   additional commits.
+   Also enable "Allow GitHub Actions to create and approve pull requests" if needed.
+
+3. **Anchor tags.** Each managed module needs a starting tag matching its manifest
+   entry, or release-please has no baseline. If a module has no prior tag, create one:
+   ```bash
+   git tag <module-path>/v0.0.1 <baseline-sha>   # or bare v0.0.1 for the root module
+   git push origin <module-path>/v0.0.1
+   ```
+   Deleting existing published version tags is harmful — leave them; release-please reads
+   the manifest, not tags, to pick the next version.
+
+4. **Branch protection:** add **Lint PR title (Conventional Commits)** as a required check.
+
+---
+
+## Adoption steps
+
+1. **Inventory your releasable modules.** `find . -name go.mod -not -path '*/vendor/*'`.
+   A module is *managed* if it has (or will have) downstream `go get` consumers **or**
+   builds an executable shipped as a Docker image — either warrants semver. Test-support
+   and codegen-only modules are typically excluded.
+
+2. **Copy the samples** into the repo root / `.github/workflows/` and fill placeholders:
+
+   - **`release-please-config.json`** — one `packages` entry per managed module.
+     - The root `"."` entry gets **no** `package-name` (so its tags stay bare `vX.Y.Z`).
+     - Every **other** managed module gets `"package-name": "<its-path>"`.
+     - **Root `exclude-paths` is the critical knob.** Root's `"."` matches *every* file, so
+       without excludes it claims every commit. Exclude: every other managed module path,
+       every non-managed submodule path, and non-library noise (`changelog`, `docs`,
+       `.github`, generated `tools/` dirs). Do **not** exclude root `go.mod`/`go.sum` — a
+       root dependency bump is a real root change. Keep the list **tight**: an over-broad
+       exclude makes release-please silently ignore wanted commits.
+   - **`.release-please-manifest.json`** — one line per managed module, each at its current
+     version (match your anchor tags; new modules start at `0.0.1`).
+   - **`release-please.yaml`** — confirm the GATI secret names; otherwise verbatim.
+   - **`pr-checks.yaml`** — verbatim.
+   - **`release-publish.yaml`** — *only if you ship Docker services.* Fill the `module:`
+     matrix and the ECR registry/role secret names. Otherwise delete this file.
+
+3. **Sanity-check the first release PR.** Because pre-adoption history isn't
+   Conventional-Commit formatted, no release fires until the next `feat:`/`fix:` lands.
+   When it does, verify: (a) one release PR *per* managed module (`separate-pull-requests`),
+   (b) the **root** PR produces a **bare `vX.Y.Z`** tag — if it prefixes, set `"component": ""`
+   on the root package explicitly — and (c) each PR reflects the *right* commits for its
+   module (a misattribution means an `exclude-paths` bug).
+
+4. **Watch for wedged required checks.** Path-filtered required checks can sit "pending"
+   on a release PR that doesn't touch their path, and `push`/`merge_group`-only checks
+   won't run on the bot PR. Mark such checks not-strictly-required or add an always-runs
+   gate job.
+
+---
+
+## Patching a released version (hotfixes)
+
+**The standard is roll-forward: fix on `main`, let the normal release-please flow cut the
+next version.** Suppose your latest release is `v0.10.0`. You merge a `fix:` PR to `main` 
+like any other change, and release-please ships it as `v0.10.1` (or folds it into the next 
+`v0.11.0` if features also landed). You do **not** maintain long-lived release branches by 
+default.
+
+### Why roll-forward, not a maintenance-branch backport
+
+The alternative — the chainlink-node pattern of a `release/vX.Y.Z` branch you cherry-pick
+fixes onto and cut patches from — exists to solve one specific problem: *shipping a minimal
+fix without also shipping the commits that landed on `main` since the release.* That is only
+worth its cost when those intervening commits are a liability you must exclude. Our default
+assumes the opposite, for concrete reasons:
+
+- **`main` is always shippable** (the first [principle](#principles)). The commits that
+  landed since `v0.10.0` are themselves prod-bound on the next release — not an unvetted
+  backlog you need to hold back. If a specific one *isn't* safe to ship, that is a signal to
+  fix `main`'s shippability, not to route around it.
+- **A branch is a second reality to maintain.** A release branch needs its own release-please
+  invocation, its own manifest state, and a discipline of cherry-picking every fix onto both
+  branches in the right order. That machinery drifts and rots when it's used rarely — and by
+  design it *is* used rarely — so it's most likely to be broken exactly when an incident
+  finally needs it.
+- **Roll-forward keeps one source of truth.** History stays linear, each version is an
+  ancestor of the next, and the changelog reads as one story. Backport branches fork the
+  narrative: `v0.10.1` and `v0.11.0` can contain different fixes, and reconciling "what's
+  actually in prod" becomes a cross-branch diff.
+- **The escape hatch is cheap to add later, retroactively.** Because you can branch from an
+  already-published tag at any time (see the sketch below), deferring costs nothing: the day a
+  real incident demands a minimal patch, the branch is an afternoon of setup against a known
+  commit — not a decision you had to pre-pay.
+
+**When to reconsider:** if a client repo ships to an environment where taking `main`'s
+divergence is genuinely unacceptable (strict change-control, a customer pinned to `v0.10.x`
+demanding a security patch and nothing else), the backport flow below is fully supported.
+
+### Sketch: a maintenance-branch hotfix with release-please
+
+release-please supports this natively via `target-branch` — no new tooling, just a branch and
+a scoped workflow. To patch a shipped `v0.10.0`:
+
+1. **Fix `main` first.** Merge the `fix:` PR to `main` as normal. This keeps `main` correct and
+   gives you a commit to backport (never patch only the branch — that reintroduces the bug on
+   the next `main` release).
+2. **Branch from the released tag:**
+   ```bash
+   git checkout -b release/0.10 v0.10.0
+   git push origin release/0.10
+   ```
+   That branch's `.release-please-manifest.json` already reads `0.10.0` — the baseline
+   release-please bumps from.
+3. **Cherry-pick just the fix** onto the branch: `git cherry-pick <sha>`, push.
+4. **Run release-please against the branch.** Add a workflow scoped to `release/**` that sets
+   `target-branch` (the default workflow only manages `main`):
+   ```yaml
+   on:
+     push:
+       branches: [ 'release/**' ]
+   # ...same steps as release-please.yaml, plus:
+       with:
+         target-branch: ${{ github.ref_name }}
+         config-file: release-please-config.json
+         manifest-file: .release-please-manifest.json
+   ```
+   release-please reads the branch's manifest (`0.10.0`), sees one `fix:`, opens a release PR
+   **against the branch**, and on merge cuts **`v0.10.1`** — carrying only the cherry-pick,
+   none of `main`'s divergence.
+5. **Docker publish needs no changes.** Tags aren't branch-scoped, so the `v0.10.1` tag matches
+   `release-publish.yaml`'s `v[0-9]+.[0-9]+.[0-9]+` glob and publishes an image built from the
+   branch's state — same as a `main` release, and it fires because the tag is pushed under the
+   GATI app token.
+
+---
+
+## Conventions
+
+- **Manifest mode, `release-type: go`**, `separate-pull-requests: true`, `tag-separator: "/"`.
+- **Stay on `0.x` deliberately:** `bump-minor-pre-major: true`. Going to `1.0.0` is a
+  deliberate future act, not an accident.
+- **Conventional Commits enforced on PR titles, required from day one.** `feat`/`fix`/`!`
+  set the bump level; commit *scopes* are optional (routing is by changed-file path, not
+  scope).
+- **Changelog-only PRs** (touching only excluded paths like `changelog/`) intentionally
+  trigger no release.
+- **Hotfixes roll forward** — patch by fixing `main` and cutting the next version, not via
+  maintenance branches (see [Patching a released version](#patching-a-released-version-hotfixes)).
+- **Pinned action SHAs are part of the standard.** Bump them deliberately and bump this
+  document's VERSION when you do.
+
+---
+
+## Versioning this document
+
+The `<!-- VERSION: X.Y.Z -->` header at the top is the semantic version of *this process*,
+independent of any repo's own version. Adopters cite it ("we're on release QUICKSTART
+`1.0.0`") so drift between repos is a diffable fact.
+
+- **patch** — clarifications, typo fixes, non-behavioral wording.
+- **minor** — additive, backward-compatible changes (a new optional file/field/step) that
+  don't force existing adopters to change anything.
+- **major** — a change that requires adopters to modify what they've already stamped
+  (a renamed field, a changed default, a retired file, a bumped required action SHA).
+
+When you change the standard, bump the header and note it below.
+
+## Changelog
+
+- **1.0.0** — Initial standard, extracted from the chainlink-ccv reference implementation.

--- a/docs/release/samples/.github/workflows/pr-checks.yaml
+++ b/docs/release/samples/.github/workflows/pr-checks.yaml
@@ -1,0 +1,32 @@
+# Sample: pr-checks.yaml
+# Lints the PR title as a Conventional Commit. REQUIRED from day one and added to
+# branch protection: the repo is squash-merge-only and the squash subject derives
+# from the PR title, so a non-conventional title is invisible to release-please
+# (no bump, no changelog entry, permanently).
+#
+# Per-repo edits: none. The merge_group skip is intentional (title info is absent there).
+name: Pull Request Checks
+
+on:
+  merge_group:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened, edited ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  lint-pr-title:
+    name: Lint PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      # Skip PR-title linting on merge_group events — that title info isn't available there.
+      - if: github.event_name == 'pull_request'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/release/samples/.github/workflows/release-please.yaml
+++ b/docs/release/samples/.github/workflows/release-please.yaml
@@ -1,0 +1,44 @@
+# Sample: release-please.yaml
+# Opens/updates one release PR per managed Go module on every push to main, and
+# cuts tags + generates CHANGELOG.md when a release PR is merged.
+#
+# Per-repo edits: none required beyond confirming your repo's GATI secret names
+# match (see QUICKSTART "Prerequisites"). The action SHAs below are the standard
+# pins — bump them deliberately, in lockstep with the QUICKSTART VERSION.
+name: Release Please
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      # A GATI-issued GitHub App token (NOT GITHUB_TOKEN) is required: events created
+      # by GITHUB_TOKEN don't trigger other workflows, which would leave the bot's
+      # release PR's required checks unrun (and thus unmergeable) and tag-listening
+      # workflows (e.g. release-publish.yaml) unfired.
+      - name: Issue GitHub Token
+        id: issue-github-token
+        uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
+        with:
+          # EDIT: confirm these three secret names exist in your repo (releng-provisioned,
+          # write-scoped: contents:write + pull-requests:write).
+          aws-role-arn: ${{ secrets.GATI_AWS_ROLE_ARN_AUTO_PR_TOKEN_ISSUER }}
+          aws-lambda-url: ${{ secrets.GATI_LAMBDA_URL_CCIP_PROTOCOL }}
+          aws-region: ${{ secrets.GATI_AWS_REGION }}
+
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ steps.issue-github-token.outputs.access-token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/docs/release/samples/.github/workflows/release-publish.yaml
+++ b/docs/release/samples/.github/workflows/release-publish.yaml
@@ -1,0 +1,69 @@
+# Sample: release-publish.yaml  (OPTIONAL — only if your repo ships Docker services)
+# Publishes GA (non-RC) service images when release-please cuts a ROOT release.
+# Omit this file entirely if your repo has no deployable Docker services.
+#
+# The bare root tag `vX.Y.Z` is produced by release-please under the GATI GitHub App
+# token, which triggers this workflow. In GitHub Actions tag globs `*` do not match `/`,
+# so `v[0-9]+.[0-9]+.[0-9]+` matches ONLY the bare root tag — never module tags
+# (`<module>/vX.Y.Z`) or RC tags (`<svc>/vX.Y.Z-rc`).
+name: Publish GA Image From Release Tag
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # EDIT: the set of deployable services in your repo (each must have a
+        # `just <svc>/build` and `just <svc>/publish <registry> <version>` recipe).
+        module: [REPLACE_ME_svc_a, REPLACE_ME_svc_b]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
+
+      # EDIT: registry auth blocks + secret names to match your repo's ECR setup.
+      - name: Authenticate to AWS ECR (primary)
+        uses: ./.github/actions/aws-ecr-auth
+        with:
+          role-to-assume: ${{ secrets.REPLACE_ME_IAM_ROLE_PRIMARY }}
+          aws-region: us-west-2
+          registry-type: private
+
+      - name: Authenticate to AWS ECR (secondary)
+        uses: ./.github/actions/aws-ecr-auth
+        with:
+          role-to-assume: ${{ secrets.REPLACE_ME_IAM_ROLE_SECONDARY }}
+          aws-region: us-east-2
+          registry-type: private
+
+      - name: Build & Publish GA Image
+        env:
+          MODULE: ${{ matrix.module }}
+          VERSION: ${{ github.ref_name }}
+          # EDIT: registry secret names.
+          ECR_REGISTRY_PRIMARY: ${{ secrets.REPLACE_ME_ECR_REGISTRY_PRIMARY }}
+          ECR_REGISTRY_SECONDARY: ${{ secrets.REPLACE_ME_ECR_REGISTRY_SECONDARY }}
+        run: |
+          echo "Module: $MODULE"
+          echo "Version: $VERSION"
+          echo "Building GA Image.."
+          just "$MODULE"/build
+          echo "Publishing GA Image (primary).."
+          just "$MODULE"/publish "$ECR_REGISTRY_PRIMARY" "$VERSION"
+          echo "Publishing GA Image (secondary).."
+          just "$MODULE"/publish "$ECR_REGISTRY_SECONDARY" "$VERSION"

--- a/docs/release/samples/.release-please-manifest.json
+++ b/docs/release/samples/.release-please-manifest.json
@@ -1,0 +1,4 @@
+{
+  ".": "0.0.1",
+  "REPLACE_ME/managed-module-path": "0.0.1"
+}

--- a/docs/release/samples/release-please-config.json
+++ b/docs/release/samples/release-please-config.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "go",
+  "separate-pull-requests": true,
+  "tag-separator": "/",
+  "bump-minor-pre-major": true,
+  "pull-request-title-pattern": "chore: release ${component} ${version}",
+  "packages": {
+    ".": {
+      "release-type": "go",
+      "exclude-paths": [
+        "REPLACE_ME/every-other-managed-module-path",
+        "REPLACE_ME/non-managed-submodule-paths",
+        "changelog",
+        "docs",
+        ".github",
+        "tools/bin",
+        "tools/lib"
+      ]
+    },
+    "REPLACE_ME/managed-module-path": {
+      "release-type": "go",
+      "package-name": "REPLACE_ME/managed-module-path"
+    }
+  },
+  "changelog-sections": [
+    { "type": "build", "section": "Builds", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous", "hidden": true },
+    { "type": "ci", "section": "Continuous Integrations", "hidden": true },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements", "bump": "patch" },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "revert", "section": "Reverts", "bump": "patch" },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true }
+  ]
+}


### PR DESCRIPTION
## Description

- Add docs/release/QUICKSTART.md documenting the standard release process: per-module semver via release-please, Conventional-Commit PR titles, and GA Docker publishing
- Add copy-paste samples/ (config, manifest, and workflows) with REPLACE_ME/# EDIT placeholders for per-repo values
- Carry a semver VERSION header so adopters can cite and diff which revision of the process they are on

## Testing

N/A, docs.

<!-- Run through this list before requesting review. -->
## Checklist

- [x] PR title follows Conventional Commits (see `CONTRIBUTING.md`); breaking changes marked with `!` / `BREAKING CHANGE:`
- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
