### PR TITLE
fix: replace the empty executor args and token args with real optional params

### DIFF
--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -58,10 +58,9 @@ type EVMTXGun struct {
 	nonce               sync.Map              // map[NonceKey]*uint64
 	messageProfiles     []load.MessageProfileConfig
 	userSelector        map[uint64]func() *bind.TransactOpts
-	executorArgsParams  any                // optional, passed to BuildV3ExtraArgs
-	tokenReceiverParams any                // optional, passed to BuildV3ExtraArgs
-	tokenArgsParams     any                // optional, passed to BuildV3ExtraArgs
-	finalityOverride    *protocol.Finality // optional, overrides random finality; nil = random (existing behavior)
+	executorArgsParams  any // optional, passed to BuildV3ExtraArgs
+	tokenReceiverParams any // optional, passed to BuildV3ExtraArgs
+	tokenArgsParams     any // optional, passed to BuildV3ExtraArgs
 }
 
 // CloseSentChannel closes the sent messages channel to signal no more messages will be sent.
@@ -122,17 +121,6 @@ func WithTokenReceiverParams(params any) EVMTXGunOption {
 func WithTokenArgsParams(params any) EVMTXGunOption {
 	return func(g *EVMTXGun) {
 		g.tokenArgsParams = params
-	}
-}
-
-// WithFinalityConfig overrides the per-message finality selection.
-// By default the gun randomly picks between finality 0 (wait-for-finality)
-// and 1 (1-block depth) per message. Set this to force a specific finality
-// for all messages — e.g. protocol.Finality(1) for fast finality on chains
-// with slow finality (Sepolia ~12 min).
-func WithFinalityConfig(f protocol.Finality) EVMTXGunOption {
-	return func(g *EVMTXGun) {
-		g.finalityOverride = &f
 	}
 }
 
@@ -401,17 +389,9 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 	}
 
 	// generate a random finality between 0 (chain default finality) and 1 (custom finality)
-	// unless overridden by WithFinalityConfig, in Devnet(Anvil): we have 1~2 second instant finality, but in Sepolia, finality is ~12 minutes
-	// TODO: any reason we have to randomly generate finality ? finality should be passed from caller rather than randomly generated
-	var finalityVal int64
-	if m.finalityOverride != nil {
-		finalityVal = int64(*m.finalityOverride)
-	} else {
-		finality, err := rand.Int(rand.Reader, big.NewInt(2))
-		if err != nil {
-			return cciptestinterfaces.MessageFields{}, cciptestinterfaces.MessageOptions{}, fmt.Errorf("failed to generate finality: %w", err)
-		}
-		finalityVal = finality.Int64()
+	finality, err := rand.Int(rand.Reader, big.NewInt(2))
+	if err != nil {
+		return cciptestinterfaces.MessageFields{}, cciptestinterfaces.MessageOptions{}, fmt.Errorf("failed to generate finality: %w", err)
 	}
 	if m.testConfig == nil || m.testConfig.Messages == nil {
 		return cciptestinterfaces.MessageFields{
@@ -419,7 +399,7 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 				Data:     []byte{},
 				FeeToken: protocol.UnknownAddress(common.HexToAddress(wethContract.Address).Bytes()),
 			}, cciptestinterfaces.MessageOptions{
-				FinalityConfig: protocol.Finality(finalityVal),
+				FinalityConfig: protocol.Finality(finality.Int64()),
 				CCVs: []protocol.CCV{
 					{
 						CCVAddress: common.HexToAddress(committeeVerifierProxyRef.Address).Bytes(),
@@ -439,12 +419,7 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 		Data:     []byte{},
 		FeeToken: protocol.UnknownAddress(common.HexToAddress(wethContract.Address).Bytes()),
 	}
-	var finalityForOpts protocol.Finality
-	if m.finalityOverride != nil {
-		finalityForOpts = *m.finalityOverride
-	} else {
-		finalityForOpts = protocol.Finality(messageProfile.Finality)
-	}
+	var finalityForOpts protocol.Finality = protocol.Finality(messageProfile.Finality)
 	opts := cciptestinterfaces.MessageOptions{
 		FinalityConfig: finalityForOpts,
 	}

--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -101,7 +101,7 @@ func NewEVMTransactionGun(cfg *ccv.Cfg, e *deployment.Environment, selectors []u
 type EVMTXGunOption func(*EVMTXGun)
 
 // WithExecutorArgsParams sets the executorArgsParams passed to BuildV3ExtraArgs.
-// Use this when the destination chain requires chain-specific executor args
+// Params are forwarded to the destination chain's MessageV3Destination.GetExecutorArgs implementation (applied for all destinations used by this gun).
 func WithExecutorArgsParams(params any) EVMTXGunOption {
 	return func(g *EVMTXGun) {
 		g.executorArgsParams = params
@@ -109,7 +109,7 @@ func WithExecutorArgsParams(params any) EVMTXGunOption {
 }
 
 // WithTokenReceiverParams sets the tokenReceiverParams passed to BuildV3ExtraArgs.
-// Use this when the destination chain requires chain-specific token receiver args
+// Params are forwarded to the destination chain's MessageV3Destination.GetTokenReceiver implementation (applied for all destinations used by this gun).
 func WithTokenReceiverParams(params any) EVMTXGunOption {
 	return func(g *EVMTXGun) {
 		g.tokenReceiverParams = params
@@ -117,7 +117,7 @@ func WithTokenReceiverParams(params any) EVMTXGunOption {
 }
 
 // WithTokenArgsParams sets the tokenArgsParams passed to BuildV3ExtraArgs.
-// Use this when the destination chain requires chain-specific token args
+// Params are forwarded to the destination chain's MessageV3Destination.GetTokenArgs implementation (applied for all destinations used by this gun).
 func WithTokenArgsParams(params any) EVMTXGunOption {
 	return func(g *EVMTXGun) {
 		g.tokenArgsParams = params
@@ -160,7 +160,9 @@ func NewEVMTransactionGunFromTestConfig(cfg *ccv.Cfg, testProfile *load.TestProf
 		userSelector:    userSelector,
 	}
 	for _, opt := range opts {
-		opt(g)
+		if opt != nil {
+			opt(g)
+		}
 	}
 	return g
 }
@@ -358,7 +360,7 @@ func (m *EVMTXGun) buildExtraArgs(srcSelector uint64, dest destLoadInfo, opts cc
 		}
 	}
 
-	// Receiver is in MessageFields; token params nil for data only load
+	// Receiver is in MessageFields; optional extra-args params are passed through to BuildV3ExtraArgs.
 	return v3Src.BuildV3ExtraArgs(v3Opts, v3Dest, m.executorArgsParams, m.tokenReceiverParams, m.tokenArgsParams)
 }
 

--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -419,9 +419,8 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 		Data:     []byte{},
 		FeeToken: protocol.UnknownAddress(common.HexToAddress(wethContract.Address).Bytes()),
 	}
-	var finalityForOpts protocol.Finality = protocol.Finality(messageProfile.Finality)
 	opts := cciptestinterfaces.MessageOptions{
-		FinalityConfig: finalityForOpts,
+		FinalityConfig: protocol.Finality(messageProfile.Finality),
 	}
 
 	if messageProfile.HasData {

--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -58,9 +58,10 @@ type EVMTXGun struct {
 	nonce               sync.Map              // map[NonceKey]*uint64
 	messageProfiles     []load.MessageProfileConfig
 	userSelector        map[uint64]func() *bind.TransactOpts
-	executorArgsParams  any // optional, passed to BuildV3ExtraArgs
-	tokenReceiverParams any // optional, passed to BuildV3ExtraArgs
-	tokenArgsParams     any // optional, passed to BuildV3ExtraArgs
+	executorArgsParams  any                // optional, passed to BuildV3ExtraArgs
+	tokenReceiverParams any                // optional, passed to BuildV3ExtraArgs
+	tokenArgsParams     any                // optional, passed to BuildV3ExtraArgs
+	finalityOverride    *protocol.Finality // optional, overrides random finality; nil = random (existing behavior)
 }
 
 // CloseSentChannel closes the sent messages channel to signal no more messages will be sent.
@@ -121,6 +122,17 @@ func WithTokenReceiverParams(params any) EVMTXGunOption {
 func WithTokenArgsParams(params any) EVMTXGunOption {
 	return func(g *EVMTXGun) {
 		g.tokenArgsParams = params
+	}
+}
+
+// WithFinalityConfig overrides the per-message finality selection.
+// By default the gun randomly picks between finality 0 (wait-for-finality)
+// and 1 (1-block depth) per message. Set this to force a specific finality
+// for all messages — e.g. protocol.Finality(1) for fast finality on chains
+// with slow finality (Sepolia ~12 min).
+func WithFinalityConfig(f protocol.Finality) EVMTXGunOption {
+	return func(g *EVMTXGun) {
+		g.finalityOverride = &f
 	}
 }
 
@@ -389,17 +401,24 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 	}
 
 	// generate a random finality between 0 (chain default finality) and 1 (custom finality)
-	finality, err := rand.Int(rand.Reader, big.NewInt(2))
-	if err != nil {
-		return cciptestinterfaces.MessageFields{}, cciptestinterfaces.MessageOptions{}, fmt.Errorf("failed to generate finality: %w", err)
+	// unless overridden by WithFinalityConfig
+	var finalityVal int64
+	if m.finalityOverride != nil {
+		finalityVal = int64(*m.finalityOverride)
+	} else {
+		finality, err := rand.Int(rand.Reader, big.NewInt(2))
+		if err != nil {
+			return cciptestinterfaces.MessageFields{}, cciptestinterfaces.MessageOptions{}, fmt.Errorf("failed to generate finality: %w", err)
+		}
+		finalityVal = finality.Int64()
 	}
 	if m.testConfig == nil || m.testConfig.Messages == nil {
 		return cciptestinterfaces.MessageFields{
 				Receiver: receiver,
 				Data:     []byte{},
-				FeeToken: protocol.UnknownAddress(common.HexToAddress(wethContract.Address).Bytes()),
+				FeeToken: common.HexToAddress(wethContract.Address).Bytes(),
 			}, cciptestinterfaces.MessageOptions{
-				FinalityConfig: protocol.Finality(finality.Int64()),
+				FinalityConfig: protocol.Finality(finalityVal),
 				CCVs: []protocol.CCV{
 					{
 						CCVAddress: common.HexToAddress(committeeVerifierProxyRef.Address).Bytes(),
@@ -420,7 +439,7 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 		FeeToken: protocol.UnknownAddress(common.HexToAddress(wethContract.Address).Bytes()),
 	}
 	opts := cciptestinterfaces.MessageOptions{
-		FinalityConfig: protocol.Finality(messageProfile.Finality),
+		FinalityConfig: protocol.Finality(finalityVal),
 	}
 
 	if messageProfile.HasData {

--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -401,7 +401,8 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 	}
 
 	// generate a random finality between 0 (chain default finality) and 1 (custom finality)
-	// unless overridden by WithFinalityConfig
+	// unless overridden by WithFinalityConfig, in Devnet(Anvil): we have 1~2 second instant finality, but in Sepolia, finality is ~12 minutes
+	// TODO: any reason we have to randomly generate finality ? finality should be passed from caller rather than randomly generated
 	var finalityVal int64
 	if m.finalityOverride != nil {
 		finalityVal = int64(*m.finalityOverride)
@@ -416,7 +417,7 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 		return cciptestinterfaces.MessageFields{
 				Receiver: receiver,
 				Data:     []byte{},
-				FeeToken: common.HexToAddress(wethContract.Address).Bytes(),
+				FeeToken: protocol.UnknownAddress(common.HexToAddress(wethContract.Address).Bytes()),
 			}, cciptestinterfaces.MessageOptions{
 				FinalityConfig: protocol.Finality(finalityVal),
 				CCVs: []protocol.CCV{
@@ -438,8 +439,14 @@ func (m *EVMTXGun) selectMessageProfile(srcSelector uint64, dest destLoadInfo) (
 		Data:     []byte{},
 		FeeToken: protocol.UnknownAddress(common.HexToAddress(wethContract.Address).Bytes()),
 	}
+	var finalityForOpts protocol.Finality
+	if m.finalityOverride != nil {
+		finalityForOpts = *m.finalityOverride
+	} else {
+		finalityForOpts = protocol.Finality(messageProfile.Finality)
+	}
 	opts := cciptestinterfaces.MessageOptions{
-		FinalityConfig: protocol.Finality(finalityVal),
+		FinalityConfig: finalityForOpts,
 	}
 
 	if messageProfile.HasData {

--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -44,20 +44,23 @@ type NonceKey struct {
 var _ load.LoadGun = (*EVMTXGun)(nil)
 
 type EVMTXGun struct {
-	cfg             *ccv.Cfg
-	testConfig      *load.TestProfileConfig
-	e               *deployment.Environment
-	selectors       []uint64
-	impl            map[uint64]cciptestinterfaces.CCIP17
-	sentMsgSet      map[load.SentMessage]struct{}
-	srcSelectors    []uint64
-	destSelectors   []uint64
-	seqNosMu        sync.Mutex
-	sentMsgCh       chan load.SentMessage // Channel for real-time message notifications
-	closeOnce       sync.Once             // Ensure channel is closed only once
-	nonce           sync.Map              // map[NonceKey]*uint64
-	messageProfiles []load.MessageProfileConfig
-	userSelector    map[uint64]func() *bind.TransactOpts
+	cfg                 *ccv.Cfg
+	testConfig          *load.TestProfileConfig
+	e                   *deployment.Environment
+	selectors           []uint64
+	impl                map[uint64]cciptestinterfaces.CCIP17
+	sentMsgSet          map[load.SentMessage]struct{}
+	srcSelectors        []uint64
+	destSelectors       []uint64
+	seqNosMu            sync.Mutex
+	sentMsgCh           chan load.SentMessage // Channel for real-time message notifications
+	closeOnce           sync.Once             // Ensure channel is closed only once
+	nonce               sync.Map              // map[NonceKey]*uint64
+	messageProfiles     []load.MessageProfileConfig
+	userSelector        map[uint64]func() *bind.TransactOpts
+	executorArgsParams  any // optional, passed to BuildV3ExtraArgs; nil = no executor args (existing behavior)
+	tokenReceiverParams any // optional, passed to BuildV3ExtraArgs; nil = no token receiver
+	tokenArgsParams     any // optional, passed to BuildV3ExtraArgs; nil = no token args
 }
 
 // CloseSentChannel closes the sent messages channel to signal no more messages will be sent.
@@ -94,7 +97,34 @@ func NewEVMTransactionGun(cfg *ccv.Cfg, e *deployment.Environment, selectors []u
 	}, nil
 }
 
-func NewEVMTransactionGunFromTestConfig(cfg *ccv.Cfg, testProfile *load.TestProfileConfig, messageProfiles []load.MessageProfileConfig, e *deployment.Environment, impls map[uint64]cciptestinterfaces.CCIP17) *EVMTXGun {
+// EVMTXGunOption configures an EVMTXGun at construction time.
+type EVMTXGunOption func(*EVMTXGun)
+
+// WithExecutorArgsParams sets the executorArgsParams passed to BuildV3ExtraArgs.
+// Use this when the destination chain requires chain-specific executor args
+func WithExecutorArgsParams(params any) EVMTXGunOption {
+	return func(g *EVMTXGun) {
+		g.executorArgsParams = params
+	}
+}
+
+// WithTokenReceiverParams sets the tokenReceiverParams passed to BuildV3ExtraArgs.
+// Use this when the destination chain requires chain-specific token receiver args
+func WithTokenReceiverParams(params any) EVMTXGunOption {
+	return func(g *EVMTXGun) {
+		g.tokenReceiverParams = params
+	}
+}
+
+// WithTokenArgsParams sets the tokenArgsParams passed to BuildV3ExtraArgs.
+// Use this when the destination chain requires chain-specific token args
+func WithTokenArgsParams(params any) EVMTXGunOption {
+	return func(g *EVMTXGun) {
+		g.tokenArgsParams = params
+	}
+}
+
+func NewEVMTransactionGunFromTestConfig(cfg *ccv.Cfg, testProfile *load.TestProfileConfig, messageProfiles []load.MessageProfileConfig, e *deployment.Environment, impls map[uint64]cciptestinterfaces.CCIP17, opts ...EVMTXGunOption) *EVMTXGun {
 	selectors := make([]uint64, 0, len(testProfile.ChainsAsSource)+len(testProfile.ChainsAsDest))
 	srcSelectors := make([]uint64, 0, len(testProfile.ChainsAsSource))
 	destSelectors := make([]uint64, 0, len(testProfile.ChainsAsDest))
@@ -116,7 +146,7 @@ func NewEVMTransactionGunFromTestConfig(cfg *ccv.Cfg, testProfile *load.TestProf
 		}
 	}
 
-	return &EVMTXGun{
+	g := &EVMTXGun{
 		cfg:             cfg,
 		testConfig:      testProfile,
 		e:               e,
@@ -129,6 +159,10 @@ func NewEVMTransactionGunFromTestConfig(cfg *ccv.Cfg, testProfile *load.TestProf
 		messageProfiles: messageProfiles,
 		userSelector:    userSelector,
 	}
+	for _, opt := range opts {
+		opt(g)
+	}
+	return g
 }
 
 func (m *EVMTXGun) initNonce(key NonceKey, userAddress common.Address) error {
@@ -325,7 +359,7 @@ func (m *EVMTXGun) buildExtraArgs(srcSelector uint64, dest destLoadInfo, opts cc
 	}
 
 	// Receiver is in MessageFields; token params nil for data only load
-	return v3Src.BuildV3ExtraArgs(v3Opts, v3Dest, nil, nil, nil)
+	return v3Src.BuildV3ExtraArgs(v3Opts, v3Dest, m.executorArgsParams, m.tokenReceiverParams, m.tokenArgsParams)
 }
 
 // selectMessageProfile builds message options for load sends and applies defaults when no profile is configured.

--- a/build/devenv/tests/e2e/gun.go
+++ b/build/devenv/tests/e2e/gun.go
@@ -58,9 +58,9 @@ type EVMTXGun struct {
 	nonce               sync.Map              // map[NonceKey]*uint64
 	messageProfiles     []load.MessageProfileConfig
 	userSelector        map[uint64]func() *bind.TransactOpts
-	executorArgsParams  any // optional, passed to BuildV3ExtraArgs; nil = no executor args (existing behavior)
-	tokenReceiverParams any // optional, passed to BuildV3ExtraArgs; nil = no token receiver
-	tokenArgsParams     any // optional, passed to BuildV3ExtraArgs; nil = no token args
+	executorArgsParams  any // optional, passed to BuildV3ExtraArgs
+	tokenReceiverParams any // optional, passed to BuildV3ExtraArgs
+	tokenArgsParams     any // optional, passed to BuildV3ExtraArgs
 }
 
 // CloseSentChannel closes the sent messages channel to signal no more messages will be sent.


### PR DESCRIPTION
EVM Load gun not passing extra args, values should be provided during evm gun creation time

Related [PR](https://github.com/smartcontractkit/chainlink-ccip-solana/pull/283)
