### PR TITLE
feat: Remove blocking mechanism in enqueue

### DIFF
--- a/aggregator/pkg/aggregation/aggregation_channel_manager.go
+++ b/aggregator/pkg/aggregation/aggregation_channel_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
-	"time"
 
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/common"
 	"github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/model"
@@ -41,7 +40,7 @@ func NewChannelManagerFromConfig(config *model.AggregatorConfig) *ChannelManager
 	return NewChannelManager(keys, config.Aggregation.ChannelBufferSize)
 }
 
-func (m *ChannelManager) Enqueue(ctx context.Context, key model.ChannelKey, req aggregationRequest, maxBlockTime time.Duration) error {
+func (m *ChannelManager) Enqueue(ctx context.Context, key model.ChannelKey, req aggregationRequest) error {
 	if m.closed.Load() {
 		return common.ErrShuttingDown
 	}
@@ -49,8 +48,6 @@ func (m *ChannelManager) Enqueue(ctx context.Context, key model.ChannelKey, req 
 	if !ok {
 		return fmt.Errorf("channel not found for key: %s", key)
 	}
-	timer := time.NewTimer(maxBlockTime)
-	defer timer.Stop()
 	select {
 	case ch <- req:
 		select {
@@ -58,10 +55,10 @@ func (m *ChannelManager) Enqueue(ctx context.Context, key model.ChannelKey, req 
 		default:
 		}
 		return nil
-	case <-timer.C:
-		return common.ErrAggregationChannelFull
 	case <-ctx.Done():
 		return ctx.Err()
+	default:
+		return common.ErrAggregationChannelFull
 	}
 }
 

--- a/aggregator/pkg/aggregation/aggregation_channel_manager_test.go
+++ b/aggregator/pkg/aggregation/aggregation_channel_manager_test.go
@@ -120,7 +120,7 @@ func TestNewChannelManagerFromConfig_ExtractsClientIDsAndAddsOrphanRecovery(t *t
 func TestEnqueue_SucceedsForExistingKey(t *testing.T) {
 	manager := NewChannelManager([]model.ChannelKey{"client1", "client2"}, 10)
 
-	err := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Second)
+	err := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"})
 
 	assert.NoError(t, err)
 }
@@ -128,7 +128,7 @@ func TestEnqueue_SucceedsForExistingKey(t *testing.T) {
 func TestEnqueue_ReturnsErrorForNonExistingKey(t *testing.T) {
 	manager := NewChannelManager([]model.ChannelKey{"client1"}, 10)
 
-	err := manager.Enqueue(context.Background(), "non_existing_key", aggregationRequest{ChannelKey: "non_existing_key"}, time.Millisecond)
+	err := manager.Enqueue(context.Background(), "non_existing_key", aggregationRequest{ChannelKey: "non_existing_key"})
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "channel not found")
@@ -137,44 +137,24 @@ func TestEnqueue_ReturnsErrorForNonExistingKey(t *testing.T) {
 func TestEnqueue_ReturnsErrorWhenChannelFull(t *testing.T) {
 	manager := NewChannelManager([]model.ChannelKey{"client1"}, 1)
 
-	err1 := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Second)
+	err1 := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"})
 	assert.NoError(t, err1)
 
-	err2 := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Millisecond)
+	err2 := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"})
 	assert.Error(t, err2)
+	assert.Equal(t, common.ErrAggregationChannelFull, err2)
 }
 
 func TestEnqueue_ReturnsErrorWhenContextAlreadyCancelled(t *testing.T) {
 	manager := NewChannelManager([]model.ChannelKey{"client1"}, 1)
-	_ = manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Second)
+	_ = manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := manager.Enqueue(ctx, "client1", aggregationRequest{ChannelKey: "client1"}, 5*time.Second)
+	err := manager.Enqueue(ctx, "client1", aggregationRequest{ChannelKey: "client1"})
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
-}
-
-func TestEnqueue_ReturnsErrorWhenContextCancelledWhileBlocking(t *testing.T) {
-	manager := NewChannelManager([]model.ChannelKey{"client1"}, 1)
-	_ = manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Second)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		cancel()
-	}()
-
-	start := time.Now()
-	err := manager.Enqueue(ctx, "client1", aggregationRequest{ChannelKey: "client1"}, 5*time.Second)
-	elapsed := time.Since(start)
-
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, context.Canceled)
-	assert.Less(t, elapsed, 5*time.Second, "Enqueue should return promptly on context cancellation")
 }
 
 func TestGetAggregationChannel_ReturnsNonNilChannel(t *testing.T) {
@@ -203,7 +183,7 @@ func TestStart_ForwardsRequestsFromClientChannelToAggregationChannel(t *testing.
 		ChannelKey:     "client1",
 	}
 
-	err := manager.Enqueue(context.Background(), "client1", expectedRequest, time.Second)
+	err := manager.Enqueue(context.Background(), "client1", expectedRequest)
 	require.NoError(t, err)
 
 	select {
@@ -261,7 +241,7 @@ func TestStart_ReceivesMultipleRequestsFromMultipleClients(t *testing.T) {
 			AggregationKey: "key-client1",
 			MessageID:      model.MessageID{byte(i)},
 			ChannelKey:     "client1",
-		}, time.Second)
+		})
 		require.NoError(t, err)
 	}
 
@@ -270,7 +250,7 @@ func TestStart_ReceivesMultipleRequestsFromMultipleClients(t *testing.T) {
 			AggregationKey: "key-client2",
 			MessageID:      model.MessageID{byte(i + 100)},
 			ChannelKey:     "client2",
-		}, time.Second)
+		})
 		require.NoError(t, err)
 	}
 
@@ -316,14 +296,14 @@ func TestStart_FairSchedulingPreventsBusyClientStarvation(t *testing.T) {
 		err := manager.Enqueue(context.Background(), "busy", aggregationRequest{
 			ChannelKey: "busy",
 			MessageID:  model.MessageID{byte(i)},
-		}, time.Second)
+		})
 		require.NoError(t, err)
 	}
 
 	err := manager.Enqueue(context.Background(), "quiet", aggregationRequest{
 		ChannelKey: "quiet",
 		MessageID:  model.MessageID{0xFF},
-	}, time.Second)
+	})
 	require.NoError(t, err)
 
 	received := make([]aggregationRequest, 0)
@@ -359,7 +339,7 @@ func TestEnqueue_RejectsAfterShutdown(t *testing.T) {
 	cancel()
 	<-startDone
 
-	err := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"}, time.Second)
+	err := manager.Enqueue(context.Background(), "client1", aggregationRequest{ChannelKey: "client1"})
 	assert.ErrorIs(t, err, common.ErrShuttingDown)
 }
 
@@ -372,14 +352,14 @@ func TestStart_DrainsFairlyOnShutdown(t *testing.T) {
 		err := manager.Enqueue(ctx, "client1", aggregationRequest{
 			ChannelKey: "client1",
 			MessageID:  model.MessageID{byte(i)},
-		}, time.Second)
+		})
 		require.NoError(t, err)
 	}
 	for i := range 3 {
 		err := manager.Enqueue(ctx, "client2", aggregationRequest{
 			ChannelKey: "client2",
 			MessageID:  model.MessageID{byte(i + 100)},
-		}, time.Second)
+		})
 		require.NoError(t, err)
 	}
 
@@ -426,7 +406,7 @@ func TestStart_ForwardsMidSendItemOnShutdown(t *testing.T) {
 	err := manager.Enqueue(context.Background(), "client1", aggregationRequest{
 		ChannelKey: "client1",
 		MessageID:  model.MessageID{1},
-	}, time.Second)
+	})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/aggregator/pkg/aggregation/aggregator.go
+++ b/aggregator/pkg/aggregation/aggregator.go
@@ -54,13 +54,13 @@ type aggregationRequest struct {
 }
 
 // CheckAggregation enqueues a new aggregation request for the specified message ID.
-func (c *CommitReportAggregator) CheckAggregation(ctx context.Context, messageID model.MessageID, aggregationKey model.AggregationKey, channelKey model.ChannelKey, maxBlockTime time.Duration) error {
+func (c *CommitReportAggregator) CheckAggregation(ctx context.Context, messageID model.MessageID, aggregationKey model.AggregationKey, channelKey model.ChannelKey) error {
 	request := aggregationRequest{
 		MessageID:      messageID,
 		AggregationKey: aggregationKey,
 		ChannelKey:     channelKey,
 	}
-	err := c.channelManager.Enqueue(ctx, channelKey, request, maxBlockTime)
+	err := c.channelManager.Enqueue(ctx, channelKey, request)
 	if err != nil {
 		return err
 	}

--- a/aggregator/pkg/aggregation/aggregator_test.go
+++ b/aggregator/pkg/aggregation/aggregator_test.go
@@ -308,7 +308,7 @@ func TestHealthCheck(t *testing.T) {
 			a := NewCommitReportAggregator(store, nil, sink, mocks.NewMockQuorumValidator(t), config, logger.Sugared(logger.Test(t)), monitoring, channelManager)
 
 			for i := 0; i < tc.pending; i++ {
-				_ = channelManager.Enqueue(t.Context(), "test-client", aggregationRequest{}, time.Millisecond)
+				_ = channelManager.Enqueue(t.Context(), "test-client", aggregationRequest{})
 			}
 			if tc.stopped {
 				a.done = make(chan struct{})
@@ -340,7 +340,7 @@ func TestCheckAggregation_EnqueueAndFull(t *testing.T) {
 		channelManager := NewChannelManager([]model.ChannelKey{"test-client"}, config.Aggregation.ChannelBufferSize)
 		a := NewCommitReportAggregator(store, nil, sink, mocks.NewMockQuorumValidator(t), config, logger.Sugared(logger.Test(t)), monitoring, channelManager)
 
-		err := a.CheckAggregation(t.Context(), []byte{1}, "test-key", "test-client", time.Millisecond)
+		err := a.CheckAggregation(t.Context(), []byte{1}, "test-key", "test-client")
 		require.NoError(t, err)
 	})
 
@@ -355,9 +355,9 @@ func TestCheckAggregation_EnqueueAndFull(t *testing.T) {
 		channelManager := NewChannelManager([]model.ChannelKey{"test-client"}, config.Aggregation.ChannelBufferSize)
 		a := NewCommitReportAggregator(store, nil, sink, mocks.NewMockQuorumValidator(t), config, logger.Sugared(logger.Test(t)), monitoring, channelManager)
 
-		_ = channelManager.Enqueue(t.Context(), "test-client", aggregationRequest{}, time.Millisecond)
+		_ = channelManager.Enqueue(t.Context(), "test-client", aggregationRequest{})
 
-		err := a.CheckAggregation(t.Context(), []byte{1}, "test-key", "test-client", time.Millisecond)
+		err := a.CheckAggregation(t.Context(), []byte{1}, "test-key", "test-client")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, common.ErrAggregationChannelFull)
 	})
@@ -567,14 +567,14 @@ func TestHealthCheck_RecoversPanicEmitsMetricAndKeepsRunning(t *testing.T) {
 	require.NoError(t, a.Ready())
 
 	// First request panics
-	_ = a.CheckAggregation(ctx, []byte{1, 2, 3}, "test-key", "test-client", time.Millisecond)
+	_ = a.CheckAggregation(ctx, []byte{1, 2, 3}, "test-key", "test-client")
 	time.Sleep(100 * time.Millisecond)
 
 	// Still healthy after panic - we now emit metrics instead of tracking consecutive panics
 	require.NoError(t, a.Ready())
 
 	// Second request succeeds
-	_ = a.CheckAggregation(ctx, []byte{4, 5, 6}, "test-key-2", "test-client", time.Millisecond)
+	_ = a.CheckAggregation(ctx, []byte{4, 5, 6}, "test-key-2", "test-client")
 	time.Sleep(100 * time.Millisecond)
 
 	require.NoError(t, a.Ready())
@@ -625,9 +625,9 @@ func TestHealthCheck_ReturnsErrorAfterConsecutiveWorkerFailures(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	require.NoError(t, a.Ready(), "should be ready after start")
 
-	_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client", time.Millisecond)
-	_ = a.CheckAggregation(ctx, []byte{2}, "key-2", "test-client", time.Millisecond)
-	_ = a.CheckAggregation(ctx, []byte{3}, "key-3", "test-client", time.Millisecond)
+	_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client")
+	_ = a.CheckAggregation(ctx, []byte{2}, "key-2", "test-client")
+	_ = a.CheckAggregation(ctx, []byte{3}, "key-3", "test-client")
 
 	require.Eventually(t, func() bool {
 		err := a.Ready()
@@ -638,7 +638,7 @@ func TestHealthCheck_ReturnsErrorAfterConsecutiveWorkerFailures(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "times in a row")
 
-	_ = a.CheckAggregation(ctx, []byte{4}, "key-4", "test-client", time.Millisecond)
+	_ = a.CheckAggregation(ctx, []byte{4}, "key-4", "test-client")
 
 	require.Eventually(t, func() bool {
 		return a.Ready() == nil
@@ -682,9 +682,9 @@ func TestStartBackground_Shutdown(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		a.StartBackground(ctx)
 
-		_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client", time.Second)
-		_ = a.CheckAggregation(ctx, []byte{2}, "key-2", "test-client", time.Second)
-		_ = a.CheckAggregation(ctx, []byte{3}, "key-3", "test-client", time.Second)
+		_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client")
+		_ = a.CheckAggregation(ctx, []byte{2}, "key-2", "test-client")
+		_ = a.CheckAggregation(ctx, []byte{3}, "key-3", "test-client")
 
 		time.Sleep(50 * time.Millisecond)
 		require.Equal(t, int32(0), processedCount.Load(), "no requests should be processed before drain")
@@ -728,7 +728,7 @@ func TestStartBackground_Shutdown(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		a.StartBackground(ctx)
 
-		_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client", time.Second)
+		_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client")
 
 		<-workerStarted
 		cancel()
@@ -773,7 +773,7 @@ func TestStartBackground_Shutdown(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		a.StartBackground(ctx)
 
-		_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client", time.Second)
+		_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client")
 		<-workerStarted
 		cancel()
 
@@ -806,7 +806,7 @@ func TestStartBackground_Shutdown(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		a.StartBackground(ctx)
 
-		_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client", time.Second)
+		_ = a.CheckAggregation(ctx, []byte{1}, "key-1", "test-client")
 
 		time.Sleep(50 * time.Millisecond)
 		cancel()

--- a/aggregator/pkg/handlers/batch_write_commit_verifier_node_result_test.go
+++ b/aggregator/pkg/handlers/batch_write_commit_verifier_node_result_test.go
@@ -76,7 +76,7 @@ func TestBatchWriteCommitCCVNodeDataHandler_BatchSizeValidation(t *testing.T) {
 					Signer: signer,
 				}, nil).Maybe()
 				sig.EXPECT().DeriveAggregationKey(mock.Anything, mock.Anything).Return("messageId", nil).Maybe()
-				agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey, time.Millisecond).Return(nil).Maybe()
+				agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey).Return(nil).Maybe()
 				store.EXPECT().SaveCommitVerification(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 			}
 
@@ -86,7 +86,7 @@ func TestBatchWriteCommitCCVNodeDataHandler_BatchSizeValidation(t *testing.T) {
 			labeler.EXPECT().With(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(labeler).Maybe()
 			labeler.EXPECT().IncrementVerificationsTotal(mock.Anything).Maybe()
 
-			writeHandler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, time.Millisecond, messagerules.NoopChecker{})
+			writeHandler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, messagerules.NoopChecker{})
 			batchHandler := NewBatchWriteCommitVerifierNodeResultHandler(writeHandler, tc.maxBatchSize)
 
 			requests := make([]*committeepb.WriteCommitteeVerifierNodeResultRequest, tc.numRequests)
@@ -132,7 +132,7 @@ func TestBatchWriteCommitCCVNodeDataHandler_MixedSuccessAndInvalidArgument(t *te
 	}, nil)
 	sig.EXPECT().DeriveAggregationKey(mock.Anything, mock.Anything).Return("messageId", nil)
 
-	agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey, time.Millisecond).Return(nil).Maybe()
+	agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey).Return(nil).Maybe()
 
 	store.EXPECT().SaveCommitVerification(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -142,7 +142,7 @@ func TestBatchWriteCommitCCVNodeDataHandler_MixedSuccessAndInvalidArgument(t *te
 	labeler.EXPECT().With(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(labeler).Maybe()
 	labeler.EXPECT().IncrementVerificationsTotal(mock.Anything).Maybe()
 
-	writeHandler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, time.Millisecond, messagerules.NoopChecker{})
+	writeHandler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, messagerules.NoopChecker{})
 	batchHandler := NewBatchWriteCommitVerifierNodeResultHandler(writeHandler, 10)
 
 	validReq := makeValidProtoRequest()
@@ -184,7 +184,7 @@ func TestBatchWriteCommitCCVNodeDataHandler_NilRequestAtIndexReturnsInvalidArgum
 		Signer: signer,
 	}, nil)
 	sig.EXPECT().DeriveAggregationKey(mock.Anything, mock.Anything).Return("messageId", nil)
-	agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey, time.Millisecond).Return(nil)
+	agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey).Return(nil)
 	store.EXPECT().SaveCommitVerification(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	mon := mocks.NewMockAggregatorMonitoring(t)
@@ -193,7 +193,7 @@ func TestBatchWriteCommitCCVNodeDataHandler_NilRequestAtIndexReturnsInvalidArgum
 	labeler.EXPECT().With(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(labeler).Maybe()
 	labeler.EXPECT().IncrementVerificationsTotal(mock.Anything).Maybe()
 
-	writeHandler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, time.Millisecond, messagerules.NoopChecker{})
+	writeHandler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, messagerules.NoopChecker{})
 	batchHandler := NewBatchWriteCommitVerifierNodeResultHandler(writeHandler, 10)
 
 	validReq := makeValidProtoRequest()
@@ -240,8 +240,8 @@ func TestBatchWriteCommitCCVNodeDataHandler_CancelledContextReturnsImmediately(t
 	sig.EXPECT().DeriveAggregationKey(mock.Anything, mock.Anything).Return("messageId", nil).Maybe()
 	store.EXPECT().SaveCommitVerification(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey, blockDuration).
-		RunAndReturn(func(ctx context.Context, _ model.MessageID, _ model.AggregationKey, _ model.ChannelKey, _ time.Duration) error {
+	agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey).
+		RunAndReturn(func(ctx context.Context, _ model.MessageID, _ model.AggregationKey, _ model.ChannelKey) error {
 			<-ctx.Done()
 			return ctx.Err()
 		}).Maybe()
@@ -252,7 +252,7 @@ func TestBatchWriteCommitCCVNodeDataHandler_CancelledContextReturnsImmediately(t
 	labeler.EXPECT().With(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(labeler).Maybe()
 	labeler.EXPECT().IncrementVerificationsTotal(mock.Anything).Maybe()
 
-	writeHandler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, blockDuration, messagerules.NoopChecker{})
+	writeHandler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, messagerules.NoopChecker{})
 	batchHandler := NewBatchWriteCommitVerifierNodeResultHandler(writeHandler, 10)
 
 	ctx, cancel := context.WithCancel(auth.ToContext(context.Background(), auth.CreateCallerIdentity(testCallerID, false)))

--- a/aggregator/pkg/handlers/write_commit_verifier_node_result.go
+++ b/aggregator/pkg/handlers/write_commit_verifier_node_result.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"strconv"
-	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -29,18 +28,17 @@ type SignatureValidator interface {
 // AggregationTriggerer defines an interface for triggering aggregation checks.
 type AggregationTriggerer interface {
 	// CheckAggregation triggers the aggregation process for the specified aggregation key.
-	CheckAggregation(ctx context.Context, messageID model.MessageID, aggregationKey model.AggregationKey, channelKey model.ChannelKey, maxBlockTime time.Duration) error
+	CheckAggregation(ctx context.Context, messageID model.MessageID, aggregationKey model.AggregationKey, channelKey model.ChannelKey) error
 }
 
 // WriteCommitVerifierNodeResultHandler handles requests to write commit verification records.
 type WriteCommitVerifierNodeResultHandler struct {
-	storage                 common.CommitVerificationStore
-	aggregator              AggregationTriggerer
-	m                       common.AggregatorMonitoring
-	l                       logger.SugaredLogger
-	signatureValidator      SignatureValidator
-	checkAggregationTimeout time.Duration
-	disablementChecker      messagerules.Checker
+	storage            common.CommitVerificationStore
+	aggregator         AggregationTriggerer
+	m                  common.AggregatorMonitoring
+	l                  logger.SugaredLogger
+	signatureValidator SignatureValidator
+	disablementChecker messagerules.Checker
 }
 
 func (h *WriteCommitVerifierNodeResultHandler) logger(ctx context.Context) logger.SugaredLogger {
@@ -120,7 +118,7 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 	)
 	metrics.IncrementVerificationsTotal(ctx)
 
-	if err := h.aggregator.CheckAggregation(ctx, record.MessageID, aggregationKey, model.ChannelKey(identity.CallerID), h.checkAggregationTimeout); err != nil {
+	if err := h.aggregator.CheckAggregation(ctx, record.MessageID, aggregationKey, model.ChannelKey(identity.CallerID)); err != nil {
 		if err == common.ErrAggregationChannelFull {
 			reqLogger.Errorf("Aggregation channel is full")
 			return &committeepb.WriteCommitteeVerifierNodeResultResponse{
@@ -141,17 +139,16 @@ func (h *WriteCommitVerifierNodeResultHandler) Handle(ctx context.Context, req *
 }
 
 // NewWriteCommitCCVNodeDataHandler creates a new instance of WriteCommitCCVNodeDataHandler.
-func NewWriteCommitCCVNodeDataHandler(store common.CommitVerificationStore, aggregator AggregationTriggerer, m common.AggregatorMonitoring, l logger.SugaredLogger, signatureValidator SignatureValidator, checkAggregationTimeout time.Duration, disablementChecker messagerules.Checker) *WriteCommitVerifierNodeResultHandler {
+func NewWriteCommitCCVNodeDataHandler(store common.CommitVerificationStore, aggregator AggregationTriggerer, m common.AggregatorMonitoring, l logger.SugaredLogger, signatureValidator SignatureValidator, disablementChecker messagerules.Checker) *WriteCommitVerifierNodeResultHandler {
 	if disablementChecker == nil {
 		disablementChecker = messagerules.NoopChecker{}
 	}
 	return &WriteCommitVerifierNodeResultHandler{
-		storage:                 store,
-		aggregator:              aggregator,
-		m:                       m,
-		l:                       l,
-		signatureValidator:      signatureValidator,
-		checkAggregationTimeout: checkAggregationTimeout,
-		disablementChecker:      disablementChecker,
+		storage:            store,
+		aggregator:         aggregator,
+		m:                  m,
+		l:                  l,
+		signatureValidator: signatureValidator,
+		disablementChecker: disablementChecker,
 	}
 }

--- a/aggregator/pkg/handlers/write_commit_verifier_node_result_test.go
+++ b/aggregator/pkg/handlers/write_commit_verifier_node_result_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -70,12 +69,12 @@ func TestWriteCommitCCVNodeDataHandler_MessageDisablementGate(t *testing.T) {
 
 	// None of these should be called when the message is disabled
 	store.EXPECT().SaveCommitVerification(mock.Anything, mock.Anything, mock.Anything).Maybe()
-	agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+	agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
 	sig.EXPECT().ValidateSignature(mock.Anything, mock.Anything).Maybe()
 	sig.EXPECT().DeriveAggregationKey(mock.Anything, mock.Anything).Maybe()
 	mon.EXPECT().Metrics().Maybe()
 
-	handler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, time.Millisecond, alwaysDisabledChecker{})
+	handler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, alwaysDisabledChecker{})
 	ctx := auth.ToContext(context.Background(), auth.CreateCallerIdentity(testCallerID, false))
 
 	resp, err := handler.Handle(ctx, makeValidProtoRequest())
@@ -216,13 +215,13 @@ func TestWriteCommitCCVNodeDataHandler_Handle_Table(t *testing.T) {
 			var lastMsgID model.MessageID
 			var lastAggregation model.AggregationKey
 			if tc.expectAggCalls > 0 {
-				agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey, time.Millisecond).Run(func(_ context.Context, m model.MessageID, a model.AggregationKey, _ model.ChannelKey, _ time.Duration) {
+				agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, testChannelKey).Run(func(_ context.Context, m model.MessageID, a model.AggregationKey, _ model.ChannelKey) {
 					aggCalled++
 					lastMsgID = m
 					lastAggregation = a
 				}).Return(tc.aggErr).Times(tc.expectAggCalls)
 			} else {
-				agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+				agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
 			}
 
 			mon := mocks.NewMockAggregatorMonitoring(t)
@@ -231,7 +230,7 @@ func TestWriteCommitCCVNodeDataHandler_Handle_Table(t *testing.T) {
 			labeler.EXPECT().With(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(labeler).Maybe()
 			labeler.EXPECT().IncrementVerificationsTotal(mock.Anything).Maybe()
 
-			handler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, time.Millisecond, messagerules.NoopChecker{})
+			handler := NewWriteCommitCCVNodeDataHandler(store, agg, mon, lggr, sig, messagerules.NoopChecker{})
 
 			ctx := auth.ToContext(context.Background(), auth.CreateCallerIdentity(testCallerID, false))
 			resp, err := handler.Handle(ctx, tc.req)

--- a/aggregator/pkg/model/config.go
+++ b/aggregator/pkg/model/config.go
@@ -166,10 +166,6 @@ type AggregationConfig struct {
 	ChannelBufferSize int `toml:"channelBufferSize"`
 	// BackgroundWorkerCount controls the number of background workers processing aggregation requests
 	BackgroundWorkerCount int `toml:"backgroundWorkerCount"`
-	// CheckAggregationTimeout is the timeout for each check aggregation operation in the write commit verifier node result handler.
-	// Consider the batch size when setting this value. A larger batch size will require a longer timeout.
-	// Example: "5s", "100ms", "1m"
-	CheckAggregationTimeout time.Duration `toml:"checkAggregationTimeout"`
 	// OperationTimeout is the timeout for each aggregation operation (0 = no timeout)
 	OperationTimeout time.Duration `toml:"operationTimeout"`
 	// DrainTimeout bounds how long shutdown waits for in-flight aggregation workers to complete.
@@ -679,15 +675,11 @@ func (c *AggregatorConfig) SetDefaults() {
 	}
 	// Aggregation defaults
 	if c.Aggregation.ChannelBufferSize == 0 {
-		// Set to 10 by default matching the number of background workers
-		c.Aggregation.ChannelBufferSize = 10
+		// Set to MaxCommitVerifierNodeResultRequestsPerBatch * 2 by default to allow for some buffering of requests
+		c.Aggregation.ChannelBufferSize = c.MaxCommitVerifierNodeResultRequestsPerBatch * 2
 	}
 	if c.Aggregation.BackgroundWorkerCount == 0 {
 		c.Aggregation.BackgroundWorkerCount = 10
-	}
-	// Default check aggregation timeout: 5 seconds
-	if c.Aggregation.CheckAggregationTimeout == 0 {
-		c.Aggregation.CheckAggregationTimeout = 5 * time.Second
 	}
 	if c.Aggregation.DrainTimeout == 0 {
 		c.Aggregation.DrainTimeout = 10 * time.Second
@@ -850,9 +842,6 @@ func (c *AggregatorConfig) ValidateAggregationConfig() error {
 	}
 	if c.Aggregation.DrainTimeout > 5*time.Minute {
 		return errors.New("aggregation.drainTimeout cannot exceed 5 minutes")
-	}
-	if c.Aggregation.CheckAggregationTimeout <= 0 {
-		return errors.New("aggregation.checkAggregationTimeout must be greater than 0")
 	}
 
 	return nil
@@ -1064,6 +1053,11 @@ func (c *AggregatorConfig) ValidateWithoutSecrets() error {
 	// Validate orphan recovery configuration
 	if err := c.ValidateOrphanRecoveryConfig(); err != nil {
 		return fmt.Errorf("orphan recovery configuration error: %w", err)
+	}
+
+	// Validate that the client channel buffer size is sufficient for the batch size
+	if c.Aggregation.ChannelBufferSize < c.MaxCommitVerifierNodeResultRequestsPerBatch {
+		return fmt.Errorf("aggregation channel buffer size (%d) is smaller than the max commit verifier node result requests per batch (%d). Large batch will be rejected instantly", c.Aggregation.ChannelBufferSize, c.MaxCommitVerifierNodeResultRequestsPerBatch)
 	}
 
 	return nil

--- a/aggregator/pkg/model/config_test.go
+++ b/aggregator/pkg/model/config_test.go
@@ -67,7 +67,7 @@ func TestSetDefaults(t *testing.T) {
 
 		assert.Equal(t, 100, cfg.MaxMessageIDsPerBatch)
 		assert.Equal(t, 100, cfg.MaxCommitVerifierNodeResultRequestsPerBatch)
-		assert.Equal(t, 10, cfg.Aggregation.ChannelBufferSize)
+		assert.Equal(t, 200, cfg.Aggregation.ChannelBufferSize)
 		assert.Equal(t, 10, cfg.Aggregation.BackgroundWorkerCount)
 		assert.NotNil(t, cfg.Storage)
 		assert.Equal(t, 100, cfg.Storage.PageSize)
@@ -79,7 +79,6 @@ func TestSetDefaults(t *testing.T) {
 		assert.Equal(t, 168*time.Hour, cfg.OrphanRecovery.MaxAge)
 		assert.Equal(t, "8080", cfg.HealthCheck.Port)
 		assert.Equal(t, 10*time.Second, cfg.Server.RequestTimeout)
-		assert.Equal(t, 5*time.Second, cfg.Aggregation.CheckAggregationTimeout)
 		assert.Equal(t, 10*time.Second, cfg.Aggregation.DrainTimeout)
 		assert.Equal(t, 5*time.Second, cfg.OrphanRecovery.CheckAggregationTimeout)
 		assert.Equal(t, common.Duration(10*time.Second), cfg.Storage.QueryTimeout)
@@ -262,10 +261,9 @@ func TestValidateBatchConfig(t *testing.T) {
 
 func TestValidateAggregationConfig(t *testing.T) {
 	validBase := AggregationConfig{
-		ChannelBufferSize:       10,
-		BackgroundWorkerCount:   10,
-		CheckAggregationTimeout: 5 * time.Second,
-		DrainTimeout:            30 * time.Second,
+		ChannelBufferSize:     10,
+		BackgroundWorkerCount: 10,
+		DrainTimeout:          30 * time.Second,
 	}
 
 	tests := []struct {
@@ -327,12 +325,6 @@ func TestValidateAggregationConfig(t *testing.T) {
 			expectError: true,
 			errorMsg:    "drainTimeout cannot exceed 5 minutes",
 		},
-		{
-			name:        "negative check aggregation timeout fails",
-			mutate:      func(c *AggregationConfig) { c.CheckAggregationTimeout = -1 },
-			expectError: true,
-			errorMsg:    "aggregation.checkAggregationTimeout must be greater than 0",
-		},
 	}
 
 	for _, tt := range tests {
@@ -341,6 +333,54 @@ func TestValidateAggregationConfig(t *testing.T) {
 			tt.mutate(&config)
 			cfg := &AggregatorConfig{Aggregation: config}
 			err := cfg.ValidateAggregationConfig()
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateWithoutSecrets_ChannelBufferSizeVsBatchSize(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(c *AggregatorConfig)
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "buffer smaller than batch size fails",
+			mutate: func(c *AggregatorConfig) {
+				c.MaxCommitVerifierNodeResultRequestsPerBatch = 100
+				c.Aggregation.ChannelBufferSize = 50
+			},
+			expectError: true,
+			errorMsg:    "aggregation channel buffer size (50) is smaller than the max commit verifier node result requests per batch (100)",
+		},
+		{
+			name: "buffer equal to batch size passes",
+			mutate: func(c *AggregatorConfig) {
+				c.MaxCommitVerifierNodeResultRequestsPerBatch = 100
+				c.Aggregation.ChannelBufferSize = 100
+			},
+			expectError: false,
+		},
+		{
+			name:        "default buffer size accommodates default batch size",
+			mutate:      func(_ *AggregatorConfig) {},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createMinimalValidConfig()
+			tt.mutate(cfg)
+
+			err := cfg.ValidateWithoutSecrets()
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/aggregator/pkg/orphan_recoverer.go
+++ b/aggregator/pkg/orphan_recoverer.go
@@ -181,7 +181,7 @@ func (o *OrphanRecoverer) RecoverOrphans(ctx context.Context) error {
 
 // processOrphanedRecord attempts to re-aggregate an orphaned verification record.
 func (o *OrphanRecoverer) processOrphanedRecord(ctx context.Context, record model.OrphanedKey) error {
-	err := o.aggregator.CheckAggregation(ctx, record.MessageID, record.AggregationKey, model.OrphanRecoveryChannelKey, o.config.OrphanRecovery.CheckAggregationTimeout)
+	err := o.aggregator.CheckAggregation(ctx, record.MessageID, record.AggregationKey, model.OrphanRecoveryChannelKey)
 	if err != nil {
 		return fmt.Errorf("failed to trigger aggregation check: %w", err)
 	}

--- a/aggregator/pkg/orphan_recoverer_test.go
+++ b/aggregator/pkg/orphan_recoverer_test.go
@@ -282,8 +282,8 @@ func TestOrphanRecoverer_RecoverOrphans_MaxOrphansPerScanEnforced(t *testing.T) 
 			store.EXPECT().ListOrphanedKeys(mock.Anything, mock.Anything, mock.Anything).Return(orphansChan, errChan)
 
 			var checkAggCount atomic.Int32
-			agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, model.OrphanRecoveryChannelKey, mock.Anything).
-				RunAndReturn(func(_ context.Context, _ model.MessageID, _ model.AggregationKey, _ model.ChannelKey, _ time.Duration) error {
+			agg.EXPECT().CheckAggregation(mock.Anything, mock.Anything, mock.Anything, model.OrphanRecoveryChannelKey).
+				RunAndReturn(func(_ context.Context, _ model.MessageID, _ model.AggregationKey, _ model.ChannelKey) error {
 					checkAggCount.Add(1)
 					return nil
 				}).Maybe()

--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -344,7 +344,7 @@ func NewServer(l logger.SugaredLogger, config *model.AggregatorConfig, aggMonito
 
 	agg := createAggregator(store, store, store, validator, config, l, aggMonitoring)
 
-	writeCommitVerifierNodeResultHandler := handlers.NewWriteCommitCCVNodeDataHandler(store, agg, aggMonitoring, l, validator, config.Aggregation.CheckAggregationTimeout, messageDisablementRegistry)
+	writeCommitVerifierNodeResultHandler := handlers.NewWriteCommitCCVNodeDataHandler(store, agg, aggMonitoring, l, validator, messageDisablementRegistry)
 	readCommitVerifierNodeResultHandler := handlers.NewReadCommitVerifierNodeResultHandler(store, l)
 	getMessagesSinceHandler := handlers.NewGetMessagesSinceHandler(store, config.Committee, l, aggMonitoring)
 	getVerifierResultsForMessageHandler := handlers.NewGetVerifierResultsForMessageHandler(store, config.Committee, config.MaxMessageIDsPerBatch, l)

--- a/build/devenv/tests/services/aggregator_test.go
+++ b/build/devenv/tests/services/aggregator_test.go
@@ -447,13 +447,16 @@ func setupAggregatorTestFixture(t *testing.T) *aggregatorTestFixture {
 	// Setup aggregator with 2-of-3 threshold
 	sourceChainSelStr := fmt.Sprintf("%d", sourceChainSel)
 	out, err := services.NewAggregator(&services.AggregatorInput{
-		CommitteeName:                committeeName,
-		Image:                        "aggregator:latest",
-		HostPort:                     8110,
-		ExposedHostPort:              grpcHostPort, // Expose gRPC port directly for test
-		SourceCodePath:               "../../../aggregator",
-		RootPath:                     "../../../../",
-		AggregationChannelBufferSize: 1, // Minimal buffer for channel exhaustion tests
+		CommitteeName:   committeeName,
+		Image:           "aggregator:latest",
+		HostPort:        8110,
+		ExposedHostPort: grpcHostPort, // Expose gRPC port directly for test
+		SourceCodePath:  "../../../aggregator",
+		RootPath:        "../../../../",
+		// Buffer must be >= the default max batch size (100, config validation), so it can't be made
+		// artificially tiny here. Sized with headroom above 100 so a max-size batch still fits
+		// alongside any requests left over from earlier subtests in this single slow-draining worker.
+		AggregationChannelBufferSize: 150,
 		BackgroundWorkerCount:        1, // Single worker = slow drain for deterministic tests
 		DB: &services.AggregatorDBInput{
 			Image:    "postgres:16-alpine",

--- a/docs/config/aggregator/config.documented.toml
+++ b/docs/config/aggregator/config.documented.toml
@@ -94,13 +94,9 @@ maxCommitVerifierNodeResultRequestsPerBatch = 100
 # aggregation configures the signature-aggregation workers.
 [aggregation]
   # channelBufferSize controls the size of the aggregation request channel buffer
-  channelBufferSize = 10
+  channelBufferSize = 200
   # backgroundWorkerCount controls the number of background workers processing aggregation requests
   backgroundWorkerCount = 10
-  # checkAggregationTimeout is the timeout for each check aggregation operation in the write commit verifier node result handler.
-  # Consider the batch size when setting this value. A larger batch size will require a longer timeout.
-  # Example: "5s", "100ms", "1m"
-  checkAggregationTimeout = "5s"
   # operationTimeout is the timeout for each aggregation operation (0 = no timeout)
   operationTimeout = "0s"
   # drainTimeout bounds how long shutdown waits for in-flight aggregation workers to complete.

--- a/internal/mocks/mock_AggregationTriggerer.go
+++ b/internal/mocks/mock_AggregationTriggerer.go
@@ -5,8 +5,6 @@ package mocks
 import (
 	context "context"
 
-	time "time"
-
 	model "github.com/smartcontractkit/chainlink-ccv/aggregator/pkg/model"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -24,17 +22,17 @@ func (_m *MockAggregationTriggerer) EXPECT() *MockAggregationTriggerer_Expecter 
 	return &MockAggregationTriggerer_Expecter{mock: &_m.Mock}
 }
 
-// CheckAggregation provides a mock function with given fields: ctx, messageID, aggregationKey, channelKey, maxBlockTime
-func (_m *MockAggregationTriggerer) CheckAggregation(ctx context.Context, messageID []byte, aggregationKey string, channelKey model.ChannelKey, maxBlockTime time.Duration) error {
-	ret := _m.Called(ctx, messageID, aggregationKey, channelKey, maxBlockTime)
+// CheckAggregation provides a mock function with given fields: ctx, messageID, aggregationKey, channelKey
+func (_m *MockAggregationTriggerer) CheckAggregation(ctx context.Context, messageID []byte, aggregationKey string, channelKey model.ChannelKey) error {
+	ret := _m.Called(ctx, messageID, aggregationKey, channelKey)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckAggregation")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, string, model.ChannelKey, time.Duration) error); ok {
-		r0 = rf(ctx, messageID, aggregationKey, channelKey, maxBlockTime)
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, string, model.ChannelKey) error); ok {
+		r0 = rf(ctx, messageID, aggregationKey, channelKey)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -52,14 +50,13 @@ type MockAggregationTriggerer_CheckAggregation_Call struct {
 //   - messageID []byte
 //   - aggregationKey string
 //   - channelKey model.ChannelKey
-//   - maxBlockTime time.Duration
-func (_e *MockAggregationTriggerer_Expecter) CheckAggregation(ctx interface{}, messageID interface{}, aggregationKey interface{}, channelKey interface{}, maxBlockTime interface{}) *MockAggregationTriggerer_CheckAggregation_Call {
-	return &MockAggregationTriggerer_CheckAggregation_Call{Call: _e.mock.On("CheckAggregation", ctx, messageID, aggregationKey, channelKey, maxBlockTime)}
+func (_e *MockAggregationTriggerer_Expecter) CheckAggregation(ctx interface{}, messageID interface{}, aggregationKey interface{}, channelKey interface{}) *MockAggregationTriggerer_CheckAggregation_Call {
+	return &MockAggregationTriggerer_CheckAggregation_Call{Call: _e.mock.On("CheckAggregation", ctx, messageID, aggregationKey, channelKey)}
 }
 
-func (_c *MockAggregationTriggerer_CheckAggregation_Call) Run(run func(ctx context.Context, messageID []byte, aggregationKey string, channelKey model.ChannelKey, maxBlockTime time.Duration)) *MockAggregationTriggerer_CheckAggregation_Call {
+func (_c *MockAggregationTriggerer_CheckAggregation_Call) Run(run func(ctx context.Context, messageID []byte, aggregationKey string, channelKey model.ChannelKey)) *MockAggregationTriggerer_CheckAggregation_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]byte), args[2].(string), args[3].(model.ChannelKey), args[4].(time.Duration))
+		run(args[0].(context.Context), args[1].([]byte), args[2].(string), args[3].(model.ChannelKey))
 	})
 	return _c
 }
@@ -69,7 +66,7 @@ func (_c *MockAggregationTriggerer_CheckAggregation_Call) Return(_a0 error) *Moc
 	return _c
 }
 
-func (_c *MockAggregationTriggerer_CheckAggregation_Call) RunAndReturn(run func(context.Context, []byte, string, model.ChannelKey, time.Duration) error) *MockAggregationTriggerer_CheckAggregation_Call {
+func (_c *MockAggregationTriggerer_CheckAggregation_Call) RunAndReturn(run func(context.Context, []byte, string, model.ChannelKey) error) *MockAggregationTriggerer_CheckAggregation_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Aggregator will reject any write request once the specific client channel reaches its limit. This will free up requests and allow more efficient resource usage under higher load.

Previously clients filling up their channel would still wait 5 seconds before Enqueue release the request. Under higher load this cause unnecessary pressure on the aggregator