### PR TITLE
ci: sign commits when updating chain-selectors

### DIFF
--- a/.github/workflows/update-chain-selectors.yaml
+++ b/.github/workflows/update-chain-selectors.yaml
@@ -63,3 +63,4 @@ jobs:
           body: |
             Updates github.com/smartcontractkit/chain-selectors in every Go module and runs `just tidy`.
           delete-branch: true
+          sign-commits: true


### PR DESCRIPTION
## Description

We require signed commits, even from bots. This PR enables that for the update-chain-selectors.yml action.

## Testing

Successful PR here: https://github.com/smartcontractkit/chainlink-ccv/pull/1304 w/ a signed commit.

## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
