### PR TITLE
ci: chain-selectors auto-update workflow fixes

### DIFF
--- a/.github/workflows/update-chain-selectors.yaml
+++ b/.github/workflows/update-chain-selectors.yaml
@@ -53,8 +53,8 @@ jobs:
         with:
           token: ${{ steps.issue-github-token.outputs.access-token }}
           branch: automation/update-chain-selectors
-          commit-message: "chore(deps): bump chain-selectors"
-          title: "chore(deps): bump chain-selectors"
+          commit-message: "fix(deps): bump chain-selectors"
+          title: "fix(deps): bump chain-selectors"
           body: |
             Updates github.com/smartcontractkit/chain-selectors in every Go module and runs `just tidy`.
           delete-branch: true

--- a/.github/workflows/update-chain-selectors.yaml
+++ b/.github/workflows/update-chain-selectors.yaml
@@ -37,6 +37,11 @@ jobs:
             go.sum
             **/go.sum
           go-version-file: go.mod
+      
+      - name: Install Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+        with:
+          just-version: '1.40.0'
 
       - name: Install module tools
         run: |

--- a/.github/workflows/update-chain-selectors.yaml
+++ b/.github/workflows/update-chain-selectors.yaml
@@ -40,8 +40,7 @@ jobs:
 
       - name: Install module tools
         run: |
-          go install github.com/jmank88/gomods@v0.1.6
-          go install github.com/jmank88/modgraph@v0.1.6
+          just install-go-tools
 
       - name: Update chain-selectors in every module
         run: gomods -c 'go get github.com/smartcontractkit/chain-selectors@latest'


### PR DESCRIPTION
## Description

Copy/pasta error copied the wrong version for modgraph - use `just install-go-tools` instead to always pull the right version.

Also changed the PR title from `chore(deps)` to `fix(deps)` because a chain-selectors bump usually warrants a new release, for chain expansion reasons.

## Testing

Tested the fixes here: https://github.com/smartcontractkit/chainlink-ccv/pull/1295

## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [x] Cross link related PRs (in this or other repositories)
