### PR TITLE
feat: Backpressure improvements

### DIFF
--- a/aggregator/pkg/aggregation/aggregation_channel_manager.go
+++ b/aggregator/pkg/aggregation/aggregation_channel_manager.go
@@ -29,7 +29,7 @@ func NewChannelManager(keys []model.ChannelKey, bufferSize int) *ChannelManager 
 	manager := &ChannelManager{
 		clientChannel:       make(map[model.ChannelKey]chan aggregationRequest),
 		clientOrder:         make([]model.ChannelKey, 0, len(keys)),
-		AggregationChannel:  make(chan aggregationRequest),
+		AggregationChannel:  make(chan aggregationRequest, len(keys)),
 		wakeUp:              make(chan struct{}, 1),
 		currentlyQueued:     make(map[string]struct{}),
 		currentlyQueuedLock: sync.Mutex{},

--- a/aggregator/pkg/aggregation/aggregation_channel_manager.go
+++ b/aggregator/pkg/aggregation/aggregation_channel_manager.go
@@ -27,11 +27,12 @@ type ChannelManager struct {
 
 func NewChannelManager(keys []model.ChannelKey, bufferSize int) *ChannelManager {
 	manager := &ChannelManager{
-		clientChannel:      make(map[model.ChannelKey]chan aggregationRequest),
-		clientOrder:        make([]model.ChannelKey, 0, len(keys)),
-		AggregationChannel: make(chan aggregationRequest),
-		wakeUp:             make(chan struct{}, 1),
-		currentlyQueued:    make(map[string]struct{}),
+		clientChannel:       make(map[model.ChannelKey]chan aggregationRequest),
+		clientOrder:         make([]model.ChannelKey, 0, len(keys)),
+		AggregationChannel:  make(chan aggregationRequest),
+		wakeUp:              make(chan struct{}, 1),
+		currentlyQueued:     make(map[string]struct{}),
+		currentlyQueuedLock: sync.Mutex{},
 	}
 	for _, key := range keys {
 		manager.clientChannel[key] = make(chan aggregationRequest, bufferSize)

--- a/aggregator/pkg/aggregation/aggregation_channel_manager.go
+++ b/aggregator/pkg/aggregation/aggregation_channel_manager.go
@@ -3,6 +3,7 @@ package aggregation
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -16,14 +17,21 @@ type ChannelManager struct {
 	AggregationChannel chan aggregationRequest
 	wakeUp             chan struct{}
 	closed             atomic.Bool
+
+	// We deduplicate requests based on their unique ID (AggregationKey + MessageID) to avoid processing the same request multiple times.
+	// When the service is under heavy load the requests will come from multiple clients at once and we can reduce pressure by only processing one of them per messages.
+	// If 2 requests for the same message reach the channel manager at the same time it is fine to drop them since we already persisted both verification but did not aggregate yet.
+	currentlyQueued     map[string]struct{}
+	currentlyQueuedLock sync.Mutex
 }
 
 func NewChannelManager(keys []model.ChannelKey, bufferSize int) *ChannelManager {
 	manager := &ChannelManager{
 		clientChannel:      make(map[model.ChannelKey]chan aggregationRequest),
 		clientOrder:        make([]model.ChannelKey, 0, len(keys)),
-		AggregationChannel: make(chan aggregationRequest, len(keys)),
+		AggregationChannel: make(chan aggregationRequest),
 		wakeUp:             make(chan struct{}, 1),
+		currentlyQueued:    make(map[string]struct{}),
 	}
 	for _, key := range keys {
 		manager.clientChannel[key] = make(chan aggregationRequest, bufferSize)
@@ -45,24 +53,47 @@ func (m *ChannelManager) Enqueue(ctx context.Context, key model.ChannelKey, req 
 	if m.closed.Load() {
 		return common.ErrShuttingDown
 	}
+
+	if m.isQueued(req) {
+		return nil // Already queued, no need to enqueue again
+	}
+
 	ch, ok := m.clientChannel[key]
 	if !ok {
 		return fmt.Errorf("channel not found for key: %s", key)
 	}
-	timer := time.NewTimer(maxBlockTime)
-	defer timer.Stop()
 	select {
 	case ch <- req:
+		m.markAsQueued(req)
 		select {
 		case m.wakeUp <- struct{}{}:
 		default:
 		}
 		return nil
-	case <-timer.C:
-		return common.ErrAggregationChannelFull
 	case <-ctx.Done():
 		return ctx.Err()
+	default:
+		return common.ErrAggregationChannelFull
 	}
+}
+
+func (m *ChannelManager) isQueued(req aggregationRequest) bool {
+	m.currentlyQueuedLock.Lock()
+	defer m.currentlyQueuedLock.Unlock()
+	_, exists := m.currentlyQueued[req.ID()]
+	return exists
+}
+
+func (m *ChannelManager) markAsQueued(req aggregationRequest) {
+	m.currentlyQueuedLock.Lock()
+	defer m.currentlyQueuedLock.Unlock()
+	m.currentlyQueued[req.ID()] = struct{}{}
+}
+
+func (m *ChannelManager) markAsDequeued(req aggregationRequest) {
+	m.currentlyQueuedLock.Lock()
+	defer m.currentlyQueuedLock.Unlock()
+	delete(m.currentlyQueued, req.ID())
 }
 
 // Start runs the fair scheduling loop in a single goroutine.
@@ -93,6 +124,7 @@ func (m *ChannelManager) Start(ctx context.Context) error {
 				req := <-ch
 				select {
 				case m.AggregationChannel <- req:
+					m.markAsDequeued(req)
 				case <-ctx.Done():
 					m.closed.Store(true)
 					m.AggregationChannel <- req

--- a/aggregator/pkg/aggregation/aggregation_channel_manager_test.go
+++ b/aggregator/pkg/aggregation/aggregation_channel_manager_test.go
@@ -52,7 +52,7 @@ func TestNewChannelManager_CreatesChannelsForAllClients(t *testing.T) {
 				assert.Equal(t, tc.bufferSize, cap(ch))
 			}
 
-			assert.Equal(t, cap(manager.AggregationChannel), 0)
+			assert.Equal(t, len(tc.keys), cap(manager.AggregationChannel))
 		})
 	}
 }
@@ -483,33 +483,18 @@ func TestStart_ForwardsMidSendItemOnShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	// AggregationChannel is unbuffered by design (backpressure lives on the per-client
-	// channels), so a reader must be draining it concurrently with Start - mirroring
-	// the always-on consumer goroutine StartBackground runs in production - otherwise
-	// Start's mid-shutdown send blocks forever waiting for a receiver.
-	received := make(chan aggregationRequest, 1)
-	go func() {
-		for req := range manager.AggregationChannel {
-			received <- req
-		}
-	}()
-
 	startDone := make(chan struct{})
 	go func() {
 		_ = manager.Start(ctx)
 		close(startDone)
 	}()
 
-	select {
-	case <-startDone:
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for Start to complete")
-	}
+	<-startDone
 
 	select {
-	case req := <-received:
+	case req := <-manager.AggregationChannel:
 		assert.Equal(t, model.MessageID{1}, req.MessageID)
-	case <-time.After(time.Second):
+	default:
 		t.Fatal("expected item to be forwarded to aggregation channel during drain")
 	}
 }

--- a/aggregator/pkg/aggregation/aggregation_channel_manager_test.go
+++ b/aggregator/pkg/aggregation/aggregation_channel_manager_test.go
@@ -52,7 +52,7 @@ func TestNewChannelManager_CreatesChannelsForAllClients(t *testing.T) {
 				assert.Equal(t, tc.bufferSize, cap(ch))
 			}
 
-			assert.Equal(t, len(tc.keys), cap(manager.AggregationChannel))
+			assert.Equal(t, cap(manager.AggregationChannel), 0)
 		})
 	}
 }
@@ -483,18 +483,33 @@ func TestStart_ForwardsMidSendItemOnShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
+	// AggregationChannel is unbuffered by design (backpressure lives on the per-client
+	// channels), so a reader must be draining it concurrently with Start - mirroring
+	// the always-on consumer goroutine StartBackground runs in production - otherwise
+	// Start's mid-shutdown send blocks forever waiting for a receiver.
+	received := make(chan aggregationRequest, 1)
+	go func() {
+		for req := range manager.AggregationChannel {
+			received <- req
+		}
+	}()
+
 	startDone := make(chan struct{})
 	go func() {
 		_ = manager.Start(ctx)
 		close(startDone)
 	}()
 
-	<-startDone
+	select {
+	case <-startDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for Start to complete")
+	}
 
 	select {
-	case req := <-manager.AggregationChannel:
+	case req := <-received:
 		assert.Equal(t, model.MessageID{1}, req.MessageID)
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("expected item to be forwarded to aggregation channel during drain")
 	}
 }

--- a/aggregator/pkg/aggregation/aggregation_channel_manager_test.go
+++ b/aggregator/pkg/aggregation/aggregation_channel_manager_test.go
@@ -117,6 +117,64 @@ func TestNewChannelManagerFromConfig_ExtractsClientIDsAndAddsOrphanRecovery(t *t
 	}
 }
 
+func TestEnqueue_DeduplicatesRequests(t *testing.T) {
+	manager := NewChannelManager([]model.ChannelKey{"client1", "client2"}, 10)
+
+	req := aggregationRequest{
+		AggregationKey: "key1",
+		MessageID:      model.MessageID{1, 2, 3},
+		ChannelKey:     "client1",
+	}
+
+	err := manager.Enqueue(context.Background(), "client1", req, time.Second)
+	require.NoError(t, err)
+
+	// Same request (same AggregationKey + MessageID) enqueued again should be dropped silently.
+	err = manager.Enqueue(context.Background(), "client1", req, time.Second)
+	require.NoError(t, err)
+
+	assert.Len(t, manager.clientChannel["client1"], 1, "duplicate request should not be enqueued twice")
+}
+
+func TestEnqueue_AllowsReenqueueAfterDequeue(t *testing.T) {
+	manager := NewChannelManager([]model.ChannelKey{"client1"}, 10)
+
+	ctx := t.Context()
+
+	go func() { _ = manager.Start(ctx) }()
+	time.Sleep(10 * time.Millisecond)
+
+	req := aggregationRequest{
+		AggregationKey: "key1",
+		MessageID:      model.MessageID{9, 9, 9},
+		ChannelKey:     "client1",
+	}
+
+	err := manager.Enqueue(context.Background(), "client1", req, time.Second)
+	require.NoError(t, err)
+
+	select {
+	case received := <-manager.AggregationChannel:
+		assert.Equal(t, req, received)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for request on aggregation channel")
+	}
+
+	// Start marks the request as dequeued right after handing it off, which races with
+	// this goroutine picking it up; retry until that bookkeeping has completed.
+	require.Eventually(t, func() bool {
+		return manager.Enqueue(context.Background(), "client1", req, time.Second) == nil &&
+			len(manager.clientChannel["client1"]) == 1
+	}, 200*time.Millisecond, 5*time.Millisecond, "expected re-enqueue to succeed once the original request was dequeued")
+
+	select {
+	case received := <-manager.AggregationChannel:
+		assert.Equal(t, req, received)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for re-enqueued request on aggregation channel")
+	}
+}
+
 func TestEnqueue_SucceedsForExistingKey(t *testing.T) {
 	manager := NewChannelManager([]model.ChannelKey{"client1", "client2"}, 10)
 
@@ -137,44 +195,37 @@ func TestEnqueue_ReturnsErrorForNonExistingKey(t *testing.T) {
 func TestEnqueue_ReturnsErrorWhenChannelFull(t *testing.T) {
 	manager := NewChannelManager([]model.ChannelKey{"client1"}, 1)
 
-	err1 := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Second)
+	err1 := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1", MessageID: model.MessageID{1}}, time.Second)
 	assert.NoError(t, err1)
 
-	err2 := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Millisecond)
-	assert.Error(t, err2)
+	err2 := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1", MessageID: model.MessageID{2}}, time.Millisecond)
+	assert.ErrorIs(t, err2, common.ErrAggregationChannelFull)
+}
+
+func TestEnqueue_DoesNotBlockWhenChannelFull(t *testing.T) {
+	manager := NewChannelManager([]model.ChannelKey{"client1"}, 1)
+
+	err := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1", MessageID: model.MessageID{1}}, time.Second)
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1", MessageID: model.MessageID{2}}, 5*time.Second)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, common.ErrAggregationChannelFull)
+	assert.Less(t, elapsed, 50*time.Millisecond, "Enqueue should return immediately without blocking when the channel is full")
 }
 
 func TestEnqueue_ReturnsErrorWhenContextAlreadyCancelled(t *testing.T) {
 	manager := NewChannelManager([]model.ChannelKey{"client1"}, 1)
-	_ = manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Second)
+	_ = manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1", MessageID: model.MessageID{1}}, time.Second)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := manager.Enqueue(ctx, "client1", aggregationRequest{ChannelKey: "client1"}, 5*time.Second)
+	err := manager.Enqueue(ctx, "client1", aggregationRequest{ChannelKey: "client1", MessageID: model.MessageID{2}}, 5*time.Second)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
-}
-
-func TestEnqueue_ReturnsErrorWhenContextCancelledWhileBlocking(t *testing.T) {
-	manager := NewChannelManager([]model.ChannelKey{"client1"}, 1)
-	_ = manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Second)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		cancel()
-	}()
-
-	start := time.Now()
-	err := manager.Enqueue(ctx, "client1", aggregationRequest{ChannelKey: "client1"}, 5*time.Second)
-	elapsed := time.Since(start)
-
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, context.Canceled)
-	assert.Less(t, elapsed, 5*time.Second, "Enqueue should return promptly on context cancellation")
 }
 
 func TestGetAggregationChannel_ReturnsNonNilChannel(t *testing.T) {

--- a/aggregator/pkg/aggregation/aggregator.go
+++ b/aggregator/pkg/aggregation/aggregator.go
@@ -53,6 +53,10 @@ type aggregationRequest struct {
 	ChannelKey     model.ChannelKey
 }
 
+func (r aggregationRequest) ID() string {
+	return fmt.Sprintf("%s-%s", r.AggregationKey, r.MessageID)
+}
+
 // CheckAggregation enqueues a new aggregation request for the specified message ID.
 func (c *CommitReportAggregator) CheckAggregation(ctx context.Context, messageID model.MessageID, aggregationKey model.AggregationKey, channelKey model.ChannelKey, maxBlockTime time.Duration) error {
 	request := aggregationRequest{

--- a/aggregator/pkg/model/config.go
+++ b/aggregator/pkg/model/config.go
@@ -606,8 +606,8 @@ func (c *AggregatorConfig) SetDefaults() {
 	}
 	// Aggregation defaults
 	if c.Aggregation.ChannelBufferSize == 0 {
-		// Set to 10 by default matching the number of background workers
-		c.Aggregation.ChannelBufferSize = 10
+		// Set to MaxCommitVerifierNodeResultRequestsPerBatch * 2 by default to allow for some buffering of requests
+		c.Aggregation.ChannelBufferSize = c.MaxCommitVerifierNodeResultRequestsPerBatch * 2
 	}
 	if c.Aggregation.BackgroundWorkerCount == 0 {
 		c.Aggregation.BackgroundWorkerCount = 10
@@ -987,6 +987,11 @@ func (c *AggregatorConfig) ValidateWithoutSecrets() error {
 	// Validate orphan recovery configuration
 	if err := c.ValidateOrphanRecoveryConfig(); err != nil {
 		return fmt.Errorf("orphan recovery configuration error: %w", err)
+	}
+
+	// Validate that the client channel buffer size is sufficient for the batch size
+	if c.Aggregation.ChannelBufferSize < c.MaxCommitVerifierNodeResultRequestsPerBatch {
+		return fmt.Errorf("aggregation channel buffer size (%d) is smaller than the max commit verifier node result requests per batch (%d). Large batch will be rejected instantly", c.Aggregation.ChannelBufferSize, c.MaxCommitVerifierNodeResultRequestsPerBatch)
 	}
 
 	return nil

--- a/aggregator/pkg/model/config_test.go
+++ b/aggregator/pkg/model/config_test.go
@@ -67,7 +67,7 @@ func TestSetDefaults(t *testing.T) {
 
 		assert.Equal(t, 100, cfg.MaxMessageIDsPerBatch)
 		assert.Equal(t, 100, cfg.MaxCommitVerifierNodeResultRequestsPerBatch)
-		assert.Equal(t, 10, cfg.Aggregation.ChannelBufferSize)
+		assert.Equal(t, 200, cfg.Aggregation.ChannelBufferSize)
 		assert.Equal(t, 10, cfg.Aggregation.BackgroundWorkerCount)
 		assert.NotNil(t, cfg.Storage)
 		assert.Equal(t, 100, cfg.Storage.PageSize)
@@ -341,6 +341,54 @@ func TestValidateAggregationConfig(t *testing.T) {
 			tt.mutate(&config)
 			cfg := &AggregatorConfig{Aggregation: config}
 			err := cfg.ValidateAggregationConfig()
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateWithoutSecrets_ChannelBufferSizeVsBatchSize(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(c *AggregatorConfig)
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "buffer smaller than batch size fails",
+			mutate: func(c *AggregatorConfig) {
+				c.MaxCommitVerifierNodeResultRequestsPerBatch = 100
+				c.Aggregation.ChannelBufferSize = 50
+			},
+			expectError: true,
+			errorMsg:    "aggregation channel buffer size (50) is smaller than the max commit verifier node result requests per batch (100)",
+		},
+		{
+			name: "buffer equal to batch size passes",
+			mutate: func(c *AggregatorConfig) {
+				c.MaxCommitVerifierNodeResultRequestsPerBatch = 100
+				c.Aggregation.ChannelBufferSize = 100
+			},
+			expectError: false,
+		},
+		{
+			name:        "default buffer size accommodates default batch size",
+			mutate:      func(_ *AggregatorConfig) {},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createMinimalValidConfig()
+			tt.mutate(cfg)
+
+			err := cfg.ValidateWithoutSecrets()
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/build/devenv/services/aggregator.go
+++ b/build/devenv/services/aggregator.go
@@ -116,6 +116,10 @@ type AggregatorInput struct {
 	// If 0, the default (10) is used. Set to 1 for channel exhaustion tests.
 	BackgroundWorkerCount int `toml:"background_worker_count"`
 
+	// MaxCommitVerifierNodeResultRequestsPerBatch controls the max batch size for commit verifier node result requests.
+	// If 0, the default (100) is used. Must not exceed AggregationChannelBufferSize, or config validation fails at startup.
+	MaxCommitVerifierNodeResultRequestsPerBatch int `toml:"max_commit_verifier_node_result_requests_per_batch"`
+
 	// SharedTLSCerts contains shared TLS certificates for all aggregators.
 	// If set, these certs will be used instead of generating new ones.
 	SharedTLSCerts *TLSCertPaths `toml:"-"`
@@ -272,6 +276,11 @@ func (a *AggregatorInput) GenerateConfigs(generatedConfigFileName string) (*Gene
 	// Override background worker count if specified (useful for channel exhaustion tests)
 	if a.BackgroundWorkerCount > 0 {
 		config.Aggregation.BackgroundWorkerCount = a.BackgroundWorkerCount
+	}
+
+	// Override max commit verifier node result requests per batch if specified
+	if a.MaxCommitVerifierNodeResultRequestsPerBatch > 0 {
+		config.MaxCommitVerifierNodeResultRequestsPerBatch = a.MaxCommitVerifierNodeResultRequestsPerBatch
 	}
 
 	// Build the client list for the config (client_id/enabled/groups only) and, in parallel, the

--- a/build/devenv/services/aggregator.go
+++ b/build/devenv/services/aggregator.go
@@ -116,10 +116,6 @@ type AggregatorInput struct {
 	// If 0, the default (10) is used. Set to 1 for channel exhaustion tests.
 	BackgroundWorkerCount int `toml:"background_worker_count"`
 
-	// MaxCommitVerifierNodeResultRequestsPerBatch controls the max batch size for commit verifier node result requests.
-	// If 0, the default (100) is used. Must not exceed AggregationChannelBufferSize, or config validation fails at startup.
-	MaxCommitVerifierNodeResultRequestsPerBatch int `toml:"max_commit_verifier_node_result_requests_per_batch"`
-
 	// SharedTLSCerts contains shared TLS certificates for all aggregators.
 	// If set, these certs will be used instead of generating new ones.
 	SharedTLSCerts *TLSCertPaths `toml:"-"`
@@ -276,11 +272,6 @@ func (a *AggregatorInput) GenerateConfigs(generatedConfigFileName string) (*Gene
 	// Override background worker count if specified (useful for channel exhaustion tests)
 	if a.BackgroundWorkerCount > 0 {
 		config.Aggregation.BackgroundWorkerCount = a.BackgroundWorkerCount
-	}
-
-	// Override max commit verifier node result requests per batch if specified
-	if a.MaxCommitVerifierNodeResultRequestsPerBatch > 0 {
-		config.MaxCommitVerifierNodeResultRequestsPerBatch = a.MaxCommitVerifierNodeResultRequestsPerBatch
 	}
 
 	// Build the client list for the config (client_id/enabled/groups only) and, in parallel, the

--- a/build/devenv/tests/services/aggregator_test.go
+++ b/build/devenv/tests/services/aggregator_test.go
@@ -455,6 +455,7 @@ func setupAggregatorTestFixture(t *testing.T) *aggregatorTestFixture {
 		RootPath:                     "../../../../",
 		AggregationChannelBufferSize: 1, // Minimal buffer for channel exhaustion tests
 		BackgroundWorkerCount:        1, // Single worker = slow drain for deterministic tests
+		MaxCommitVerifierNodeResultRequestsPerBatch: 1, // Must not exceed AggregationChannelBufferSize (config validation)
 		DB: &services.AggregatorDBInput{
 			Image:    "postgres:16-alpine",
 			HostPort: 7440,

--- a/build/devenv/tests/services/aggregator_test.go
+++ b/build/devenv/tests/services/aggregator_test.go
@@ -447,15 +447,17 @@ func setupAggregatorTestFixture(t *testing.T) *aggregatorTestFixture {
 	// Setup aggregator with 2-of-3 threshold
 	sourceChainSelStr := fmt.Sprintf("%d", sourceChainSel)
 	out, err := services.NewAggregator(&services.AggregatorInput{
-		CommitteeName:                committeeName,
-		Image:                        "aggregator:latest",
-		HostPort:                     8110,
-		ExposedHostPort:              grpcHostPort, // Expose gRPC port directly for test
-		SourceCodePath:               "../../../aggregator",
-		RootPath:                     "../../../../",
-		AggregationChannelBufferSize: 1, // Minimal buffer for channel exhaustion tests
+		CommitteeName:   committeeName,
+		Image:           "aggregator:latest",
+		HostPort:        8110,
+		ExposedHostPort: grpcHostPort, // Expose gRPC port directly for test
+		SourceCodePath:  "../../../aggregator",
+		RootPath:        "../../../../",
+		// Buffer must be >= the default max batch size (100, config validation), so it can't be made
+		// artificially tiny here. Sized with headroom above 100 so a max-size batch still fits
+		// alongside any requests left over from earlier subtests in this single slow-draining worker.
+		AggregationChannelBufferSize: 150,
 		BackgroundWorkerCount:        1, // Single worker = slow drain for deterministic tests
-		MaxCommitVerifierNodeResultRequestsPerBatch: 1, // Must not exceed AggregationChannelBufferSize (config validation)
 		DB: &services.AggregatorDBInput{
 			Image:    "postgres:16-alpine",
 			HostPort: 7440,

--- a/docs/config/aggregator/config.documented.toml
+++ b/docs/config/aggregator/config.documented.toml
@@ -94,7 +94,7 @@ maxCommitVerifierNodeResultRequestsPerBatch = 100
 # aggregation configures the signature-aggregation workers.
 [aggregation]
   # channelBufferSize controls the size of the aggregation request channel buffer
-  channelBufferSize = 10
+  channelBufferSize = 200
   # backgroundWorkerCount controls the number of background workers processing aggregation requests
   backgroundWorkerCount = 10
   # checkAggregationTimeout is the timeout for each check aggregation operation in the write commit verifier node result handler.


### PR DESCRIPTION
This PR is changing 2 behaviour in the aggregation.

1. It eliminate block time when the client channel is full. Previously the channel manager would block for X seconds before throwing the `ErrAggregationChannelFull` error. With this change it will throw it instantly. This prevent aggregator keeping request open when it is already under high load.

2. Another change we made is that if another client sent a request for the same message and that this message have not been checked for aggregation we will not duplicate the aggregationRequest. This save some resources since we almost always have 16 NOPs sending their verification around the same time. If aggregator is under high load and processing is tight this effect will be amplified.

We also add a validation in the config now since the max batch size for verification need to be at least the size of the channel otherwise large batch would always be rejected. The default channel size will default to 2x the max batch size