### PR TITLE
ci(devenv): run devenv unit tests in CI

### DIFF
--- a/.github/workflows/test-devenv-module.yaml
+++ b/.github/workflows/test-devenv-module.yaml
@@ -1,0 +1,77 @@
+name: Devenv Module Tests
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: devenv-module-tests
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Full history so the change-detection step can diff against the PR base.
+          fetch-depth: 0
+
+      # This job intentionally has no `paths:` filter so it runs (and reports a status) on every
+      # PR — a required check with a paths filter deadlocks PRs that don't touch the filtered
+      # paths. Only the expensive steps below are gated on build/devenv/** actually changing.
+      - name: Detect devenv changes
+        id: changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # merge_group (the merge-queue gate) and push to main always run the full suite.
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "${BASE_SHA}...HEAD" | grep -qE '^(build/devenv/|\.github/workflows/test-devenv-module\.yaml)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No build/devenv/** changes; skipping devenv module tests."
+          fi
+
+      - name: Setup GitHub Token
+        if: steps.changes.outputs.changed == 'true'
+        id: setup-github-token
+        uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
+        with:
+          aws-role-arn: ${{ secrets.GATI_AWS_ROLE_ARN_CHAINLINK_READ_ONLY }}
+          aws-lambda-url: ${{ secrets.GATI_LAMBDA_URL_RELENG }}
+          aws-region: ${{ secrets.GATI_AWS_REGION }}
+          set-git-config: true
+
+      - name: Set up Go
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-go@v6
+        env:
+          GOPRIVATE: github.com/smartcontractkit/*
+        with:
+          cache: true
+          go-version-file: build/devenv/go.mod
+          cache-dependency-path: build/devenv/go.sum
+
+      # -short skips the e2e/service tests (which need a live devenv environment or
+      # Docker service containers); those run in test-smoke.yaml / test-services.yaml.
+      # The guards live in the tests themselves (`if testing.Short() { t.Skip(...) }`).
+      - name: Run tests
+        if: steps.changes.outputs.changed == 'true'
+        working-directory: build/devenv
+        run: go test -short ./...

--- a/build/devenv/tests/composable/messaging/evmPOC_test.go
+++ b/build/devenv/tests/composable/messaging/evmPOC_test.go
@@ -20,6 +20,9 @@ const (
 )
 
 func TestEVM2EVMV3(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	ctx := ccv.Plog.WithContext(t.Context())
 
 	lib, err := ccv.NewLibFromCCVEnv(&ccv.Plog, composableTestPath)
@@ -60,6 +63,9 @@ func TestEVM2EVMV3(t *testing.T) {
 }
 
 func TestEVM2EVMV2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	ctx := ccv.Plog.WithContext(t.Context())
 
 	lib, err := ccv.NewLibFromCCVEnv(&ccv.Plog, composableTestPath)

--- a/build/devenv/tests/e2e/chaos_test.go
+++ b/build/devenv/tests/e2e/chaos_test.go
@@ -29,6 +29,9 @@ const (
 )
 
 func TestChaos_AggregatorOutageRecovery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	setup := setupChaos(t, GetSmokeTestConfig())
 
 	var defaultAggregatorContainerName string
@@ -74,6 +77,9 @@ func TestChaos_AggregatorOutageRecovery(t *testing.T) {
 }
 
 func TestChaos_VerifierFaultToleranceThresholdViolated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	setup := setupChaos(t, GetSmokeTestConfig())
 
 	var defaultVerifierInputs []*committeeverifier.Input
@@ -159,6 +165,9 @@ func TestChaos_VerifierFaultToleranceThresholdViolated(t *testing.T) {
 }
 
 func TestChaos_AllExecutorsDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	setup := setupChaos(t, GetSmokeTestConfig())
 
 	var defaultExecutorContainerNames []string
@@ -205,6 +214,9 @@ func TestChaos_AllExecutorsDown(t *testing.T) {
 }
 
 func TestChaos_IndexerDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	setup := setupChaos(t, GetSmokeTestConfig())
 
 	require.NotEmpty(t, setup.in.Indexer, "no indexer in config")

--- a/build/devenv/tests/e2e/finality_reorg_curse_test.go
+++ b/build/devenv/tests/e2e/finality_reorg_curse_test.go
@@ -41,6 +41,9 @@ import (
 // IMPORTANT: Need to run this test against an env that has source chain with auto mining.
 // Run `just rebuild-all "env.toml,env-src-auto-mine.toml"` before running this test.
 func TestE2EReorg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	ctx := ccv.Plog.WithContext(context.Background())
 	l := zerolog.Ctx(ctx)
 	smokeTestConfig := GetSmokeTestConfig()

--- a/build/devenv/tests/e2e/ha_test.go
+++ b/build/devenv/tests/e2e/ha_test.go
@@ -178,6 +178,9 @@ func restartContainer(t *testing.T, l *zerolog.Logger, containerName string) {
 // produced the expected topology and a message flows end-to-end with all
 // services running.
 func TestHA_Baseline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	setup := setupHATest(t)
 
 	// Verify HA is enabled.
@@ -228,6 +231,9 @@ func TestHA_Baseline(t *testing.T) {
 // HA-enabled committee, verifies that a message still flows through the
 // surviving aggregator, then restarts and confirms recovery.
 func TestHA_SingleAggregatorDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	setup := setupHATest(t)
 
 	haCommittee := setup.findHACommittee(t)
@@ -253,6 +259,9 @@ func TestHA_SingleAggregatorDown(t *testing.T) {
 // TestHA_SingleIndexerDown kills one of two redundant indexers, verifies that a
 // message still flows, then restarts and verifies recovery.
 func TestHA_SingleIndexerDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	setup := setupHATest(t)
 	require.Len(t, setup.in.Indexer, 2, "need 2 indexers for this test")
 
@@ -276,6 +285,9 @@ func TestHA_SingleIndexerDown(t *testing.T) {
 // TestHA_CrossComponentDown kills one aggregator and one indexer simultaneously,
 // verifying that the system tolerates a multi-component partial failure.
 func TestHA_CrossComponentDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	setup := setupHATest(t)
 	require.Len(t, setup.in.Indexer, 2, "need 2 indexers for this test")
 

--- a/build/devenv/tests/e2e/load_test.go
+++ b/build/devenv/tests/e2e/load_test.go
@@ -100,6 +100,9 @@ func createLoadProfile(in *ccv.Cfg, rps int64, testDuration time.Duration, e *de
 }
 
 func TestE2ELoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	outfile := os.Getenv("LOAD_TEST_OUT_FILE")
 	if outfile == "" {
 		outfile = "../../env-out.toml"
@@ -523,6 +526,9 @@ func TestE2ELoad(t *testing.T) {
 }
 
 func TestStaging(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	outfile := os.Getenv("LOAD_TEST_OUT_FILE")
 	if outfile == "" {
 		outfile = "../../env-staging.toml"

--- a/build/devenv/tests/e2e/smoke_aggregator_message_disablement_rules_test.go
+++ b/build/devenv/tests/e2e/smoke_aggregator_message_disablement_rules_test.go
@@ -32,6 +32,9 @@ import (
 const aggregatorRefreshBuffer = 10 * time.Second
 
 func TestE2ESmoke_AggregatorMessageDisablementRulesCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)
@@ -89,6 +92,9 @@ func TestE2ESmoke_AggregatorMessageDisablementRulesCLI(t *testing.T) {
 //     the verifier checkpoint has advanced; rewinding the committee checkpoint
 //     makes the original message process normally.
 func TestE2ESmoke_AggregatorLaneDisablementRule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)
@@ -207,6 +213,9 @@ func TestE2ESmoke_AggregatorLaneDisablementRule(t *testing.T) {
 // drops any message touching the configured selector while unrelated chains
 // keep flowing, and that dropped messages require a checkpoint rewind to replay.
 func TestE2ESmoke_AggregatorChainDisablementRule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)

--- a/build/devenv/tests/e2e/smoke_chain_statuses_cli_test.go
+++ b/build/devenv/tests/e2e/smoke_chain_statuses_cli_test.go
@@ -23,6 +23,9 @@ import (
 )
 
 func TestE2ESmoke_ChainStatusesCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)
@@ -66,6 +69,9 @@ func TestE2ESmoke_ChainStatusesCLI(t *testing.T) {
 }
 
 func TestE2ESmoke_ChainStatusDisableEnable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)
@@ -156,6 +162,9 @@ func TestE2ESmoke_ChainStatusDisableEnable(t *testing.T) {
 }
 
 func TestE2ESmoke_ChainStatusFinalizedHeight(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)

--- a/build/devenv/tests/e2e/smoke_extra_args_v2_test.go
+++ b/build/devenv/tests/e2e/smoke_extra_args_v2_test.go
@@ -31,6 +31,9 @@ type v2TestCase struct {
 }
 
 func TestE2ESmoke_ExtraArgsV2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)

--- a/build/devenv/tests/e2e/smoke_jobqueue_cli_test.go
+++ b/build/devenv/tests/e2e/smoke_jobqueue_cli_test.go
@@ -23,6 +23,9 @@ import (
 // verifier process so it cannot race with the CLI assertions, then resumes it
 // once the checks are done.
 func TestE2ESmoke_JobQueueCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)

--- a/build/devenv/tests/e2e/smoke_remove_remote_pool_test.go
+++ b/build/devenv/tests/e2e/smoke_remove_remote_pool_test.go
@@ -33,6 +33,9 @@ import (
 //
 // Requires a running devenv (same as the other smoke tests).
 func TestE2ESmoke_RemoveRemotePool(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	ctx := ccv.Plog.WithContext(t.Context())
 
 	lib, err := ccv.NewLibFromCCVEnv(&ccv.Plog, GetSmokeTestConfig())

--- a/build/devenv/tests/e2e/smoke_replay_cli_test.go
+++ b/build/devenv/tests/e2e/smoke_replay_cli_test.go
@@ -63,6 +63,9 @@ func replayCLIArgs(subcommand string, extra ...string) []string {
 // TestE2ESmoke_ReplayCLI verifies the replay CLI subcommands work end-to-end:
 // migration check, list, status, and a discovery dry-run.
 func TestE2ESmoke_ReplayCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)
@@ -190,6 +193,9 @@ func sendAndWaitForIndexed(
 //     and verifies neither message's timestamp changed because there is nothing
 //     new to backfill.
 func TestE2ESmoke_ReplayForceOverwrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)

--- a/build/devenv/tests/e2e/smoke_test.go
+++ b/build/devenv/tests/e2e/smoke_test.go
@@ -25,6 +25,9 @@ const (
 )
 
 func TestE2ESmoke_Basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	ctx := ccv.Plog.WithContext(t.Context())
 
 	lib, err := ccv.NewLibFromCCVEnv(&ccv.Plog, GetSmokeTestConfig())

--- a/build/devenv/tests/e2e/smoke_token_pool_migration_test.go
+++ b/build/devenv/tests/e2e/smoke_token_pool_migration_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestE2ESmoke_TokenPoolMigrationEVM2EVM(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	const (
 		QualLockReleaseAV1 = "EVM_POOL_LNR_A_V1"
 		QualLockReleaseBV1 = "EVM_POOL_LNR_B_V1"

--- a/build/devenv/tests/e2e/smoke_token_verification_test.go
+++ b/build/devenv/tests/e2e/smoke_token_verification_test.go
@@ -39,6 +39,9 @@ type tokenVerifierTestCase struct {
 }
 
 func TestE2ESmoke_TokenVerification(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode; requires a running devenv environment")
+	}
 	smokeTestConfig := GetSmokeTestConfig()
 	in, err := ccv.LoadOutput[ccv.Cfg](smokeTestConfig)
 	require.NoError(t, err)

--- a/build/devenv/tests/services/aggregator_test.go
+++ b/build/devenv/tests/services/aggregator_test.go
@@ -52,6 +52,9 @@ func generateTestSigningKey(committeeName string, nodeIndex int) (privateKey, si
 }
 
 func TestServiceAggregator(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping service test in short mode; requires Docker service containers")
+	}
 	committeeName := "default"
 	_, publicKey, err := generateTestSigningKey(committeeName, 0)
 	require.NoError(t, err)
@@ -115,6 +118,9 @@ func TestServiceAggregator(t *testing.T) {
 // This test requires a real network connection (not bufconn) because the
 // anonymous auth middleware validates peer IP addresses.
 func TestServiceAggregatorAuthentication(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping service test in short mode; requires Docker service containers")
+	}
 	committeeName := "auth-test"
 	_, publicKey, err := generateTestSigningKey(committeeName, 0)
 	require.NoError(t, err)

--- a/build/devenv/tests/services/committee_verifier_local_test.go
+++ b/build/devenv/tests/services/committee_verifier_local_test.go
@@ -32,6 +32,9 @@ import (
 // Named TestService... so the test-services CI job (which builds verifier:latest/aggregator:latest
 // and runs -run TestService) picks it up. Requires Docker.
 func TestServiceCommitteeVerifierLocalMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping service test in short mode; requires Docker service containers")
+	}
 	const committeeName = "local"
 	const verifierContainerName = "verifier-local"
 	const chainID = "1337"
@@ -170,6 +173,9 @@ func TestServiceCommitteeVerifierLocalMode(t *testing.T) {
 //
 // Named TestService... so the test-services CI job picks it up. Requires Docker.
 func TestServiceCommitteeVerifierLocalModeDeferredConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping service test in short mode; requires Docker service containers")
+	}
 	const committeeName = "localdefer"
 	const verifierContainerName = "verifier-localdefer"
 	const chainID = "1337"

--- a/build/devenv/tests/services/indexer_test.go
+++ b/build/devenv/tests/services/indexer_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestServiceIndexer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping service test in short mode; requires Docker service containers")
+	}
 	out, err := services.NewIndexer(&services.IndexerInput{
 		Image:          "indexer:latest",
 		SourceCodePath: "../../../indexer",

--- a/build/devenv/tests/services/load/indexer_load_test.go
+++ b/build/devenv/tests/services/load/indexer_load_test.go
@@ -37,6 +37,9 @@ func createLoadProfile(rps int64, testDuration time.Duration) (*wasp.Profile, *I
 }
 
 func TestIndexerLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping service test in short mode; requires Docker service containers")
+	}
 	rps := int64(50)
 	testDuration := 1 * time.Minute
 


### PR DESCRIPTION
## Description

- Add test-devenv-module.yaml running `go test -short ./...` in build/devenv, gated on build/devenv/** changes (mirrors the deployment and evm module workflows)
- Guard the e2e/service tests with `if testing.Short() { t.Skip }` so they skip under the new job; they need a live devenv env or Docker containers and still run via test-smoke/test-services (which omit -short)

## Testing

New CI workflow passes.


<!-- Run through this list before requesting review. -->
## Checklist

- [x] PR title follows Conventional Commits (see `CONTRIBUTING.md`); breaking changes marked with `!` / `BREAKING CHANGE:`
- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
- [ ] `just lint fix` - no new lint errors
- [ ] `just generate` - mocks and protobufs are up to date
