### PR TITLE
ci: EVM verifier and aggregator public ECR publish

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -60,3 +60,39 @@ jobs:
           just "$MODULE"/publish "$ECR_REGISTRY_PRIMARY" "$VERSION"
           echo "Publishing GA Image (secondary).."
           just "$MODULE"/publish "$ECR_REGISTRY_SECONDARY" "$VERSION"
+
+  build-public:
+    name: Build, sign & publish public ${{ matrix.module }} image
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: committee verifier
+            repository: chainlink-ccv-verifier
+            dockerfile: verifier/Dockerfile
+            build_args: VERIFIER_TYPE=committee
+          - module: aggregator
+            repository: chainlink-ccv-aggregator
+            dockerfile: aggregator/Dockerfile
+            build_args: ''
+    permissions:
+      contents: read
+      id-token: write
+    uses: smartcontractkit/.github/.github/workflows/reusable-docker-build-publish.yml@f4ff50d0f4713ed7b247dbd8a58316484907f958 # 2026-01-13
+    with:
+      aws-ecr-name: ${{ matrix.repository }}
+      aws-region-ecr: us-east-1
+      build-arm64-image: 'true'
+      dockerfile: ${{ matrix.dockerfile }}
+      docker-build-context: .
+      docker-build-args: ${{ matrix.build_args }}
+      docker-manifest-sign: 'true'
+      docker-registry-url-override: public.ecr.aws/w0i8p0z9
+      git-sha: ${{ github.sha }}
+      github-event-name: ${{ github.event_name }}
+      github-ref-name: ${{ github.ref_name }}
+      github-ref-type: ${{ github.ref_type }}
+      github-workflow-repository: ${{ github.repository }}
+    secrets:
+      AWS_ACCOUNT_ID: '804282218731'
+      AWS_ROLE_PUBLISH_ARN: ${{ secrets.CCV_IAM_ROLE_PROD }}

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -94,5 +94,5 @@ jobs:
       github-ref-type: ${{ github.ref_type }}
       github-workflow-repository: ${{ github.repository }}
     secrets:
-      AWS_ACCOUNT_ID: '804282218731'
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       AWS_ROLE_PUBLISH_ARN: ${{ secrets.CCV_IAM_ROLE_PROD }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ their tag formats: root (`vX.Y.Z`), `deployment/vX.Y.Z`, `build/devenv/vX.Y.Z`,
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the PR-title format.
 
+Root releases publish signed, multi-architecture committee verifier and aggregator
+images to public ECR:
+
+- `public.ecr.aws/w0i8p0z9/chainlink-ccv-verifier:vX.Y.Z`
+- `public.ecr.aws/w0i8p0z9/chainlink-ccv-aggregator:vX.Y.Z`
+
+Use a release tag or image digest in third-party deployments. The verifier image
+contains the committee verifier; token-verifier images are not published publicly.
+
 ## Local Dev Environment
 Follow the [README](./build/devenv/README.md)
 


### PR DESCRIPTION
## Description

Adds public ECR publishing for the EVM committee verifier and aggregator images so external and starter-kit deployments do not require access to private ECR.

For root GA release tags (`vX.Y.Z`), the release workflow now:

- Builds `amd64` and `arm64` images using the shared Docker publish workflow.
- Publishes signed multi-architecture manifests to:
  - `public.ecr.aws/w0i8p0z9/chainlink-ccv-verifier:vX.Y.Z`
  - `public.ecr.aws/w0i8p0z9/chainlink-ccv-aggregator:vX.Y.Z`
- Builds the verifier with `VERIFIER_TYPE=committee`.
- Leaves the existing private ECR publishing path unchanged.

The README now documents the public image locations and recommends using a release tag or image digest. Token-verifier images are intentionally not published publicly.

Related infrastructure: smartcontractkit/infra#8899

## Testing

- Confirmed both public ECR repositories were successfully provisioned and their URLs match the workflow configuration.
- Confirmed the publishing IAM role was applied and the `CCV_IAM_ROLE_PROD` repository secret is configured.
- Verified the workflow remains restricted to root GA release tags.
- No application runtime code is changed.
- End-to-end publishing was not invoked from this PR because the workflow requires a root release tag; it will run on the next GA release.

## Checklist

- [x] Breaking changes documented in changelog (N/A — no breaking changes)
- [x] Cross link related PRs (in this or other repositories): smartcontractkit/infra#8899