### PR TITLE
fix(configdoc): error on nil fields in example config

### DIFF
--- a/docs/config/aggregator/config.documented.toml
+++ b/docs/config/aggregator/config.documented.toml
@@ -150,6 +150,10 @@ maxCommitVerifierNodeResultRequestsPerBatch = 100
   [rateLimiting.storage]
     # type of storage: "memory" or "redis"
     type = ""
+    # redis configuration (only used when Type is "redis")
+    [rateLimiting.storage.redis]
+      # key_prefix for Redis keys (default: "ratelimit")
+      key_prefix = "ratelimit"
 
 # healthCheck configures the health-check HTTP server.
 [healthCheck]

--- a/tools/configdoc/configdoc_test.go
+++ b/tools/configdoc/configdoc_test.go
@@ -8,6 +8,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type pointerTestChild struct {
+	Value string `toml:"value"`
+}
+
+type pointerTestNested struct {
+	Child *pointerTestChild `toml:"child,omitempty"`
+}
+
+type PointerTestEmbedded struct {
+	Child *pointerTestChild `toml:"child,omitempty"`
+}
+
+type PointerTestEmbeddedPointer struct {
+	Child *pointerTestChild `toml:"child,omitempty"`
+}
+
+type pointerTestConfig struct {
+	Child   *pointerTestChild `toml:"child,omitempty"`
+	Nested  pointerTestNested `toml:"nested"`
+	Ignored *pointerTestChild `toml:"-"`
+}
+
+type pointerTestAnonymousConfig struct {
+	PointerTestEmbedded
+	*PointerTestEmbeddedPointer
+}
+
+type pointerTestCollectionConfig struct {
+	Items   []pointerTestNested          `toml:"items"`
+	Entries map[string]pointerTestNested `toml:"entries"`
+}
+
 // TestModulePath covers the go.mod module-directive parsing used by NewGenerator.
 func TestModulePath(t *testing.T) {
 	p, err := modulePath([]byte("module github.com/foo/bar\n\ngo 1.24\n"))
@@ -42,4 +74,43 @@ func TestNewGeneratorFindsModule(t *testing.T) {
 func TestNewGeneratorNoModule(t *testing.T) {
 	_, err := NewGenerator(t.TempDir())
 	require.Error(t, err)
+}
+
+func TestValidateInitializedPointers(t *testing.T) {
+	t.Run("reports nil documented pointer", func(t *testing.T) {
+		err := validateInitializedPointers(&pointerTestConfig{Child: &pointerTestChild{}})
+		require.EqualError(t, err, "uninitialized pointer fields: Nested.Child; all config struct pointer fields must be initialized for documentation purposes")
+	})
+
+	t.Run("accepts initialized pointer and ignores excluded fields", func(t *testing.T) {
+		err := validateInitializedPointers(&pointerTestConfig{
+			Child:  &pointerTestChild{},
+			Nested: pointerTestNested{Child: &pointerTestChild{}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("checks anonymous struct fields and ignores anonymous pointer fields", func(t *testing.T) {
+		err := validateInitializedPointers(&pointerTestAnonymousConfig{})
+		require.EqualError(t, err, "uninitialized pointer fields: PointerTestEmbedded.Child; all config struct pointer fields must be initialized for documentation purposes")
+
+		err = validateInitializedPointers(&pointerTestAnonymousConfig{
+			PointerTestEmbedded: PointerTestEmbedded{Child: &pointerTestChild{}},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("checks pointers in slices", func(t *testing.T) {
+		err := validateInitializedPointers(&pointerTestCollectionConfig{
+			Items: []pointerTestNested{{}},
+		})
+		require.EqualError(t, err, "uninitialized pointer fields: Items.Child; all config struct pointer fields must be initialized for documentation purposes")
+	})
+
+	t.Run("checks pointers in maps", func(t *testing.T) {
+		err := validateInitializedPointers(&pointerTestCollectionConfig{
+			Entries: map[string]pointerTestNested{"example": {}},
+		})
+		require.EqualError(t, err, "uninitialized pointer fields: Entries.Child; all config struct pointer fields must be initialized for documentation purposes")
+	})
 }

--- a/tools/configdoc/generate.go
+++ b/tools/configdoc/generate.go
@@ -137,6 +137,9 @@ func (g *Generator) Check(targets []Target, outDir string) ([]Stale, error) {
 // in, and injects those comments into the encoded output.
 func (g *Generator) Render(t Target) (string, error) {
 	inst := t.New()
+	if err := validateInitializedPointers(inst); err != nil {
+		return "", fmt.Errorf("%s: %w", t.Name, err)
+	}
 
 	var buf bytes.Buffer
 	if err := toml.NewEncoder(&buf).Encode(inst); err != nil {
@@ -153,6 +156,72 @@ func (g *Generator) Render(t Target) (string, error) {
 		return "", fmt.Errorf("%s: %w", t.Name, err)
 	}
 	return g.header(t) + body, nil
+}
+
+// validateInitializedPointers ensures the example instance exposes every
+// documented pointer-backed configuration section to the TOML encoder.
+func validateInitializedPointers(inst any) error {
+	var nilFields []string
+
+	// walk recursively traverses the value tree of inst, recording the path of any
+	// nil pointer fields. It follows pointers, structs, slices/arrays, and maps.
+	var walk func(reflect.Value, string)
+	walk = func(v reflect.Value, path string) {
+		if !v.IsValid() {
+			return
+		}
+
+		switch v.Kind() {
+		case reflect.Pointer:
+			if v.IsNil() {
+				nilFields = append(nilFields, path)
+				return
+			}
+			walk(v.Elem(), path)
+		case reflect.Struct:
+			for i := range v.NumField() {
+				f := v.Type().Field(i)
+				if !f.IsExported() {
+					continue
+				}
+				fieldPath := f.Name
+				if path != "" {
+					fieldPath = path + "." + fieldPath
+				}
+				if f.Anonymous {
+					// Polymorphic config types use nil embedded pointers and custom
+					// unmarshalling, so they are not TOML sections to document here.
+					if f.Type.Kind() == reflect.Pointer {
+						continue
+					}
+					walk(v.Field(i), fieldPath)
+					continue
+				}
+				if key, ok := tomlKey(f); !ok || key == "" {
+					continue
+				}
+				walk(v.Field(i), fieldPath)
+			}
+		case reflect.Slice, reflect.Array:
+			for i := range v.Len() {
+				walk(v.Index(i), path)
+			}
+		case reflect.Map:
+			iter := v.MapRange()
+			for iter.Next() {
+				walk(iter.Value(), path)
+			}
+		}
+	}
+
+	walk(reflect.ValueOf(inst), "")
+	if len(nilFields) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"uninitialized pointer fields: %s; all config struct pointer fields must be initialized for documentation purposes",
+		strings.Join(nilFields, ", "),
+	)
 }
 
 func (g *Generator) header(t Target) string {

--- a/tools/configdoc/registry/registry.go
+++ b/tools/configdoc/registry/registry.go
@@ -100,6 +100,11 @@ func aggregatorConfigInstance() any {
 		Heartbeat: aggregator.HeartbeatConfig{
 			Redis: &heartbeatRedisConfig,
 		},
+		RateLimiting: aggregator.RateLimitingConfig{
+			Storage: aggregator.RateLimiterStoreConfig{
+				Redis: &aggregator.RateLimiterRedisConfig{KeyPrefix: aggregator.DefaultRateLimiterRedisKeyPrefix},
+			},
+		},
 	}
 	c.SetDefaults()
 	return c


### PR DESCRIPTION
## Description

In PR #1284, a pointer field was added to the aggregator config, but not to the example config. configdoc did not error in that scenario; meaning that it is up to discipline to add the pointer field to the example config or not.

This change makes it so that configdoc will error out if an optional (pointer) field was added to the config that was not initialized in the example config. This happens prior to rendering, so that all the usual checks (comment injection) happens after.

## Testing

New unit tests testing this exact scenario.

## Checklist

- [ ] Breaking changes documented in changelog (see `changelog` directory)
- [ ] Cross link related PRs (in this or other repositories)
