### PR TITLE
fix: skip JD chain support validation for non-EVM verifier adapter

### DIFF
--- a/deployment/adapters/verifier_config.go
+++ b/deployment/adapters/verifier_config.go
@@ -26,3 +26,23 @@ type VerifierConfigAdapter interface {
 	// verifier jobs must use (e.g. chainsel.FamilyEVM for EVM committee verifiers).
 	GetSignerAddressFamily() string
 }
+
+// VerifierNodeChainJDSupport is an optional extension of VerifierConfigAdapter.
+// Implement it to opt out of JD node chain support validation in ApplyVerifierConfig.
+// Adapters that do not implement VerifierNodeChainJDSupport default to true (require JD).
+type VerifierNodeChainJDSupport interface {
+	// RequiresNodeChainSupportInJD reports whether ApplyVerifierConfig must verify that
+	// target NOPs have this chain registered in JD (ListNodeChainConfigs) before proposing
+	// ccvcommitteeverifier job specs. EVM chains require JD registration; families such as
+	// Solana whose standalone verifiers do not report chain configs to JD may return false.
+	RequiresNodeChainSupportInJD() bool
+}
+
+// VerifierRequiresNodeChainSupportInJD returns whether the adapter requires JD node chain
+// support validation. Adapters without VerifierNodeChainJDSupport default to true.
+func VerifierRequiresNodeChainSupportInJD(adapter VerifierConfigAdapter) bool {
+	if a, ok := adapter.(VerifierNodeChainJDSupport); ok {
+		return a.RequiresNodeChainSupportInJD()
+	}
+	return true
+}

--- a/deployment/changesets/apply_verifier_config.go
+++ b/deployment/changesets/apply_verifier_config.go
@@ -678,9 +678,16 @@ func validateVerifierChainSupport(
 	var validationResults []shared.ChainValidationResult
 	for _, nopAlias := range nopsToValidate {
 		requiredChains := getRequiredChainsForVerifierNOP(nopAlias, committee)
+		jdRequiredChains, err := filterVerifierChainsRequiringJDSupport(requiredChains)
+		if err != nil {
+			return err
+		}
+		if len(jdRequiredChains) == 0 {
+			continue
+		}
 		result := shared.ValidateNOPChainSupport(
 			string(nopAlias),
-			requiredChains,
+			jdRequiredChains,
 			supportedChains[string(nopAlias)],
 		)
 		if result != nil {
@@ -689,6 +696,20 @@ func validateVerifierChainSupport(
 	}
 
 	return shared.FormatChainValidationError(validationResults)
+}
+
+func filterVerifierChainsRequiringJDSupport(chains []uint64) ([]uint64, error) {
+	filtered := make([]uint64, 0, len(chains))
+	for _, sel := range chains {
+		adapter, err := adapters.GetVerifierRegistry().Get(sel)
+		if err != nil {
+			return nil, err
+		}
+		if adapters.VerifierRequiresNodeChainSupportInJD(adapter) {
+			filtered = append(filtered, sel)
+		}
+	}
+	return filtered, nil
 }
 
 func getRequiredChainsForVerifierNOP(nopAlias shared.NOPAlias, committee CommitteeInput) []uint64 {


### PR DESCRIPTION
There was this old [PR](https://github.com/smartcontractkit/chainlink-ccv/pull/1199) for fixing chain support validation for non-EVM executor adapter. However, we should skip for the verifier as well.