### PR TITLE
feat: verifier + executor bundle changeset

### DIFF
--- a/deployment/changesets/apply_verifier_executor_config.go
+++ b/deployment/changesets/apply_verifier_executor_config.go
@@ -1,0 +1,161 @@
+package changesets
+
+// ApplyVerifierExecutorConfig changeset overview
+//
+// ApplyVerifierExecutorConfig bundles ApplyVerifierConfig and ApplyExecutorConfig
+// into a single ChangeSetV2: one deduplicated input type, one up-front validation
+// pass covering both sub-flows plus the shared preconditions, one apply that runs
+// both sub-flows and merges their outputs, and a combined FromState builder.
+//
+// It introduces zero new job-spec-generation logic: both sub-flows run entirely
+// unchanged via their own public ApplyVerifierConfig() / ApplyExecutorConfig()
+// ChangeSetV2 values. ApplyVerifierConfig and ApplyExecutorConfig remain public
+// and are unaffected by this bundle; devenv continues to call them directly.
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
+)
+
+const defaultQualifier = "default"
+
+// VerifierBundleCommittee mirrors CommitteeInput but omits Qualifier: the bundle
+// always resolves to defaultQualifier, so a committee-level qualifier here would
+// be dead input.
+type VerifierBundleCommittee struct {
+	Aggregators  []AggregatorRef
+	ChainConfigs map[uint64]CommitteeChainMembership
+}
+
+type VerifierBundleInput struct {
+	Committee               VerifierBundleCommittee
+	DisableFinalityCheckers []string
+	ConsolidateAggregators  bool
+}
+
+type ExecutorBundleInput struct {
+	Pool           ExecutorPoolInput
+	IndexerAddress []string
+}
+
+type ApplyVerifierExecutorConfigInput struct {
+	NOPs               []NOPInput
+	PyroscopeURL       string
+	TargetNOPs         []shared.NOPAlias
+	RevokeOrphanedJobs bool
+	Verifier           VerifierBundleInput
+	Executor           ExecutorBundleInput
+}
+
+// deriveVerifierInput projects the combined input down to the
+// ApplyVerifierConfigInput that would be handed to the standalone
+// ApplyVerifierConfig changeset for the same fields.
+//
+// The bundle is the sole owner of the default-qualifier behavior: its input
+// carries no qualifier fields at all (see ApplyVerifierExecutorConfigInput and
+// VerifierBundleCommittee), and the executor side has no matching field to keep
+// a custom qualifier in sync with, so both sides must always resolve to the
+// same qualifier. This bundle injects defaultQualifier here rather than relying
+// on the sub-changesets to default it.
+func deriveVerifierInput(cfg ApplyVerifierExecutorConfigInput) ApplyVerifierConfigInput {
+	return ApplyVerifierConfigInput{
+		NOPs:                     cfg.NOPs,
+		CommitteeQualifier:       defaultQualifier,
+		DefaultExecutorQualifier: defaultQualifier,
+		Committee: CommitteeInput{
+			Qualifier:    defaultQualifier,
+			Aggregators:  cfg.Verifier.Committee.Aggregators,
+			ChainConfigs: cfg.Verifier.Committee.ChainConfigs,
+		},
+		PyroscopeURL:            cfg.PyroscopeURL,
+		TargetNOPs:              cfg.TargetNOPs,
+		DisableFinalityCheckers: cfg.Verifier.DisableFinalityCheckers,
+		RevokeOrphanedJobs:      cfg.RevokeOrphanedJobs,
+		ConsolidateAggregators:  cfg.Verifier.ConsolidateAggregators,
+	}
+}
+
+func deriveExecutorInput(cfg ApplyVerifierExecutorConfigInput) ApplyExecutorConfigInput {
+	return ApplyExecutorConfigInput{
+		NOPs:               cfg.NOPs,
+		ExecutorQualifier:  defaultQualifier,
+		Pool:               cfg.Executor.Pool,
+		IndexerAddress:     cfg.Executor.IndexerAddress,
+		PyroscopeURL:       cfg.PyroscopeURL,
+		TargetNOPs:         cfg.TargetNOPs,
+		RevokeOrphanedJobs: cfg.RevokeOrphanedJobs,
+	}
+}
+
+func ApplyVerifierExecutorConfig() deployment.ChangeSetV2[ApplyVerifierExecutorConfigInput] {
+	verifierChangeset := ApplyVerifierConfig()
+	executorChangeset := ApplyExecutorConfig()
+
+	validate := func(e deployment.Environment, cfg ApplyVerifierExecutorConfigInput) error {
+		var errs []error
+
+		if err := verifierChangeset.VerifyPreconditions(e, deriveVerifierInput(cfg)); err != nil {
+			errs = append(errs, fmt.Errorf("verifier: %w", err))
+		}
+
+		if err := executorChangeset.VerifyPreconditions(e, deriveExecutorInput(cfg)); err != nil {
+			errs = append(errs, fmt.Errorf("executor: %w", err))
+		}
+
+		if len(cfg.NOPs) > 0 && e.Offchain == nil {
+			errs = append(errs, errors.New("NOPs require JD but e.Offchain is nil"))
+		}
+
+		return errors.Join(errs...)
+	}
+
+	apply := func(e deployment.Environment, cfg ApplyVerifierExecutorConfigInput) (deployment.ChangesetOutput, error) {
+		var reports []operations.Report[any, any]
+
+		verifierOutput, err := verifierChangeset.Apply(e, deriveVerifierInput(cfg))
+		reports = append(reports, verifierOutput.Reports...)
+		if err != nil {
+			return deployment.ChangesetOutput{
+				Reports:   reports,
+				DataStore: verifierOutput.DataStore,
+			}, fmt.Errorf("verifier flow failed, executor flow not attempted: %w", err)
+		}
+
+		executorOutput, err := executorChangeset.Apply(e, deriveExecutorInput(cfg))
+		reports = append(reports, executorOutput.Reports...)
+
+		executorErr := err
+
+		ds := datastore.NewMemoryDataStore()
+		if verifierOutput.DataStore != nil {
+			if mergeErr := ds.Merge(verifierOutput.DataStore.Seal()); mergeErr != nil {
+				return deployment.ChangesetOutput{Reports: reports}, errors.Join(fmt.Errorf("failed to merge verifier datastore: %w", mergeErr), executorErr)
+			}
+		}
+		if executorOutput.DataStore != nil {
+			if mergeErr := ds.Merge(executorOutput.DataStore.Seal()); mergeErr != nil {
+				return deployment.ChangesetOutput{Reports: reports, DataStore: ds}, errors.Join(fmt.Errorf("failed to merge executor datastore: %w", mergeErr), executorErr)
+			}
+		}
+
+		if executorErr != nil {
+			return deployment.ChangesetOutput{
+				Reports:   reports,
+				DataStore: ds,
+			}, fmt.Errorf("verifier flow succeeded but executor flow failed (no rollback, accepted verifier proposal left in place): %w", executorErr)
+		}
+
+		return deployment.ChangesetOutput{
+			Reports:   reports,
+			DataStore: ds,
+		}, nil
+	}
+
+	return deployment.CreateChangeSet(apply, validate)
+}

--- a/deployment/changesets/apply_verifier_executor_config_test.go
+++ b/deployment/changesets/apply_verifier_executor_config_test.go
@@ -1,0 +1,231 @@
+package changesets
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+
+	"github.com/smartcontractkit/chainlink-ccv/deployment/shared"
+)
+
+// nopOffchainClient is a non-nil offchain.Client value used only to make
+// e.Offchain != nil true for validate-only tests. It embeds the interface
+// itself (rather than implementing it) so every method promotes from a nil
+// field -- calling any of them would panic, but validate() never calls any
+// Offchain method, only checks it for nilness, so this is safe here. This is
+// intentionally not a JD/Offchain mock: it carries no behavior at all.
+type nopOffchainClient struct {
+	offchain.Client
+}
+
+func validCombinedVerifierExecutorInput(sel uint64) ApplyVerifierExecutorConfigInput {
+	return ApplyVerifierExecutorConfigInput{
+		NOPs: []NOPInput{{Alias: "nop1", SignerAddressByFamily: map[string]string{chainsel.FamilyEVM: "0xAAA"}}},
+		Verifier: VerifierBundleInput{
+			Committee: VerifierBundleCommittee{
+				Aggregators: []AggregatorRef{{Name: "agg", Address: "0xAGG"}},
+				ChainConfigs: map[uint64]CommitteeChainMembership{
+					sel: {NOPAliases: []shared.NOPAlias{"nop1"}},
+				},
+			},
+		},
+		Executor: ExecutorBundleInput{
+			Pool: ExecutorPoolInput{
+				ChainConfigs: map[uint64]ChainExecutorPoolMembership{
+					sel: {NOPAliases: []shared.NOPAlias{"nop1"}, ExecutionInterval: 5 * time.Second},
+				},
+			},
+			IndexerAddress: []string{"indexer:1234"},
+		},
+	}
+}
+
+func TestApplyVerifierExecutorConfig_Validation_AcceptsValidCombinedInput(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	registerEVMOnchain(&stubOnchainAdapter{})
+	cs := ApplyVerifierExecutorConfig()
+
+	err := cs.VerifyPreconditions(
+		deployment.Environment{Offchain: nopOffchainClient{}},
+		validCombinedVerifierExecutorInput(sel),
+	)
+	require.NoError(t, err)
+}
+
+func TestApplyVerifierExecutorConfig_Validation_VerifierInvalidNamesVerifierFailure(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	registerEVMOnchain(&stubOnchainAdapter{})
+	cs := ApplyVerifierExecutorConfig()
+
+	cfg := validCombinedVerifierExecutorInput(sel)
+	cfg.Verifier.Committee.Aggregators = nil // invalidate verifier side only
+
+	err := cs.VerifyPreconditions(deployment.Environment{Offchain: nopOffchainClient{}}, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verifier:")
+	assert.Contains(t, err.Error(), "at least one aggregator is required")
+}
+
+func TestApplyVerifierExecutorConfig_Validation_ExecutorInvalidNamesExecutorFailure(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	registerEVMOnchain(&stubOnchainAdapter{})
+	cs := ApplyVerifierExecutorConfig()
+
+	cfg := validCombinedVerifierExecutorInput(sel)
+	cfg.Executor.IndexerAddress = nil // invalidate executor side only
+
+	err := cs.VerifyPreconditions(deployment.Environment{Offchain: nopOffchainClient{}}, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "executor:")
+	assert.Contains(t, err.Error(), "indexer address is required")
+}
+
+func TestApplyVerifierExecutorConfig_Validation_BothInvalidAggregatesBothFailures(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	registerEVMOnchain(&stubOnchainAdapter{})
+	cs := ApplyVerifierExecutorConfig()
+
+	cfg := validCombinedVerifierExecutorInput(sel)
+	cfg.Verifier.Committee.Aggregators = nil
+	cfg.Executor.IndexerAddress = nil
+
+	err := cs.VerifyPreconditions(deployment.Environment{Offchain: nopOffchainClient{}}, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one aggregator is required")
+	assert.Contains(t, err.Error(), "indexer address is required")
+}
+
+func TestApplyVerifierExecutorConfig_Validation_OffchainAbsentFailsFastWithNonEmptyInput(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	registerEVMOnchain(&stubOnchainAdapter{})
+	cs := ApplyVerifierExecutorConfig()
+
+	err := cs.VerifyPreconditions(deployment.Environment{}, validCombinedVerifierExecutorInput(sel))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NOPs require JD but e.Offchain is nil")
+}
+
+// TestApplyVerifierExecutorConfig_InjectsDefaultQualifier proves the bundle input
+// exposes no qualifier field at all (see VerifierBundleCommittee) and that the
+// derive helpers inject defaultQualifier on every qualifier the sub-changesets
+// consume -- committee, default-executor, the derived CommitteeInput, and the
+// executor pool -- so nothing is left to downstream defaulting.
+func TestApplyVerifierExecutorConfig_InjectsDefaultQualifier(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	registerEVMOnchain(&stubOnchainAdapter{})
+	cs := ApplyVerifierExecutorConfig()
+
+	cfg := validCombinedVerifierExecutorInput(sel)
+
+	err := cs.VerifyPreconditions(deployment.Environment{Offchain: nopOffchainClient{}}, cfg)
+	require.NoError(t, err)
+	derived := deriveVerifierInput(cfg)
+	assert.Equal(t, defaultQualifier, derived.Committee.Qualifier)
+	assert.Equal(t, defaultQualifier, derived.CommitteeQualifier)
+	assert.Equal(t, defaultQualifier, derived.DefaultExecutorQualifier)
+	assert.Equal(t, defaultQualifier, deriveExecutorInput(cfg).ExecutorQualifier)
+}
+
+func TestApplyVerifierExecutorConfig_Validation_ProductionRejectsPyroscope(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	registerEVMOnchain(&stubOnchainAdapter{})
+	cs := ApplyVerifierExecutorConfig()
+
+	cfg := validCombinedVerifierExecutorInput(sel)
+	cfg.PyroscopeURL = "http://pyroscope.example"
+
+	err := cs.VerifyPreconditions(deployment.Environment{Name: "mainnet", Offchain: nopOffchainClient{}}, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pyroscope URL is not supported for production")
+}
+
+// ---- derive-function parity ----
+
+func TestDeriveVerifierInput_MatchesHandBuiltStandaloneInput(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	cfg := ApplyVerifierExecutorConfigInput{
+		NOPs:               []NOPInput{{Alias: "nop1", Mode: shared.NOPModeCL}},
+		PyroscopeURL:       "http://pyroscope.example",
+		TargetNOPs:         []shared.NOPAlias{"nop1"},
+		RevokeOrphanedJobs: true,
+		Verifier: VerifierBundleInput{
+			Committee: VerifierBundleCommittee{
+				Aggregators: []AggregatorRef{{Name: "agg", Address: "0xAGG"}},
+				ChainConfigs: map[uint64]CommitteeChainMembership{
+					sel: {NOPAliases: []shared.NOPAlias{"nop1"}},
+				},
+			},
+			DisableFinalityCheckers: []string{"1"},
+			ConsolidateAggregators:  true,
+		},
+		Executor: ExecutorBundleInput{
+			Pool:           ExecutorPoolInput{ChainConfigs: map[uint64]ChainExecutorPoolMembership{sel: {NOPAliases: []shared.NOPAlias{"nop1"}}}},
+			IndexerAddress: []string{"indexer:1234"},
+		},
+	}
+
+	want := ApplyVerifierConfigInput{
+		// The combined input carries no qualifier fields; the bundle injects
+		// defaultQualifier on every qualifier the sub-changeset consumes,
+		// including the derived CommitteeInput.Qualifier.
+		NOPs:                     cfg.NOPs,
+		CommitteeQualifier:       defaultQualifier,
+		DefaultExecutorQualifier: defaultQualifier,
+		Committee: CommitteeInput{
+			Qualifier:    defaultQualifier,
+			Aggregators:  cfg.Verifier.Committee.Aggregators,
+			ChainConfigs: cfg.Verifier.Committee.ChainConfigs,
+		},
+		PyroscopeURL:            cfg.PyroscopeURL,
+		TargetNOPs:              cfg.TargetNOPs,
+		DisableFinalityCheckers: cfg.Verifier.DisableFinalityCheckers,
+		RevokeOrphanedJobs:      cfg.RevokeOrphanedJobs,
+		ConsolidateAggregators:  cfg.Verifier.ConsolidateAggregators,
+	}
+
+	assert.Equal(t, want, deriveVerifierInput(cfg))
+}
+
+func TestDeriveExecutorInput_MatchesHandBuiltStandaloneInput(t *testing.T) {
+	sel := chainsel.TEST_90000001.Selector
+	cfg := ApplyVerifierExecutorConfigInput{
+		NOPs:               []NOPInput{{Alias: "nop1", Mode: shared.NOPModeCL}},
+		PyroscopeURL:       "http://pyroscope.example",
+		TargetNOPs:         []shared.NOPAlias{"nop1"},
+		RevokeOrphanedJobs: true,
+		Verifier: VerifierBundleInput{
+			Committee: VerifierBundleCommittee{
+				Aggregators: []AggregatorRef{{Name: "agg", Address: "0xAGG"}},
+			},
+		},
+		Executor: ExecutorBundleInput{
+			Pool: ExecutorPoolInput{
+				ChainConfigs: map[uint64]ChainExecutorPoolMembership{
+					sel: {NOPAliases: []shared.NOPAlias{"nop1"}, ExecutionInterval: 5 * time.Second},
+				},
+				WorkerCount: 3,
+			},
+			IndexerAddress: []string{"indexer:1234"},
+		},
+	}
+
+	want := ApplyExecutorConfigInput{
+		// The combined input carries no qualifier field; the bundle injects
+		// defaultQualifier.
+		NOPs:               cfg.NOPs,
+		ExecutorQualifier:  defaultQualifier,
+		Pool:               cfg.Executor.Pool,
+		IndexerAddress:     cfg.Executor.IndexerAddress,
+		PyroscopeURL:       cfg.PyroscopeURL,
+		TargetNOPs:         cfg.TargetNOPs,
+		RevokeOrphanedJobs: cfg.RevokeOrphanedJobs,
+	}
+
+	assert.Equal(t, want, deriveExecutorInput(cfg))
+}


### PR DESCRIPTION
## Description
Creates a wrapper changeset which defaults all qualifier fields to `default`. This is then given to `apply_verifier_config` and `apply_executor_config` to perform the actual changset logic with the results being bundled into a single changeset.

closes:
- https://smartcontract-it.atlassian.net/browse/CCIP-11953
- https://smartcontract-it.atlassian.net/browse/CCIP-11956

## Testing


## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
